### PR TITLE
Add progress bar for large up- and downloads

### DIFF
--- a/commandline/cli.go
+++ b/commandline/cli.go
@@ -30,6 +30,7 @@ func (c Cli) run(args []string, input []byte) error {
 		Input:              input,
 		StdIn:              c.StdIn,
 		StdOut:             c.StdOut,
+		StdErr:             c.StdErr,
 		ConfigProvider:     c.ConfigProvider,
 		Executor:           c.Executor,
 		PluginExecutor:     c.PluginExecutor,

--- a/executor/progress.go
+++ b/executor/progress.go
@@ -1,0 +1,11 @@
+package executor
+
+type Progress struct {
+	BytesRead      int64
+	BytesPerSecond int64
+	Completed      bool
+}
+
+func NewProgress(bytesRead int64, bytesPerSecond int64, completed bool) *Progress {
+	return &Progress{bytesRead, bytesPerSecond, completed}
+}

--- a/executor/progress_bar.go
+++ b/executor/progress_bar.go
@@ -1,0 +1,81 @@
+package executor
+
+import (
+	"fmt"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/UiPath/uipathcli/log"
+)
+
+type ProgressBar struct {
+	Logger         log.Logger
+	renderedLength int
+}
+
+func (b *ProgressBar) Update(text string, current int64, total int64, bytesPerSecond int64) {
+	b.Logger.LogError("\r")
+	length := b.render(text, current, total, bytesPerSecond)
+	left := b.renderedLength - length
+	if left > 0 {
+		b.Logger.LogError(strings.Repeat(" ", left))
+	}
+	b.renderedLength = length
+}
+
+func (b *ProgressBar) Remove() {
+	if b.renderedLength > 0 {
+		clear := fmt.Sprintf("\r%s\r", strings.Repeat(" ", b.renderedLength))
+		b.Logger.LogError(clear)
+	}
+}
+
+func (b ProgressBar) render(text string, currentBytes int64, totalBytes int64, bytesPerSecond int64) int {
+	percent := float64(currentBytes) / float64(totalBytes) * 100.0
+	barCount := int(percent / 5.0)
+	bar := strings.Repeat("█", barCount) + strings.Repeat(" ", 20-barCount)
+	totalBytesFormatted, unit := b.formatBytes(totalBytes)
+	currentBytesFormatted, unit := b.formatBytesInUnit(currentBytes, unit)
+	bytesPerSecondFormatted, bytesPerSecondUnit := b.formatBytes(bytesPerSecond)
+	output := fmt.Sprintf("%s %3d%% |%s| (%s/%s %s, %s %s/s)",
+		text,
+		int(percent),
+		bar,
+		currentBytesFormatted,
+		totalBytesFormatted,
+		unit,
+		bytesPerSecondFormatted,
+		bytesPerSecondUnit)
+	b.Logger.LogError(output)
+	return utf8.RuneCountInString(output)
+}
+
+func (b ProgressBar) formatBytes(count int64) (string, string) {
+	if count < 1000 {
+		return b.formatBytesInUnit(count, "B")
+	}
+	if count < 1000*1000 {
+		return b.formatBytesInUnit(count, "kB")
+	}
+	if count < 1000*1000*1000 {
+		return b.formatBytesInUnit(count, "MB")
+	}
+	return b.formatBytesInUnit(count, "GB")
+}
+
+func (b ProgressBar) formatBytesInUnit(count int64, unit string) (string, string) {
+	if unit == "B" {
+		return fmt.Sprintf("%d", count), unit
+	}
+	if unit == "kB" {
+		return fmt.Sprintf("%0.1f", float64(count)/1_000), unit
+	}
+	if unit == "MB" {
+		return fmt.Sprintf("%0.1f", float64(count)/1_000_000), unit
+	}
+	return fmt.Sprintf("%0.1f", float64(count)/1_000_000_000), unit
+}
+
+func NewProgressBar(logger log.Logger) *ProgressBar {
+	return &ProgressBar{logger, 0}
+}

--- a/executor/progress_reader.go
+++ b/executor/progress_reader.go
@@ -1,0 +1,40 @@
+package executor
+
+import (
+	"io"
+	"time"
+)
+
+type ProgressReader struct {
+	io.Reader
+	ProgressFunc func(progress Progress)
+	startTime    time.Time
+	bytesRead    int64
+	lastProgress time.Time
+}
+
+func (r *ProgressReader) Read(p []byte) (n int, err error) {
+	n, err = r.Reader.Read(p)
+	bytesRead, bytesPerSecond := r.calculateStats(n)
+	if err == io.EOF || time.Since(r.lastProgress).Nanoseconds() > (100*time.Nanosecond).Nanoseconds() {
+		r.lastProgress = time.Now()
+		progress := NewProgress(bytesRead, bytesPerSecond, err == io.EOF)
+		r.ProgressFunc(*progress)
+	}
+	return n, err
+}
+
+func (r *ProgressReader) calculateStats(n int) (int64, int64) {
+	bytesRead := r.bytesRead + int64(n)
+	seconds := time.Since(r.startTime).Seconds()
+	bytesPerSecond := int64(0)
+	if seconds > 0 {
+		bytesPerSecond = int64(float64(bytesRead) / seconds)
+	}
+	r.bytesRead = bytesRead
+	return bytesRead, bytesPerSecond
+}
+
+func NewProgressReader(reader io.Reader, progressFunc func(progress Progress)) *ProgressReader {
+	return &ProgressReader{reader, progressFunc, time.Now(), 0, time.Time{}}
+}

--- a/log/debug_logger.go
+++ b/log/debug_logger.go
@@ -8,7 +8,8 @@ import (
 )
 
 type DebugLogger struct {
-	Output io.Writer
+	Output      io.Writer
+	ErrorOutput io.Writer
 }
 
 func (l DebugLogger) writeHeaders(header http.Header) {
@@ -46,4 +47,8 @@ func (l DebugLogger) LogResponse(response ResponseInfo) {
 
 func (l DebugLogger) Log(message string) {
 	fmt.Fprint(l.Output, message)
+}
+
+func (l DebugLogger) LogError(message string) {
+	fmt.Fprint(l.ErrorOutput, message)
 }

--- a/log/default_logger.go
+++ b/log/default_logger.go
@@ -1,6 +1,12 @@
 package log
 
+import (
+	"fmt"
+	"io"
+)
+
 type DefaultLogger struct {
+	ErrorOutput io.Writer
 }
 
 func (l *DefaultLogger) LogRequest(request RequestInfo) {
@@ -10,4 +16,8 @@ func (l DefaultLogger) LogResponse(response ResponseInfo) {
 }
 
 func (l DefaultLogger) Log(message string) {
+}
+
+func (l DefaultLogger) LogError(message string) {
+	fmt.Fprint(l.ErrorOutput, message)
 }

--- a/log/logger.go
+++ b/log/logger.go
@@ -2,6 +2,7 @@ package log
 
 type Logger interface {
 	Log(message string)
+	LogError(message string)
 	LogRequest(request RequestInfo)
 	LogResponse(response ResponseInfo)
 }


### PR DESCRIPTION
- Show a progress bar when the users uploads or downloads more than 10 MB
- Progress bar displays transferred bytes, total bytes and calculates bytes per second
- Extend the logger to support writing on std error