### PR TITLE
Add config setting for identity uri

### DIFF
--- a/auth/bearer_authenticator_config.go
+++ b/auth/bearer_authenticator_config.go
@@ -1,12 +1,16 @@
 package auth
 
+import "net/url"
+
 type BearerAuthenticatorConfig struct {
 	ClientId     string
 	ClientSecret string
+	IdentityUri  *url.URL
 }
 
 func NewBearerAuthenticatorConfig(
 	clientId string,
-	clientSecret string) *BearerAuthenticatorConfig {
-	return &BearerAuthenticatorConfig{clientId, clientSecret}
+	clientSecret string,
+	identityUri *url.URL) *BearerAuthenticatorConfig {
+	return &BearerAuthenticatorConfig{clientId, clientSecret, identityUri}
 }

--- a/auth/oauth_authenticator_config.go
+++ b/auth/oauth_authenticator_config.go
@@ -6,11 +6,13 @@ type OAuthAuthenticatorConfig struct {
 	ClientId    string
 	RedirectUrl url.URL
 	Scopes      string
+	IdentityUri *url.URL
 }
 
 func NewOAuthAuthenticatorConfig(
 	clientId string,
 	redirectUrl url.URL,
-	scopes string) *OAuthAuthenticatorConfig {
-	return &OAuthAuthenticatorConfig{clientId, redirectUrl, scopes}
+	scopes string,
+	identityUri *url.URL) *OAuthAuthenticatorConfig {
+	return &OAuthAuthenticatorConfig{clientId, redirectUrl, scopes, identityUri}
 }


### PR DESCRIPTION
Users can now configure the CLI with a custom identity url in case the identity endpoint runs on a different domain than the service.