### PR TITLE
Add support to pipe request using stdin

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,14 @@ CLI arguments can also refer to files on disk. This command reads the invoice fr
 ./uipathcli digitizer digitize --api-version 1 --file file:///documents/invoice.pdf
 ```
 
+## Standard input (stdin) / Pipes
+
+You can pipe JSON into the CLI as stdin and it will be used as the request body instead of CLI parameters. The following example reads an orchestrator setting, modifies the value using `jq` and pipes the output back into to the CLI to update it:
+
+```bash
+./uipathcli orchestrator settings-get | jq '.value[] | select(.Id == "Alerts.Email.Enabled") | .Value = "FALSE"' | ./uipathcli orchestrator settings-putbyid
+```
+
 ## Debug
 
 You can set the environment variable `UIPATH_DEBUG=true` or pass the parameter `--debug` in order to see detailed output of the request and response messages:

--- a/commandline/cli.go
+++ b/commandline/cli.go
@@ -83,7 +83,7 @@ func (c Cli) applyPlugins(definitions []parser.Definition) {
 	}
 }
 
-func (c Cli) run(args []string, configData []byte, definitionData []DefinitionData) error {
+func (c Cli) run(args []string, configData []byte, definitionData []DefinitionData, input []byte) error {
 	err := c.ConfigProvider.Load(configData)
 	if err != nil {
 		return err
@@ -95,6 +95,7 @@ func (c Cli) run(args []string, configData []byte, definitionData []DefinitionDa
 	c.applyPlugins(definitions)
 
 	CommandBuilder := CommandBuilder{
+		Input:          input,
 		StdIn:          c.StdIn,
 		StdOut:         c.StdOut,
 		ConfigProvider: c.ConfigProvider,
@@ -122,8 +123,8 @@ func (c Cli) run(args []string, configData []byte, definitionData []DefinitionDa
 const colorRed = "\033[31m"
 const colorReset = "\033[0m"
 
-func (c Cli) Run(args []string, configData []byte, definitionData []DefinitionData) error {
-	err := c.run(args, configData, definitionData)
+func (c Cli) Run(args []string, configData []byte, definitionData []DefinitionData, input []byte) error {
+	err := c.run(args, configData, definitionData, input)
 	if err != nil {
 		message := err.Error()
 		if c.ColoredOutput {

--- a/commandline/command_builder.go
+++ b/commandline/command_builder.go
@@ -20,6 +20,7 @@ const uriFlagName = "uri"
 const helpFlagName = "help"
 
 type CommandBuilder struct {
+	Input          []byte
 	StdIn          io.Reader
 	StdOut         io.Writer
 	ConfigProvider config.ConfigProvider
@@ -150,9 +151,11 @@ func (b CommandBuilder) createOperationCommand(definition parser.Definition, ope
 				return err
 			}
 
-			err = b.validateArguments(context, operation.Parameters, *config)
-			if err != nil {
-				return err
+			if len(b.Input) == 0 {
+				err = b.validateArguments(context, operation.Parameters, *config)
+				if err != nil {
+					return err
+				}
 			}
 
 			pathParameters, err := b.createExecutionParameters(context, parser.ParameterInPath, operation, config.Path)
@@ -182,6 +185,7 @@ func (b CommandBuilder) createOperationCommand(definition parser.Definition, ope
 				operation.Method,
 				baseUri,
 				operation.Route,
+				b.Input,
 				pathParameters,
 				queryParameters,
 				headerParameters,

--- a/executor/execution_context.go
+++ b/executor/execution_context.go
@@ -11,6 +11,7 @@ type ExecutionContext struct {
 	Method           string
 	BaseUri          url.URL
 	Route            string
+	Body             []byte
 	PathParameters   []ExecutionParameter
 	QueryParameters  []ExecutionParameter
 	HeaderParameters []ExecutionParameter
@@ -26,6 +27,7 @@ func NewExecutionContext(
 	method string,
 	uri url.URL,
 	route string,
+	body []byte,
 	pathParameters []ExecutionParameter,
 	queryParameters []ExecutionParameter,
 	headerParameters []ExecutionParameter,
@@ -35,5 +37,5 @@ func NewExecutionContext(
 	insecure bool,
 	debug bool,
 	plugin plugin.CommandPlugin) *ExecutionContext {
-	return &ExecutionContext{method, uri, route, pathParameters, queryParameters, headerParameters, bodyParameters, formParameters, authConfig, insecure, debug, plugin}
+	return &ExecutionContext{method, uri, route, body, pathParameters, queryParameters, headerParameters, bodyParameters, formParameters, authConfig, insecure, debug, plugin}
 }

--- a/executor/http_executor.go
+++ b/executor/http_executor.go
@@ -79,7 +79,10 @@ func (e HttpExecutor) createJson(parameters []ExecutionParameter) ([]byte, strin
 	return result, "application/json", nil
 }
 
-func (e HttpExecutor) createBody(bodyParameters []ExecutionParameter, formParameters []ExecutionParameter) ([]byte, string, error) {
+func (e HttpExecutor) createBody(body []byte, bodyParameters []ExecutionParameter, formParameters []ExecutionParameter) ([]byte, string, error) {
+	if len(body) > 0 {
+		return body, "application/json", nil
+	}
 	if len(formParameters) > 0 {
 		return e.createForm(formParameters)
 	}
@@ -148,7 +151,7 @@ func (e HttpExecutor) Call(context ExecutionContext, output io.Writer) error {
 	if err != nil {
 		return err
 	}
-	body, contentType, err := e.createBody(context.BodyParameters, context.FormParameters)
+	body, contentType, err := e.createBody(context.Body, context.BodyParameters, context.FormParameters)
 	if err != nil {
 		return err
 	}

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -116,6 +117,17 @@ func colorsSupported() bool {
 	return !omitColors
 }
 
+func readStdIn() []byte {
+	stat, _ := os.Stdin.Stat()
+	if (stat.Mode() & os.ModeCharDevice) == 0 {
+		input, err := io.ReadAll(os.Stdin)
+		if err == nil {
+			return input
+		}
+	}
+	return []byte{}
+}
+
 func main() {
 	cfgFile, cfgData, err := readConfiguration()
 	if err != nil {
@@ -155,7 +167,8 @@ func main() {
 		},
 	}
 
-	err = cli.Run(os.Args, cfgData, definitions)
+	input := readStdIn()
+	err = cli.Run(os.Args, cfgData, definitions, input)
 	if err != nil {
 		os.Exit(1)
 	}

--- a/test/setup.go
+++ b/test/setup.go
@@ -195,7 +195,11 @@ func runCli(args []string, context Context) Result {
 		*commandline.NewDefinitionData(context.DefinitionName, []byte(context.DefinitionData)),
 	}
 	args = append([]string{"uipath"}, args...)
-	err := cli.Run(args, []byte(context.Config), data)
+	input := []byte{}
+	if context.StdIn != nil {
+		input = context.StdIn.Bytes()
+	}
+	err := cli.Run(args, []byte(context.Config), data, input)
 
 	return Result{
 		Error:         err,


### PR DESCRIPTION
When provided, read the JSON request body from stdin and use it instead of creating the body from the CLI parameters.
This allows clients to retrieve data via the CLI, modify it using jq and piping it back into the CLI to update it.

Example:

`./uipathcli orchestrator settings-get | jq '.value[] | select(.Id == "Alerts.Email.Enabled") | .Value = "FALSE"' | ./uipathcli orchestrator settings-putbyid`
