### PR TITLE
Only load required definitions

### DIFF
--- a/commandline/command_builder.go
+++ b/commandline/command_builder.go
@@ -271,7 +271,6 @@ func (b CommandBuilder) createAutoCompleteEnableCommand() *cli.Command {
 			},
 			b.HelpFlag(),
 		},
-		Hidden: true,
 		Action: func(context *cli.Context) error {
 			shell := context.String(shellFlagName)
 			filePath := context.String(fileFlagName)
@@ -293,13 +292,11 @@ func (b CommandBuilder) createAutoCompleteCompleteCommand(commands []*cli.Comman
 		Description: "Returns the autocomplete suggestions",
 		Flags: []cli.Flag{
 			&cli.StringFlag{
-				Name:   "command",
-				Usage:  "The command to autocomplete",
-				Hidden: true,
+				Name:  "command",
+				Usage: "The command to autocomplete",
 			},
 			b.HelpFlag(),
 		},
-		Hidden: true,
 		Action: func(context *cli.Context) error {
 			commandText := context.String("command")
 			exclude := []string{
@@ -322,11 +319,16 @@ func (b CommandBuilder) createAutoCompleteCompleteCommand(commands []*cli.Comman
 
 func (b CommandBuilder) createAutoCompleteCommand(commands []*cli.Command) *cli.Command {
 	return &cli.Command{
-		Name: "autocomplete",
+		Name:        "autocomplete",
+		Description: "Commands for autocompletion",
+		Flags: []cli.Flag{
+			b.HelpFlag(),
+		},
 		Subcommands: []*cli.Command{
 			b.createAutoCompleteEnableCommand(),
 			b.createAutoCompleteCompleteCommand(commands),
 		},
+		HideHelp: true,
 	}
 }
 
@@ -350,7 +352,6 @@ func (b CommandBuilder) createConfigCommand() *cli.Command {
 	return &cli.Command{
 		Name:        "config",
 		Description: "Interactive command to configure the CLI",
-		Hidden:      false,
 		Flags:       flags,
 		Action: func(context *cli.Context) error {
 			auth := context.String(authFlagName)

--- a/main_test.go
+++ b/main_test.go
@@ -114,6 +114,32 @@ paths:
 	}
 }
 
+func TestMainAutocompletesCommand(t *testing.T) {
+	config := createFile(t, ".uipathcli", "config")
+	definition := createFile(t, "definitions", "service-a.yaml")
+	os.WriteFile(definition, []byte(`
+paths:
+  /ping:
+    get:
+      summary: This is a simple get operation
+      operationId: ping
+`), 0600)
+
+	t.Setenv("UIPATHCLI_CONFIGURATION_PATH", config)
+	t.Setenv("UIPATHCLI_DEFINITIONS_PATH", filepath.Dir(definition))
+
+	os.Args = []string{"uipathcli", "autocomplete", "complete", "--command", "upathcli service-a p"}
+	output := captureOutput(t, func() {
+		main()
+	})
+
+	expected := `ping
+`
+	if output != expected {
+		t.Errorf("Expected operation name %s in autocomplete output, but got: %v", expected, output)
+	}
+}
+
 func captureOutput(t *testing.T, runnable func()) string {
 	realStdout := os.Stdout
 	reader, fakeStdout, err := os.Pipe()


### PR DESCRIPTION
Parsing all the OpenAPI defintions takes quite some time. Changed the definition loading to only parse definitions which are used by the CLI.

If there is no subcommand specified, it loads only the filenames of the definitions. If there is a subcommand, it loads only that specific definition. When autocomplete is requested, it checks the command parameter and applies the same logic.