### PR TITLE
Add newline after printing response body

### DIFF
--- a/test/execution_test.go
+++ b/test/execution_test.go
@@ -48,7 +48,8 @@ paths:
 
 	expectedStdOut := `{
   "hello": "world"
-}`
+}
+`
 	if result.StdOut != expectedStdOut {
 		t.Errorf("Expected response body on stdout %v, got: %v", expectedStdOut, result.StdOut)
 	}

--- a/utils/http_logger.go
+++ b/utils/http_logger.go
@@ -76,6 +76,8 @@ func (l HttpLogger) LogResponse(response *http.Response) error {
 	response.Body = io.NopCloser(bytes.NewBuffer(body))
 	if len(body) == 0 && response.StatusCode >= 400 {
 		fmt.Fprintf(l.Output, "%s %s\n", response.Proto, response.Status)
+	} else {
+		fmt.Fprint(l.Output, "\n")
 	}
 	return err
 }


### PR DESCRIPTION
On linux shells the command prompt will be shown on the same line where the uipathcli output ends. Adding a newline after printing the response body displays the prompt on the next line as expected.