### PR TITLE
Add support for du-storage

### DIFF
--- a/commandline/cli.go
+++ b/commandline/cli.go
@@ -63,7 +63,7 @@ func (c Cli) convertToParameters(parameters []plugin.CommandParameter) []parser.
 
 func (c Cli) applyPluginCommand(plugin plugin.CommandPlugin, command plugin.Command, definition *parser.Definition) {
 	parameters := c.convertToParameters(command.Parameters)
-	operation := parser.NewOperation(command.Name, command.Description, "", "", parameters, plugin, command.Hidden)
+	operation := parser.NewOperation(command.Name, command.Description, "", "", "application/json", parameters, plugin, command.Hidden)
 	for i, _ := range definition.Operations {
 		if definition.Operations[i].Name == command.Name {
 			definition.Operations[i] = *operation

--- a/definitions/storage.yaml
+++ b/definitions/storage.yaml
@@ -1,0 +1,470 @@
+openapi: 3.0.1
+info:
+  title: UiPath.DocumentUnderstanding.Storage.Api
+  version: v1
+servers:
+- url: https://cloud.uipath.com/{organization}/{tenant}/du_/api/storage
+  description: The production url
+  variables:
+    organization:
+      description: The organization name (or id)
+      default: my-org
+    tenant:
+      description: The tenant name (or id)
+      default: my-tenant
+paths:
+  /signature/{objectKey}:
+    post:
+      tags:
+        - Signature
+      summary: Generate pre-signed URL
+      description: This route generates a presigned URL which can be used to upload and download a specific object.
+      operationId: presigned-url
+      parameters:
+        - name: objectKey
+          in: path
+          description: The object key
+          required: true
+          schema:
+            type: string
+        - name: x-uipath-storage-class
+          in: header
+          description: The storage class
+          schema:
+            type: string
+      requestBody:
+        description: The presigned URL request
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GeneratePresignedUrlRequest'
+          text/json:
+            schema:
+              $ref: '#/components/schemas/GeneratePresignedUrlRequest'
+          application/*+json:
+            schema:
+              $ref: '#/components/schemas/GeneratePresignedUrlRequest'
+      responses:
+        '200':
+          description: Success
+          content:
+            text/plain:
+              schema:
+                $ref: '#/components/schemas/PresignedUrlResponse'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PresignedUrlResponse'
+            text/json:
+              schema:
+                $ref: '#/components/schemas/PresignedUrlResponse'
+        '400':
+          description: Bad Request
+          content:
+            text/plain:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+            text/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        '401':
+          description: Unauthorized
+          content:
+            text/plain:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+            text/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+  /store:
+    get:
+      tags:
+        - Storage
+      summary: List objects
+      description: "This route lists all the storage objects which optionally match a given prefix.\r\n            \r\nIt uses continuation tokens to support pagination."
+      operationId: list
+      parameters:
+        - name: prefix
+          in: query
+          description: The object prefix to search for
+          schema:
+            type: string
+        - name: continuationToken
+          in: query
+          description: The continuation token from the previous request to support pagination
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Success
+          content:
+            text/plain:
+              schema:
+                $ref: '#/components/schemas/ListObjectsResponse'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListObjectsResponse'
+            text/json:
+              schema:
+                $ref: '#/components/schemas/ListObjectsResponse'
+        '400':
+          description: Bad Request
+          content:
+            text/plain:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+            text/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Unauthorized
+          content:
+            text/plain:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+            text/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+    post:
+      tags:
+        - Storage
+      summary: Delete all objects matching prefix
+      description: This route deletes all objects which match the given deletePrefix.
+      operationId: batch-delete
+      parameters:
+        - name: deletePrefix
+          in: query
+          description: The prefix to search for
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Success
+          content:
+            text/plain:
+              schema:
+                $ref: '#/components/schemas/BatchDeleteResponse'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BatchDeleteResponse'
+            text/json:
+              schema:
+                $ref: '#/components/schemas/BatchDeleteResponse'
+        '400':
+          description: Bad Request
+          content:
+            text/plain:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+            text/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Unauthorized
+          content:
+            text/plain:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+            text/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+  /store/{objectKey}:
+    head:
+      tags:
+        - Storage
+      summary: Get object metadata
+      description: This route returns the object metadata in form of HTTP headers without the file content.
+      operationId: metadata
+      parameters:
+        - name: objectKey
+          in: path
+          description: The object key
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Success
+        '400':
+          description: Bad Request
+          content:
+            text/plain:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+            text/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        '401':
+          description: Unauthorized
+          content:
+            text/plain:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+            text/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        '404':
+          description: Not Found
+          content:
+            text/plain:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+            text/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+    get:
+      tags:
+        - Storage
+      summary: Download file from storage
+      description: This route returns the file content for the given object key.
+      operationId: download
+      parameters:
+        - name: objectKey
+          in: path
+          description: The object key
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Success
+        '400':
+          description: Bad Request
+          content:
+            text/plain:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+            text/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Unauthorized
+          content:
+            text/plain:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+            text/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        '404':
+          description: Not Found
+          content:
+            text/plain:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+            text/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+    put:
+      tags:
+        - Storage
+      summary: Upload file to storage
+      description: This route uploads the file content to storage.
+      operationId: upload
+      parameters:
+        - name: x-uipath-storage-class
+          in: header
+          description: The storage class
+          schema:
+            type: string
+        - name: objectKey
+          in: path
+          description: The object key
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+              description: The file to upload
+      responses:
+        '200':
+          description: Success
+        '400':
+          description: Bad Request
+          content:
+            text/plain:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+            text/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Unauthorized
+          content:
+            text/plain:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+            text/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+    delete:
+      tags:
+        - Storage
+      summary: Delete object
+      description: This route deletes the object with the given object key and its metadata from storage
+      operationId: delete
+      parameters:
+        - name: objectKey
+          in: path
+          description: The object key
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Success
+        '401':
+          description: Unauthorized
+          content:
+            text/plain:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+            text/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+components:
+  schemas:
+    BatchDeleteResponse:
+      type: object
+      properties:
+        numberOfDeletedKeys:
+          type: integer
+          format: int32
+      additionalProperties: false
+    ErrorResponse:
+      type: object
+      properties:
+        errorMessage:
+          type: string
+          nullable: true
+        errorMessageKey:
+          type: string
+          nullable: true
+        errorMessageParams:
+          type: array
+          items:
+            type: string
+          nullable: true
+        isSuccess:
+          type: boolean
+        hasErrors:
+          type: boolean
+          readOnly: true
+      additionalProperties: false
+    GeneratePresignedUrlRequest:
+      type: object
+      properties:
+        startDate:
+          type: string
+          description: The start date defining from when the URL is valid
+          nullable: true
+        expires:
+          type: integer
+          description: Time in seconds when the URL expires
+          format: int32
+        action:
+          $ref: '#/components/schemas/Permission'
+      additionalProperties: false
+      description: Request for generating presigned URLs
+    ListObjectsResponse:
+      type: object
+      properties:
+        objectKeys:
+          type: array
+          items:
+            type: string
+          nullable: true
+        continuationToken:
+          type: string
+          nullable: true
+      additionalProperties: false
+    Permission:
+      enum:
+        - GET
+        - PUT
+      type: string
+      description: The permission for the presigned url
+    PresignedUrlResponse:
+      type: object
+      properties:
+        url:
+          type: string
+          format: uri
+          nullable: true
+      additionalProperties: false
+    ProblemDetails:
+      type: object
+      properties:
+        type:
+          type: string
+          nullable: true
+        title:
+          type: string
+          nullable: true
+        status:
+          type: integer
+          format: int32
+          nullable: true
+        detail:
+          type: string
+          nullable: true
+        instance:
+          type: string
+          nullable: true
+      additionalProperties: {}
+  securitySchemes:
+    BearerToken:
+      type: http
+      description: Authorization header using the Bearer scheme
+      scheme: bearer
+      bearerFormat: JWT
+security:
+  - BearerToken: []

--- a/executor/execution_context.go
+++ b/executor/execution_context.go
@@ -11,6 +11,7 @@ type ExecutionContext struct {
 	Method           string
 	BaseUri          url.URL
 	Route            string
+	ContentType      string
 	Body             []byte
 	PathParameters   []ExecutionParameter
 	QueryParameters  []ExecutionParameter
@@ -27,6 +28,7 @@ func NewExecutionContext(
 	method string,
 	uri url.URL,
 	route string,
+	contentType string,
 	body []byte,
 	pathParameters []ExecutionParameter,
 	queryParameters []ExecutionParameter,
@@ -37,5 +39,5 @@ func NewExecutionContext(
 	insecure bool,
 	debug bool,
 	plugin plugin.CommandPlugin) *ExecutionContext {
-	return &ExecutionContext{method, uri, route, body, pathParameters, queryParameters, headerParameters, bodyParameters, formParameters, authConfig, insecure, debug, plugin}
+	return &ExecutionContext{method, uri, route, contentType, body, pathParameters, queryParameters, headerParameters, bodyParameters, formParameters, authConfig, insecure, debug, plugin}
 }

--- a/executor/http_executor.go
+++ b/executor/http_executor.go
@@ -67,7 +67,7 @@ func (e HttpExecutor) createForm(parameters []ExecutionParameter) ([]byte, strin
 	return b.Bytes(), writer.FormDataContentType(), nil
 }
 
-func (e HttpExecutor) createJson(parameters []ExecutionParameter) ([]byte, string, error) {
+func (e HttpExecutor) createJson(contentType string, parameters []ExecutionParameter) ([]byte, string, error) {
 	var body = map[string]interface{}{}
 	for _, parameter := range parameters {
 		body[parameter.Name] = parameter.Value
@@ -76,20 +76,20 @@ func (e HttpExecutor) createJson(parameters []ExecutionParameter) ([]byte, strin
 	if err != nil {
 		return []byte{}, "", fmt.Errorf("Error creating body: %v", err)
 	}
-	return result, "application/json", nil
+	return result, contentType, nil
 }
 
-func (e HttpExecutor) createBody(body []byte, bodyParameters []ExecutionParameter, formParameters []ExecutionParameter) ([]byte, string, error) {
+func (e HttpExecutor) createBody(contentType string, body []byte, bodyParameters []ExecutionParameter, formParameters []ExecutionParameter) ([]byte, string, error) {
 	if len(body) > 0 {
-		return body, "application/json", nil
+		return body, contentType, nil
 	}
 	if len(formParameters) > 0 {
 		return e.createForm(formParameters)
 	}
 	if len(bodyParameters) > 0 {
-		return e.createJson(bodyParameters)
+		return e.createJson(contentType, bodyParameters)
 	}
-	return []byte{}, "", nil
+	return []byte{}, contentType, nil
 }
 
 func (e HttpExecutor) formatUri(baseUri url.URL, route string, pathParameters []ExecutionParameter, queryParameters []ExecutionParameter) (*url.URL, error) {
@@ -151,7 +151,7 @@ func (e HttpExecutor) Call(context ExecutionContext, output io.Writer) error {
 	if err != nil {
 		return err
 	}
-	body, contentType, err := e.createBody(context.Body, context.BodyParameters, context.FormParameters)
+	body, contentType, err := e.createBody(context.ContentType, context.Body, context.BodyParameters, context.FormParameters)
 	if err != nil {
 		return err
 	}

--- a/parser/operation.go
+++ b/parser/operation.go
@@ -7,11 +7,12 @@ type Operation struct {
 	Description string
 	Method      string
 	Route       string
+	ContentType string
 	Parameters  []Parameter
 	Plugin      plugin.CommandPlugin
 	Hidden      bool
 }
 
-func NewOperation(name string, description string, method string, route string, parameters []Parameter, plugin plugin.CommandPlugin, hidden bool) *Operation {
-	return &Operation{name, description, method, route, parameters, plugin, hidden}
+func NewOperation(name string, description string, method string, route string, contentType string, parameters []Parameter, plugin plugin.CommandPlugin, hidden bool) *Operation {
+	return &Operation{name, description, method, route, contentType, parameters, plugin, hidden}
 }

--- a/test/parser_test.go
+++ b/test/parser_test.go
@@ -527,3 +527,34 @@ paths:
 		t.Errorf("stdout does not contain form parameter description, expected: %v, got: %v", expected, result.StdOut)
 	}
 }
+
+func TestRawRequestBodyShowsInputParameter(t *testing.T) {
+	definition := `
+paths:
+  /upload:
+    post:
+      operationId: upload
+      requestBody:
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+              description: The file to upload
+`
+	context := NewContextBuilder().
+		WithDefinition("myservice", definition).
+		Build()
+
+	result := runCli([]string{"myservice", "upload", "--help"}, context)
+
+	expected := "The file to upload"
+	if !strings.Contains(result.StdOut, expected) {
+		t.Errorf("stdout does not contain raw request body parameter description, expected: %v, got: %v", expected, result.StdOut)
+	}
+
+	expected = "--input"
+	if !strings.Contains(result.StdOut, expected) {
+		t.Errorf("stdout does not contain input parameter, expected: %v, got: %v", expected, result.StdOut)
+	}
+}


### PR DESCRIPTION
- Added OpenAPI document for storage service
- Extended parser to support raw body parameters. This is used to support simple file uploads, e.g.

uipathcli storage upload --input file://mydocument.pdf --object-key my-document