### PR TITLE
Discover definition names when autocompleting service commands

### DIFF
--- a/commandline/definition_provider.go
+++ b/commandline/definition_provider.go
@@ -18,15 +18,26 @@ func (p DefinitionProvider) Index() ([]parser.Definition, error) {
 	if err != nil {
 		return nil, err
 	}
-	return p.parse(emptyDefinitions)
+	result := []parser.Definition{}
+	for _, data := range emptyDefinitions {
+		definition, err := p.parse(data)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, *definition)
+	}
+	return result, nil
 }
 
-func (p DefinitionProvider) Load(name string) ([]parser.Definition, error) {
-	data, err := p.loadDefinitionWithData(name)
+func (p DefinitionProvider) Load(name string) (*parser.Definition, error) {
+	data, err := p.DefinitionStore.Read(name)
 	if err != nil {
 		return nil, err
 	}
-	return p.parse(data)
+	if data == nil {
+		return nil, nil
+	}
+	return p.parse(*data)
 }
 
 func (p DefinitionProvider) loadEmptyDefinitions() ([]DefinitionData, error) {
@@ -41,45 +52,34 @@ func (p DefinitionProvider) loadEmptyDefinitions() ([]DefinitionData, error) {
 	return result, nil
 }
 
-func (p DefinitionProvider) loadDefinitionWithData(name string) ([]DefinitionData, error) {
-	definition, err := p.DefinitionStore.Read(name)
+func (p DefinitionProvider) parse(data DefinitionData) (*parser.Definition, error) {
+	definition, err := p.Parser.Parse(data.Name, data.Data)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("Error parsing definition file '%s': %v", definition.Name, err)
 	}
-	if definition != nil {
-		return []DefinitionData{*definition}, nil
-	}
-	return []DefinitionData{}, nil
+	p.applyPlugins(definition)
+	return definition, nil
 }
 
-func (p DefinitionProvider) parse(data []DefinitionData) ([]parser.Definition, error) {
-	definitions, err := p.parseDefinitions(data)
-	if err != nil {
-		return nil, err
-	}
-	p.applyPlugins(definitions)
-	return definitions, nil
-}
-
-func (p DefinitionProvider) parseDefinitions(definitions []DefinitionData) ([]parser.Definition, error) {
-	result := []parser.Definition{}
-	for _, definition := range definitions {
-		d, err := p.Parser.Parse(definition.Name, definition.Data)
-		if err != nil {
-			return nil, fmt.Errorf("Error parsing definition file '%s': %v", definition.Name, err)
-		}
-		result = append(result, *d)
-	}
-	return result, nil
-}
-
-func (p DefinitionProvider) findDefinition(name string, definitions []parser.Definition) *parser.Definition {
-	for i := range definitions {
-		if definitions[i].Name == name {
-			return &definitions[i]
+func (p DefinitionProvider) applyPlugins(definition *parser.Definition) {
+	for _, plugin := range p.CommandPlugins {
+		command := plugin.Command()
+		if definition.Name == command.Service {
+			p.applyPluginCommand(plugin, command, definition)
 		}
 	}
-	return nil
+}
+
+func (p DefinitionProvider) applyPluginCommand(plugin plugin.CommandPlugin, command plugin.Command, definition *parser.Definition) {
+	parameters := p.convertToParameters(command.Parameters)
+	operation := parser.NewOperation(command.Name, command.Description, "", "", "application/json", parameters, plugin, command.Hidden)
+	for i := range definition.Operations {
+		if definition.Operations[i].Name == command.Name {
+			definition.Operations[i] = *operation
+			return
+		}
+	}
+	definition.Operations = append(definition.Operations, *operation)
 }
 
 func (p DefinitionProvider) convertToParameters(parameters []plugin.CommandParameter) []parser.Parameter {
@@ -97,26 +97,4 @@ func (p DefinitionProvider) convertToParameters(parameters []plugin.CommandParam
 		result = append(result, parameter)
 	}
 	return result
-}
-
-func (p DefinitionProvider) applyPluginCommand(plugin plugin.CommandPlugin, command plugin.Command, definition *parser.Definition) {
-	parameters := p.convertToParameters(command.Parameters)
-	operation := parser.NewOperation(command.Name, command.Description, "", "", "application/json", parameters, plugin, command.Hidden)
-	for i := range definition.Operations {
-		if definition.Operations[i].Name == command.Name {
-			definition.Operations[i] = *operation
-			return
-		}
-	}
-	definition.Operations = append(definition.Operations, *operation)
-}
-
-func (p DefinitionProvider) applyPlugins(definitions []parser.Definition) {
-	for _, plugin := range p.CommandPlugins {
-		command := plugin.Command()
-		definition := p.findDefinition(command.Service, definitions)
-		if definition != nil {
-			p.applyPluginCommand(plugin, command, definition)
-		}
-	}
 }

--- a/test/autocomplete_test.go
+++ b/test/autocomplete_test.go
@@ -5,6 +5,44 @@ import (
 	"testing"
 )
 
+func TestAutocompleteServicePrefixMatch(t *testing.T) {
+	definition := `
+paths:
+  /ping/{id}:
+    get:
+      operationId: ping
+`
+	context := NewContextBuilder().
+		WithDefinition("myservice", definition).
+		Build()
+
+	result := runCli([]string{"autocomplete", "complete", "--command", "uipathcli my"}, context)
+
+	expectedWords := "myservice\n"
+	if result.StdOut != expectedWords {
+		t.Errorf("Did not return the expected autocomplete words, expected: %v, got: %v", expectedWords, result.StdOut)
+	}
+}
+
+func TestAutocompleteServiceContainsMatch(t *testing.T) {
+	definition := `
+paths:
+  /ping/{id}:
+    get:
+      operationId: ping
+`
+	context := NewContextBuilder().
+		WithDefinition("myservice", definition).
+		Build()
+
+	result := runCli([]string{"autocomplete", "complete", "--command", "uipathcli serv"}, context)
+
+	expectedWords := "myservice\n"
+	if result.StdOut != expectedWords {
+		t.Errorf("Did not return the expected autocomplete words, expected: %v, got: %v", expectedWords, result.StdOut)
+	}
+}
+
 func TestAutocompleteNoMatch(t *testing.T) {
 	definition := `
 paths:

--- a/test/setup.go
+++ b/test/setup.go
@@ -187,7 +187,8 @@ func runCli(args []string, context Context) Result {
 		StdErr: stderr,
 		DefinitionProvider: commandline.DefinitionProvider{
 			DefinitionStore: commandline.DefinitionStore{
-				Definitions: data,
+				DefinitionFiles: []string{context.DefinitionName},
+				Definitions:     data,
 			},
 			Parser:         parser.OpenApiParser{},
 			CommandPlugins: commandPlugins,


### PR DESCRIPTION
- Loading the necessary definitions for autocompleting service commands,
   e.g. uipathcli orc --> orchestrator

- Added tests to validate bug fix