### PR TITLE
Refactored code to simplify lazy loading of definition files

### DIFF
--- a/commandline/cli.go
+++ b/commandline/cli.go
@@ -6,104 +6,40 @@ import (
 
 	"github.com/UiPath/uipathcli/config"
 	"github.com/UiPath/uipathcli/executor"
-	"github.com/UiPath/uipathcli/parser"
-	"github.com/UiPath/uipathcli/plugin"
 	"github.com/urfave/cli/v2"
 )
 
 type Cli struct {
-	StdIn          io.Reader
-	StdOut         io.Writer
-	StdErr         io.Writer
-	ColoredOutput  bool
-	Parser         parser.Parser
-	ConfigProvider config.ConfigProvider
-	Executor       executor.Executor
-	PluginExecutor executor.Executor
-	CommandPlugins []plugin.CommandPlugin
+	StdIn              io.Reader
+	StdOut             io.Writer
+	StdErr             io.Writer
+	ColoredOutput      bool
+	DefinitionProvider DefinitionProvider
+	ConfigProvider     config.ConfigProvider
+	Executor           executor.Executor
+	PluginExecutor     executor.Executor
 }
 
-func (c Cli) parseDefinitions(definitions []DefinitionData) ([]parser.Definition, error) {
-	result := []parser.Definition{}
-	for _, definition := range definitions {
-		d, err := c.Parser.Parse(definition.Name, definition.Data)
-		if err != nil {
-			return nil, fmt.Errorf("Error parsing definition file '%s': %v", definition.Name, err)
-		}
-		result = append(result, *d)
-	}
-	return result, nil
-}
-
-func (c Cli) findDefinition(name string, definitions []parser.Definition) *parser.Definition {
-	for i := range definitions {
-		if definitions[i].Name == name {
-			return &definitions[i]
-		}
-	}
-	return nil
-}
-
-func (c Cli) convertToParameters(parameters []plugin.CommandParameter) []parser.Parameter {
-	result := []parser.Parameter{}
-	for _, p := range parameters {
-		parameter := *parser.NewParameter(
-			p.Name,
-			p.Type,
-			p.Description,
-			parser.ParameterInBody,
-			p.Name,
-			p.Required,
-			nil,
-			[]parser.Parameter{})
-		result = append(result, parameter)
-	}
-	return result
-}
-
-func (c Cli) applyPluginCommand(plugin plugin.CommandPlugin, command plugin.Command, definition *parser.Definition) {
-	parameters := c.convertToParameters(command.Parameters)
-	operation := parser.NewOperation(command.Name, command.Description, "", "", "application/json", parameters, plugin, command.Hidden)
-	for i, _ := range definition.Operations {
-		if definition.Operations[i].Name == command.Name {
-			definition.Operations[i] = *operation
-			return
-		}
-	}
-	definition.Operations = append(definition.Operations, *operation)
-}
-
-func (c Cli) applyPlugins(definitions []parser.Definition) {
-	for _, plugin := range c.CommandPlugins {
-		command := plugin.Command()
-		definition := c.findDefinition(command.Service, definitions)
-		if definition != nil {
-			c.applyPluginCommand(plugin, command, definition)
-		}
-	}
-}
-
-func (c Cli) run(args []string, configData []byte, definitionData []DefinitionData, input []byte) error {
-	err := c.ConfigProvider.Load(configData)
+func (c Cli) run(args []string, input []byte) error {
+	err := c.ConfigProvider.Load()
 	if err != nil {
 		return err
 	}
-	definitions, err := c.parseDefinitions(definitionData)
-	if err != nil {
-		return err
-	}
-	c.applyPlugins(definitions)
 
 	CommandBuilder := CommandBuilder{
-		Input:          input,
-		StdIn:          c.StdIn,
-		StdOut:         c.StdOut,
-		ConfigProvider: c.ConfigProvider,
-		Executor:       c.Executor,
-		PluginExecutor: c.PluginExecutor,
+		Input:              input,
+		StdIn:              c.StdIn,
+		StdOut:             c.StdOut,
+		ConfigProvider:     c.ConfigProvider,
+		Executor:           c.Executor,
+		PluginExecutor:     c.PluginExecutor,
+		DefinitionProvider: c.DefinitionProvider,
 	}
 	flags := CommandBuilder.CreateDefaultFlags(false)
-	commands := CommandBuilder.Create(definitions)
+	commands, err := CommandBuilder.Create(args)
+	if err != nil {
+		return err
+	}
 
 	app := &cli.App{
 		Name:            "uipathcli",
@@ -123,8 +59,8 @@ func (c Cli) run(args []string, configData []byte, definitionData []DefinitionDa
 const colorRed = "\033[31m"
 const colorReset = "\033[0m"
 
-func (c Cli) Run(args []string, configData []byte, definitionData []DefinitionData, input []byte) error {
-	err := c.run(args, configData, definitionData, input)
+func (c Cli) Run(args []string, input []byte) error {
+	err := c.run(args, input)
 	if err != nil {
 		message := err.Error()
 		if c.ColoredOutput {

--- a/commandline/definition_provider.go
+++ b/commandline/definition_provider.go
@@ -1,0 +1,122 @@
+package commandline
+
+import (
+	"fmt"
+
+	"github.com/UiPath/uipathcli/parser"
+	"github.com/UiPath/uipathcli/plugin"
+)
+
+type DefinitionProvider struct {
+	DefinitionStore DefinitionStore
+	Parser          parser.Parser
+	CommandPlugins  []plugin.CommandPlugin
+}
+
+func (p DefinitionProvider) Index() ([]parser.Definition, error) {
+	emptyDefinitions, err := p.loadEmptyDefinitions()
+	if err != nil {
+		return nil, err
+	}
+	return p.parse(emptyDefinitions)
+}
+
+func (p DefinitionProvider) Load(name string) ([]parser.Definition, error) {
+	data, err := p.loadDefinitionWithData(name)
+	if err != nil {
+		return nil, err
+	}
+	return p.parse(data)
+}
+
+func (p DefinitionProvider) loadEmptyDefinitions() ([]DefinitionData, error) {
+	names, err := p.DefinitionStore.Names()
+	if err != nil {
+		return nil, err
+	}
+	result := []DefinitionData{}
+	for _, name := range names {
+		result = append(result, *NewDefinitionData(name, []byte{}))
+	}
+	return result, nil
+}
+
+func (p DefinitionProvider) loadDefinitionWithData(name string) ([]DefinitionData, error) {
+	definition, err := p.DefinitionStore.Read(name)
+	if err != nil {
+		return nil, err
+	}
+	if definition != nil {
+		return []DefinitionData{*definition}, nil
+	}
+	return []DefinitionData{}, nil
+}
+
+func (p DefinitionProvider) parse(data []DefinitionData) ([]parser.Definition, error) {
+	definitions, err := p.parseDefinitions(data)
+	if err != nil {
+		return nil, err
+	}
+	p.applyPlugins(definitions)
+	return definitions, nil
+}
+
+func (p DefinitionProvider) parseDefinitions(definitions []DefinitionData) ([]parser.Definition, error) {
+	result := []parser.Definition{}
+	for _, definition := range definitions {
+		d, err := p.Parser.Parse(definition.Name, definition.Data)
+		if err != nil {
+			return nil, fmt.Errorf("Error parsing definition file '%s': %v", definition.Name, err)
+		}
+		result = append(result, *d)
+	}
+	return result, nil
+}
+
+func (p DefinitionProvider) findDefinition(name string, definitions []parser.Definition) *parser.Definition {
+	for i := range definitions {
+		if definitions[i].Name == name {
+			return &definitions[i]
+		}
+	}
+	return nil
+}
+
+func (p DefinitionProvider) convertToParameters(parameters []plugin.CommandParameter) []parser.Parameter {
+	result := []parser.Parameter{}
+	for _, p := range parameters {
+		parameter := *parser.NewParameter(
+			p.Name,
+			p.Type,
+			p.Description,
+			parser.ParameterInBody,
+			p.Name,
+			p.Required,
+			nil,
+			[]parser.Parameter{})
+		result = append(result, parameter)
+	}
+	return result
+}
+
+func (p DefinitionProvider) applyPluginCommand(plugin plugin.CommandPlugin, command plugin.Command, definition *parser.Definition) {
+	parameters := p.convertToParameters(command.Parameters)
+	operation := parser.NewOperation(command.Name, command.Description, "", "", "application/json", parameters, plugin, command.Hidden)
+	for i := range definition.Operations {
+		if definition.Operations[i].Name == command.Name {
+			definition.Operations[i] = *operation
+			return
+		}
+	}
+	definition.Operations = append(definition.Operations, *operation)
+}
+
+func (p DefinitionProvider) applyPlugins(definitions []parser.Definition) {
+	for _, plugin := range p.CommandPlugins {
+		command := plugin.Command()
+		definition := p.findDefinition(command.Service, definitions)
+		if definition != nil {
+			p.applyPluginCommand(plugin, command, definition)
+		}
+	}
+}

--- a/commandline/definition_store.go
+++ b/commandline/definition_store.go
@@ -1,0 +1,107 @@
+package commandline
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type DefinitionStore struct {
+	DefinitionDirectory string
+	Definitions         []DefinitionData
+}
+
+const DefinitionsDirectory = "definitions"
+
+func (s DefinitionStore) Names() ([]string, error) {
+	if s.Definitions != nil {
+		names := []string{}
+		for _, definition := range s.Definitions {
+			names = append(names, definition.Name)
+		}
+		return names, nil
+	}
+
+	definitionFiles, err := s.discoverDefinitions()
+	if err != nil {
+		return nil, err
+	}
+	return s.definitionNames(definitionFiles), nil
+}
+
+func (s DefinitionStore) Read(name string) (*DefinitionData, error) {
+	if s.Definitions != nil {
+		for _, definition := range s.Definitions {
+			if name == definition.Name {
+				return &definition, nil
+			}
+		}
+		return nil, nil
+	}
+
+	definitionFiles, err := s.discoverDefinitions()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, path := range definitionFiles {
+		if name == s.definitionName(path) {
+			return s.readDefinition(path)
+		}
+	}
+	return nil, nil
+}
+
+func (s DefinitionStore) discoverDefinitions() ([]string, error) {
+	definitionsDirectory, err := s.definitionsPath()
+	if err != nil {
+		return nil, err
+	}
+	files, err := os.ReadDir(definitionsDirectory)
+	if err != nil {
+		return nil, fmt.Errorf("Error reading definition files from folder '%s': %v", definitionsDirectory, err)
+	}
+	definitionFiles := []string{}
+	for _, file := range files {
+		filename := file.Name()
+		if strings.HasSuffix(filename, "yaml") || strings.HasSuffix(filename, "yml") || strings.HasSuffix(filename, "json") {
+			path := filepath.Join(definitionsDirectory, file.Name())
+			definitionFiles = append(definitionFiles, path)
+		}
+	}
+	return definitionFiles, nil
+}
+
+func (s DefinitionStore) definitionsPath() (string, error) {
+	if s.DefinitionDirectory != "" {
+		return s.DefinitionDirectory, nil
+	}
+	currentDirectory, err := os.Executable()
+	definitionsDirectory := filepath.Join(filepath.Dir(currentDirectory), DefinitionsDirectory)
+	if err != nil {
+		return "", fmt.Errorf("Error reading definition files from folder '%s': %v", definitionsDirectory, err)
+	}
+	return definitionsDirectory, nil
+}
+
+func (s DefinitionStore) definitionName(path string) string {
+	return strings.TrimSuffix(filepath.Base(path), filepath.Ext(path))
+}
+
+func (s DefinitionStore) definitionNames(paths []string) []string {
+	names := []string{}
+	for _, path := range paths {
+		names = append(names, s.definitionName(path))
+	}
+	return names
+}
+
+func (s DefinitionStore) readDefinition(path string) (*DefinitionData, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("Error reading definition file '%s': %v", path, err)
+	}
+	name := s.definitionName(path)
+	return NewDefinitionData(name, data), nil
+}

--- a/config/config_store.go
+++ b/config/config_store.go
@@ -1,0 +1,62 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+type ConfigStore struct {
+	Config     []byte
+	ConfigFile string
+}
+
+const configFilePermissions = 0600
+const configDirectoryPermissions = 0700
+
+func (s ConfigStore) Write(data []byte) error {
+	filename, err := s.configurationFilePath()
+	if err != nil {
+		return err
+	}
+	err = os.MkdirAll(filepath.Dir(filename), configDirectoryPermissions)
+	if err != nil {
+		return fmt.Errorf("Error creating configuration folder: %v", err)
+	}
+	err = os.WriteFile(filename, data, configFilePermissions)
+	if err != nil {
+		return fmt.Errorf("Error updating configuration file: %v", err)
+	}
+	return nil
+}
+
+func (s ConfigStore) Read() ([]byte, error) {
+	if s.Config != nil {
+		return s.Config, nil
+	}
+	filename, err := s.configurationFilePath()
+	if err != nil {
+		return nil, err
+	}
+	data, err := os.ReadFile(filename)
+	if err != nil && errors.Is(err, os.ErrNotExist) {
+		return []byte{}, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("Error reading configuration file '%s': %v", filename, err)
+	}
+	return data, nil
+}
+
+func (s ConfigStore) configurationFilePath() (string, error) {
+	if s.ConfigFile != "" {
+		return s.ConfigFile, nil
+	}
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("Error reading configuration file: %v", err)
+	}
+	filename := filepath.Join(homeDir, ".uipathcli", "config")
+	return filename, nil
+}

--- a/config/plugin_config_provider.go
+++ b/config/plugin_config_provider.go
@@ -4,16 +4,27 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-type PluginConfigProvider struct{}
+type PluginConfigProvider struct {
+	PluginConfigStore PluginConfigStore
+	pluginConfig      PluginConfig
+}
 
-func (cp *PluginConfigProvider) Parse(data []byte) (*PluginConfig, error) {
-	var pluginsYaml pluginsYaml
-	err := yaml.Unmarshal(data, &pluginsYaml)
+func (cp *PluginConfigProvider) Load() error {
+	data, err := cp.PluginConfigStore.Read()
 	if err != nil {
-		return nil, err
+		return err
 	}
-	config := cp.convertToConfig(pluginsYaml)
-	return &config, nil
+	var pluginsYaml pluginsYaml
+	err = yaml.Unmarshal(data, &pluginsYaml)
+	if err != nil {
+		return err
+	}
+	cp.pluginConfig = cp.convertToConfig(pluginsYaml)
+	return nil
+}
+
+func (cp PluginConfigProvider) Config() PluginConfig {
+	return cp.pluginConfig
 }
 
 func (cp PluginConfigProvider) convertToConfig(plugins pluginsYaml) PluginConfig {

--- a/config/plugin_config_store.go
+++ b/config/plugin_config_store.go
@@ -1,0 +1,36 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+type PluginConfigStore struct {
+	PluginFile string
+}
+
+func (s PluginConfigStore) Read() ([]byte, error) {
+	filename, err := s.pluginsFilePath()
+	if err != nil {
+		return nil, err
+	}
+	data, err := os.ReadFile(filename)
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return nil, fmt.Errorf("Error reading plugins file '%s': %v", filename, err)
+	}
+	return data, nil
+}
+
+func (s PluginConfigStore) pluginsFilePath() (string, error) {
+	if s.PluginFile != "" {
+		return s.PluginFile, nil
+	}
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("Error reading plugins file: %v", err)
+	}
+	filename := filepath.Join(homeDir, ".uipathcli", "plugins")
+	return filename, nil
+}

--- a/main.go
+++ b/main.go
@@ -1,13 +1,10 @@
 package main
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"os"
-	"path/filepath"
 	"runtime"
-	"strings"
 
 	"github.com/UiPath/uipathcli/auth"
 	"github.com/UiPath/uipathcli/cache"
@@ -19,111 +16,7 @@ import (
 	plugin_digitizer "github.com/UiPath/uipathcli/plugin/digitizer"
 )
 
-const DefinitionsDirectory = "definitions"
-
-func readDefinition(path string) ([]byte, error) {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return nil, fmt.Errorf("Error reading definition file '%s': %v", path, err)
-	}
-	return data, nil
-}
-
-func definitionsPath() (string, error) {
-	path := os.Getenv("UIPATHCLI_DEFINITIONS_PATH")
-	if path != "" {
-		return path, nil
-	}
-	currentDirectory, err := os.Executable()
-	definitionsDirectory := filepath.Join(filepath.Dir(currentDirectory), DefinitionsDirectory)
-	if err != nil {
-		return "", fmt.Errorf("Error reading definition files from folder '%s': %v", definitionsDirectory, err)
-	}
-	return definitionsDirectory, nil
-}
-
-func readDefinitions(definitionName string) ([]commandline.DefinitionData, error) {
-	definitionsDirectory, err := definitionsPath()
-	if err != nil {
-		return nil, err
-	}
-	files, err := os.ReadDir(definitionsDirectory)
-	if err != nil {
-		return nil, fmt.Errorf("Error reading definition files from folder '%s': %v", definitionsDirectory, err)
-	}
-
-	result := []commandline.DefinitionData{}
-	for _, file := range files {
-		path := filepath.Join(definitionsDirectory, file.Name())
-		name := strings.TrimSuffix(filepath.Base(path), filepath.Ext(path))
-		data := commandline.NewDefinitionData(name, []byte{})
-		if definitionName == name {
-			content, err := readDefinition(path)
-			if err != nil {
-				return nil, err
-			}
-			data = commandline.NewDefinitionData(name, content)
-		}
-		result = append(result, *data)
-	}
-	return result, nil
-}
-
-func configurationFilePath() (string, error) {
-	filename := os.Getenv("UIPATHCLI_CONFIGURATION_PATH")
-	if filename != "" {
-		return filename, nil
-	}
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		return "", fmt.Errorf("Error reading configuration file: %v", err)
-	}
-	filename = filepath.Join(homeDir, ".uipathcli", "config")
-	return filename, nil
-}
-
-func readConfiguration() (string, []byte, error) {
-	filename, err := configurationFilePath()
-	if err != nil {
-		return "", nil, err
-	}
-	data, err := os.ReadFile(filename)
-	if err != nil && errors.Is(err, os.ErrNotExist) {
-		return filename, []byte{}, nil
-	}
-	if err != nil {
-		return "", nil, fmt.Errorf("Error reading configuration file '%s': %v", filename, err)
-	}
-	return filename, data, nil
-}
-
-func pluginsFilePath() (string, error) {
-	filename := os.Getenv("UIPATHCLI_PLUGINS_PATH")
-	if filename != "" {
-		return filename, nil
-	}
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		return "", fmt.Errorf("Error reading plugins file: %v", err)
-	}
-	filename = filepath.Join(homeDir, ".uipathcli", "plugins")
-	return filename, nil
-}
-
-func readPlugins() (*config.PluginConfig, error) {
-	filename, err := pluginsFilePath()
-	if err != nil {
-		return nil, err
-	}
-	data, err := os.ReadFile(filename)
-	if err != nil && !errors.Is(err, os.ErrNotExist) {
-		return nil, fmt.Errorf("Error reading plugins file '%s': %v", filename, err)
-	}
-	config_provider := config.PluginConfigProvider{}
-	return config_provider.Parse(data)
-}
-
-func authenticators(pluginsCfg *config.PluginConfig) []auth.Authenticator {
+func authenticators(pluginsCfg config.PluginConfig) []auth.Authenticator {
 	authenticators := []auth.Authenticator{}
 	for _, authenticator := range pluginsCfg.Authenticators {
 		authenticators = append(authenticators, auth.ExternalAuthenticator{
@@ -160,62 +53,56 @@ func readStdIn() []byte {
 	return []byte{}
 }
 
-func requiredDefinition(args []string) string {
-	if len(args) <= 1 {
-		return ""
-	}
-	if strings.HasPrefix(args[1], "--") {
-		return ""
-	}
-	if len(args) == 5 && args[1] == "autocomplete" && args[2] == "complete" && args[3] == "--command" {
-		autocompleteArgs := strings.Split(args[4], " ")
-		return requiredDefinition(autocompleteArgs)
-	}
-	return args[1]
-}
-
 func main() {
-	cfgFile, cfgData, err := readConfiguration()
+	configProvider := config.ConfigProvider{
+		ConfigStore: config.ConfigStore{
+			ConfigFile: os.Getenv("UIPATHCLI_CONFIGURATION_PATH"),
+		},
+	}
+	err := configProvider.Load()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err.Error())
 		os.Exit(131)
 	}
-	definitionName := requiredDefinition(os.Args)
-	definitions, err := readDefinitions(definitionName)
+	pluginConfigProvider := config.PluginConfigProvider{
+		PluginConfigStore: config.PluginConfigStore{
+			PluginFile: os.Getenv("UIPATHCLI_PLUGINS_PATH"),
+		},
+	}
+	err = pluginConfigProvider.Load()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err.Error())
 		os.Exit(132)
 	}
-	pluginsCfg, err := readPlugins()
-	if err != nil {
-		fmt.Fprintln(os.Stderr, err.Error())
-		os.Exit(133)
-	}
 
-	authenticators := authenticators(pluginsCfg)
+	pluginConfig := pluginConfigProvider.Config()
+	authenticators := authenticators(pluginConfig)
 	cli := commandline.Cli{
 		StdIn:         os.Stdin,
 		StdOut:        os.Stdout,
 		StdErr:        os.Stderr,
-		Parser:        parser.OpenApiParser{},
 		ColoredOutput: colorsSupported(),
-		ConfigProvider: config.ConfigProvider{
-			ConfigFileName: cfgFile,
+		DefinitionProvider: commandline.DefinitionProvider{
+			DefinitionStore: commandline.DefinitionStore{
+				DefinitionDirectory: os.Getenv("UIPATHCLI_DEFINITIONS_PATH"),
+			},
+			Parser: parser.OpenApiParser{},
+			CommandPlugins: []plugin.CommandPlugin{
+				plugin_digitizer.DigitizeCommand{},
+				plugin_digitizer.StatusCommand{},
+			},
 		},
+		ConfigProvider: configProvider,
 		Executor: executor.HttpExecutor{
 			Authenticators: authenticators,
 		},
 		PluginExecutor: executor.PluginExecutor{
 			Authenticators: authenticators,
 		},
-		CommandPlugins: []plugin.CommandPlugin{
-			plugin_digitizer.DigitizeCommand{},
-			plugin_digitizer.StatusCommand{},
-		},
 	}
 
 	input := readStdIn()
-	err = cli.Run(os.Args, cfgData, definitions, input)
+	err = cli.Run(os.Args, input)
 	if err != nil {
 		os.Exit(1)
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -140,6 +140,32 @@ paths:
 	}
 }
 
+func TestMainParsesBuiltInDefinitions(t *testing.T) {
+	t.Run("aiappmanager", func(t *testing.T) { MainParsesBuiltInDefinitions(t, "aiappmanager", "get-apps") })
+	t.Run("aideployer", func(t *testing.T) { MainParsesBuiltInDefinitions(t, "aideployer", "update-mlskill") })
+	t.Run("aihelper", func(t *testing.T) { MainParsesBuiltInDefinitions(t, "aihelper", "get-project-acces") })
+	t.Run("aitrainer", func(t *testing.T) { MainParsesBuiltInDefinitions(t, "aitrainer", "create-dataset") })
+	t.Run("digitizer", func(t *testing.T) { MainParsesBuiltInDefinitions(t, "digitizer", "digitize") })
+	t.Run("events", func(t *testing.T) { MainParsesBuiltInDefinitions(t, "events", "create-subscription") })
+	t.Run("metering", func(t *testing.T) { MainParsesBuiltInDefinitions(t, "metering", "track") })
+	t.Run("orchestrator", func(t *testing.T) { MainParsesBuiltInDefinitions(t, "orchestrator", "users-get-by-id") })
+	t.Run("storage", func(t *testing.T) { MainParsesBuiltInDefinitions(t, "storage", "presigned-url") })
+}
+
+func MainParsesBuiltInDefinitions(t *testing.T, name string, expected string) {
+	definitionDir, _ := os.Getwd()
+	t.Setenv("UIPATHCLI_DEFINITIONS_PATH", filepath.Join(definitionDir, "definitions/"))
+
+	os.Args = []string{"uipathcli", name}
+	output := captureOutput(t, func() {
+		main()
+	})
+
+	if !strings.Contains(output, expected) {
+		t.Errorf("Expected %s in output, but got: %v", expected, output)
+	}
+}
+
 func captureOutput(t *testing.T, runnable func()) string {
 	realStdout := os.Stdout
 	reader, fakeStdout, err := os.Pipe()
@@ -169,12 +195,14 @@ func captureOutput(t *testing.T, runnable func()) string {
 }
 
 func createFile(t *testing.T, directory string, name string) string {
-	path := filepath.Join(os.TempDir(), randomDirectoryName(), directory, name)
+	extensions := strings.TrimPrefix(filepath.Ext(name), ".")
+	filename := strings.TrimSuffix(name, filepath.Ext(name)) + ".*" + extensions
+	path := filepath.Join(os.TempDir(), randomDirectoryName(), directory, filename)
 	err := os.MkdirAll(filepath.Dir(path), 0700)
 	if err != nil {
 		t.Fatal(err)
 	}
-	tempFile, err := os.CreateTemp(filepath.Dir(path), name)
+	tempFile, err := os.CreateTemp(filepath.Dir(path), filename)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
- Moved all the logic from main.go into separate modules
- Passing the definition provider into the command builder so that it can decide which definitions to load when certain CLI commands are executed

After this change, the CLI only lists definition files when the main command is invoked which shows an overview of all available services. The definition content is only loaded and parsed when one of service commands are invoked.