### PR TITLE
Avoid loading files in memory

### DIFF
--- a/commandline/type_converter.go
+++ b/commandline/type_converter.go
@@ -1,10 +1,7 @@
 package commandline
 
 import (
-	"errors"
 	"fmt"
-	"os"
-	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -46,24 +43,12 @@ func (c TypeConverter) convertToBoolean(value string, parameter parser.Parameter
 	return false, fmt.Errorf("Cannot convert '%s' value '%s' to boolean", parameter.Name, value)
 }
 
-func (c TypeConverter) readFile(path string) (executor.FileReference, error) {
-	data, err := os.ReadFile(path)
-	if err != nil && errors.Is(err, os.ErrNotExist) {
-		return executor.FileReference{}, fmt.Errorf("File '%s' not found", path)
-	}
-	if err != nil {
-		return executor.FileReference{}, fmt.Errorf("Error reading file '%s': %v", path, err)
-	}
-	filename := filepath.Base(path)
-	return *executor.NewFileReference(filename, data), nil
-}
-
 func (c TypeConverter) convertToBinary(value string, parameter parser.Parameter) (executor.FileReference, error) {
 	if strings.HasPrefix(value, filePrefix) {
 		path := strings.TrimPrefix(value, filePrefix)
-		return c.readFile(path)
+		return *executor.NewFileReference(path), nil
 	}
-	return *executor.NewFileReference(parameter.Name, []byte(value)), nil
+	return *executor.NewFileReferenceData(parameter.Name, []byte(value)), nil
 }
 
 func (c TypeConverter) findParameter(parameter *parser.Parameter, name string) *parser.Parameter {

--- a/executor/execution_context.go
+++ b/executor/execution_context.go
@@ -12,7 +12,7 @@ type ExecutionContext struct {
 	BaseUri          url.URL
 	Route            string
 	ContentType      string
-	Body             []byte
+	Input            *FileReference
 	PathParameters   []ExecutionParameter
 	QueryParameters  []ExecutionParameter
 	HeaderParameters []ExecutionParameter
@@ -29,7 +29,7 @@ func NewExecutionContext(
 	uri url.URL,
 	route string,
 	contentType string,
-	body []byte,
+	input *FileReference,
 	pathParameters []ExecutionParameter,
 	queryParameters []ExecutionParameter,
 	headerParameters []ExecutionParameter,
@@ -39,5 +39,5 @@ func NewExecutionContext(
 	insecure bool,
 	debug bool,
 	plugin plugin.CommandPlugin) *ExecutionContext {
-	return &ExecutionContext{method, uri, route, contentType, body, pathParameters, queryParameters, headerParameters, bodyParameters, formParameters, authConfig, insecure, debug, plugin}
+	return &ExecutionContext{method, uri, route, contentType, input, pathParameters, queryParameters, headerParameters, bodyParameters, formParameters, authConfig, insecure, debug, plugin}
 }

--- a/executor/file_reference.go
+++ b/executor/file_reference.go
@@ -1,10 +1,52 @@
 package executor
 
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
 type FileReference struct {
-	Filename string
-	Data     []byte
+	path     string
+	filename string
+	data     []byte
 }
 
-func NewFileReference(filename string, data []byte) *FileReference {
-	return &FileReference{filename, data}
+func (f FileReference) Filename() string {
+	return f.filename
+}
+
+func (f FileReference) Data() (io.ReadCloser, int64, error) {
+	if f.data != nil {
+		return io.NopCloser(bytes.NewReader(f.data)), int64(len(f.data)), nil
+	}
+	file, err := os.Open(f.path)
+	if err != nil && errors.Is(err, os.ErrNotExist) {
+		return nil, -1, fmt.Errorf("File '%s' not found", f.path)
+	}
+	if err != nil {
+		return nil, -1, fmt.Errorf("Error reading file '%s': %v", f.path, err)
+	}
+	fileStat, err := file.Stat()
+	if err != nil {
+		return nil, -1, fmt.Errorf("Error reading file size '%s': %v", f.path, err)
+	}
+	return file, fileStat.Size(), nil
+}
+
+func NewFileReference(path string) *FileReference {
+	return &FileReference{
+		filename: filepath.Base(path),
+		path:     path,
+	}
+}
+
+func NewFileReferenceData(filename string, data []byte) *FileReference {
+	return &FileReference{
+		filename: filename,
+		data:     data,
+	}
 }

--- a/executor/plugin_executor.go
+++ b/executor/plugin_executor.go
@@ -37,7 +37,7 @@ func (e PluginExecutor) convertToPluginParameters(parameters []ExecutionParamete
 		name := parameter.Name
 		value := parameter.Value
 		if fileReference, ok := parameter.Value.(FileReference); ok {
-			value = *plugin.NewFileParameter(fileReference.Filename, fileReference.Data)
+			value = *plugin.NewFileParameter(fileReference.path, fileReference.filename, fileReference.data)
 		}
 		result = append(result, *plugin.NewExecutionParameter(name, value))
 	}
@@ -71,6 +71,7 @@ func (e PluginExecutor) Call(context ExecutionContext, writer output.OutputWrite
 		context.BaseUri,
 		pluginAuth,
 		pluginParams,
-		context.Insecure)
+		context.Insecure,
+		context.Debug)
 	return context.Plugin.Execute(*pluginContext, writer, logger)
 }

--- a/log/debug_logger.go
+++ b/log/debug_logger.go
@@ -31,8 +31,8 @@ func (l DebugLogger) writeHeaders(header http.Header) {
 func (l *DebugLogger) LogRequest(request RequestInfo) {
 	fmt.Fprintf(l.Output, "%s %s %s\n", request.Method, request.Url, request.Protocol)
 	l.writeHeaders(request.Header)
-	fmt.Fprint(l.Output, string(request.Body))
-	if len(request.Body) > 0 {
+	n, _ := io.Copy(l.Output, request.Body)
+	if n > 0 {
 		fmt.Fprint(l.Output, "\n\n")
 	}
 	fmt.Fprint(l.Output, "\n")
@@ -41,7 +41,7 @@ func (l *DebugLogger) LogRequest(request RequestInfo) {
 func (l DebugLogger) LogResponse(response ResponseInfo) {
 	fmt.Fprintf(l.Output, "%s %s\n", response.Protocol, response.Status)
 	l.writeHeaders(response.Header)
-	fmt.Fprint(l.Output, string(response.Body))
+	io.Copy(l.Output, response.Body)
 	fmt.Fprint(l.Output, "\n\n\n")
 }
 

--- a/log/request_info.go
+++ b/log/request_info.go
@@ -1,13 +1,15 @@
 package log
 
+import "io"
+
 type RequestInfo struct {
 	Method   string
 	Url      string
 	Protocol string
 	Header   map[string][]string
-	Body     []byte
+	Body     io.Reader
 }
 
-func NewRequestInfo(method string, url string, protocol string, header map[string][]string, body []byte) *RequestInfo {
+func NewRequestInfo(method string, url string, protocol string, header map[string][]string, body io.Reader) *RequestInfo {
 	return &RequestInfo{method, url, protocol, header, body}
 }

--- a/log/response_info.go
+++ b/log/response_info.go
@@ -1,13 +1,15 @@
 package log
 
+import "io"
+
 type ResponseInfo struct {
 	StatusCode int
 	Status     string
 	Protocol   string
 	Header     map[string][]string
-	Body       []byte
+	Body       io.Reader
 }
 
-func NewResponseInfo(statusCode int, status string, protocol string, header map[string][]string, body []byte) *ResponseInfo {
+func NewResponseInfo(statusCode int, status string, protocol string, header map[string][]string, body io.Reader) *ResponseInfo {
 	return &ResponseInfo{statusCode, status, protocol, header, body}
 }

--- a/output/json_output_writer.go
+++ b/output/json_output_writer.go
@@ -33,9 +33,13 @@ func (w JsonOutputWriter) writeBody(body []byte) error {
 }
 
 func (w JsonOutputWriter) WriteResponse(response ResponseInfo) error {
-	if len(response.Body) == 0 && response.StatusCode >= 400 {
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		return err
+	}
+	if len(body) == 0 && response.StatusCode >= 400 {
 		fmt.Fprintf(w.Output, "%s %s\n", response.Protocol, response.Status)
 		return nil
 	}
-	return w.writeBody(response.Body)
+	return w.writeBody(body)
 }

--- a/output/response_info.go
+++ b/output/response_info.go
@@ -1,13 +1,15 @@
 package output
 
+import "io"
+
 type ResponseInfo struct {
 	StatusCode int
 	Status     string
 	Protocol   string
 	Header     map[string][]string
-	Body       []byte
+	Body       io.Reader
 }
 
-func NewResponseInfo(statusCode int, status string, protocol string, header map[string][]string, body []byte) *ResponseInfo {
+func NewResponseInfo(statusCode int, status string, protocol string, header map[string][]string, body io.Reader) *ResponseInfo {
 	return &ResponseInfo{statusCode, status, protocol, header, body}
 }

--- a/output/text_output_writer.go
+++ b/output/text_output_writer.go
@@ -123,9 +123,13 @@ func (w TextOutputWriter) writeBody(body []byte) error {
 }
 
 func (w TextOutputWriter) WriteResponse(response ResponseInfo) error {
-	if len(response.Body) == 0 && response.StatusCode >= 400 {
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		return err
+	}
+	if len(body) == 0 && response.StatusCode >= 400 {
 		fmt.Fprintf(w.Output, "%s %s\n", response.Protocol, response.Status)
 		return nil
 	}
-	return w.writeBody(response.Body)
+	return w.writeBody(body)
 }

--- a/plugin/digitizer/digitize_command.go
+++ b/plugin/digitizer/digitize_command.go
@@ -15,6 +15,7 @@ import (
 	"github.com/UiPath/uipathcli/log"
 	"github.com/UiPath/uipathcli/output"
 	"github.com/UiPath/uipathcli/plugin"
+	"github.com/UiPath/uipathcli/utils"
 )
 
 type DigitizeCommand struct{}
@@ -45,26 +46,31 @@ func (c DigitizeCommand) Execute(context plugin.ExecutionContext, writer output.
 }
 
 func (c DigitizeCommand) digitize(context plugin.ExecutionContext, writer output.OutputWriter, logger log.Logger) (string, error) {
-	request, body, err := c.createDigitizeRequest(context)
+	uploadBar := utils.NewProgressBar(logger)
+	defer uploadBar.Remove()
+	requestError := make(chan error)
+	request, err := c.createDigitizeRequest(context, uploadBar, requestError)
 	if err != nil {
 		return "", err
 	}
-	logger.LogRequest(*log.NewRequestInfo(request.Method, request.URL.String(), request.Proto, request.Header, body))
-	response, err := c.sendRequest(request, context.Insecure)
+	if context.Debug {
+		c.LogRequest(logger, request)
+	}
+	response, err := c.send(request, context.Insecure, requestError)
 	if err != nil {
 		return "", fmt.Errorf("Error sending request: %v", err)
 	}
 	defer response.Body.Close()
-	responseBody, err := io.ReadAll(response.Body)
+	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		return "", fmt.Errorf("Error reading response: %v", err)
 	}
-	logger.LogResponse(*log.NewResponseInfo(response.StatusCode, response.Status, response.Proto, response.Header, responseBody))
+	c.LogResponse(logger, response, body)
 	if response.StatusCode != http.StatusAccepted {
-		return "", fmt.Errorf("Digitizer returned status code '%v' and body '%v'", response.StatusCode, string(responseBody))
+		return "", fmt.Errorf("Digitizer returned status code '%v' and body '%v'", response.StatusCode, string(body))
 	}
 	var result digitizeResponse
-	err = json.Unmarshal(responseBody, &result)
+	err = json.Unmarshal(body, &result)
 	if err != nil {
 		return "", fmt.Errorf("Error parsing json response: %v", err)
 	}
@@ -76,60 +82,76 @@ func (c DigitizeCommand) waitForDigitization(operationId string, context plugin.
 	if err != nil {
 		return true, err
 	}
-	logger.LogRequest(*log.NewRequestInfo(request.Method, request.URL.String(), request.Proto, request.Header, []byte{}))
+	if context.Debug {
+		c.LogRequest(logger, request)
+	}
 	response, err := c.sendRequest(request, context.Insecure)
 	if err != nil {
 		return true, fmt.Errorf("Error sending request: %v", err)
 	}
 	defer response.Body.Close()
-	responseBody, err := io.ReadAll(response.Body)
+	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		return true, fmt.Errorf("Error reading response: %v", err)
 	}
-	logger.LogResponse(*log.NewResponseInfo(response.StatusCode, response.Status, response.Proto, response.Header, responseBody))
+	c.LogResponse(logger, response, body)
 	if response.StatusCode != http.StatusOK {
-		return true, fmt.Errorf("Digitizer returned status code '%v' and body '%v'", response.StatusCode, string(responseBody))
+		return true, fmt.Errorf("Digitizer returned status code '%v' and body '%v'", response.StatusCode, string(body))
 	}
 	var result digitizeStatusResponse
-	err = json.Unmarshal(responseBody, &result)
+	err = json.Unmarshal(body, &result)
 	if err != nil {
 		return true, fmt.Errorf("Error parsing json response: %v", err)
 	}
 	if result.Status == "NotStarted" || result.Status == "Running" {
 		return false, nil
 	}
-	err = writer.WriteResponse(*output.NewResponseInfo(response.StatusCode, response.Status, response.Proto, response.Header, responseBody))
+	err = writer.WriteResponse(*output.NewResponseInfo(response.StatusCode, response.Status, response.Proto, response.Header, bytes.NewReader(body)))
 	return true, err
 }
 
-func (c DigitizeCommand) createDigitizeRequest(context plugin.ExecutionContext) (*http.Request, []byte, error) {
+func (c DigitizeCommand) createDigitizeRequest(context plugin.ExecutionContext, uploadBar *utils.ProgressBar, requestError chan error) (*http.Request, error) {
 	org, err := c.getParameter("organization", context.Parameters)
 	if err != nil {
-		return nil, []byte{}, err
+		return nil, err
 	}
 	tenant, err := c.getParameter("tenant", context.Parameters)
 	if err != nil {
-		return nil, []byte{}, err
+		return nil, err
 	}
 	file, err := c.getFileParameter(context.Parameters)
 	if err != nil {
-		return nil, []byte{}, err
+		return nil, err
 	}
 
+	bodyReader, bodyWriter := io.Pipe()
+	contentType, contentLength := c.writeMultipartBody(bodyWriter, file, requestError)
+	uploadReader := c.progressReader("uploading...", "completing  ", bodyReader, contentLength, uploadBar)
+
 	uri := c.formatUri(context.BaseUri, org, tenant) + "/digitize/start?api-version=1"
-	body, contentType, err := c.createBody(*file)
+	request, err := http.NewRequest("POST", uri, uploadReader)
 	if err != nil {
-		return nil, []byte{}, err
-	}
-	request, err := http.NewRequest("POST", uri, bytes.NewReader(body))
-	if err != nil {
-		return nil, []byte{}, err
+		return nil, err
 	}
 	request.Header.Add("Content-Type", contentType)
 	for key, value := range context.Auth.Header {
 		request.Header.Add(key, value)
 	}
-	return request, body, nil
+	return request, nil
+}
+
+func (c DigitizeCommand) progressReader(text string, completedText string, reader io.Reader, length int64, progressBar *utils.ProgressBar) io.Reader {
+	if length == -1 || length < 10*1024*1024 {
+		return reader
+	}
+	progressReader := utils.NewProgressReader(reader, func(progress utils.Progress) {
+		displayText := text
+		if progress.Completed {
+			displayText = completedText
+		}
+		progressBar.Update(displayText, progress.BytesRead, length, progress.BytesPerSecond)
+	})
+	return progressReader
 }
 
 func (c DigitizeCommand) formatUri(baseUri url.URL, org string, tenant string) string {
@@ -149,7 +171,7 @@ func (c DigitizeCommand) createDigitizeStatusRequest(operationId string, context
 		return nil, err
 	}
 
-	uri := fmt.Sprintf("%s://%s/%s/%s/du_/api/digitizer/digitize/result/%s?api-version=1", context.BaseUri.Scheme, context.BaseUri.Host, org, tenant, operationId)
+	uri := c.formatUri(context.BaseUri, org, tenant) + fmt.Sprintf("/digitize/result/%s?api-version=1", operationId)
 	if err != nil {
 		return nil, err
 	}
@@ -163,19 +185,61 @@ func (c DigitizeCommand) createDigitizeStatusRequest(operationId string, context
 	return request, nil
 }
 
-func (c DigitizeCommand) createBody(file plugin.FileParameter) ([]byte, string, error) {
-	var b bytes.Buffer
-	writer := multipart.NewWriter(&b)
-	w, err := writer.CreateFormFile("file", file.Filename)
+func (c DigitizeCommand) calculateMultipartSize(file *plugin.FileParameter) int64 {
+	data, size, _ := file.Data()
+	defer data.Close()
+	return size
+}
+
+func (c DigitizeCommand) writeMultipartForm(writer *multipart.Writer, file *plugin.FileParameter) error {
+	w, err := writer.CreateFormFile("file", file.Filename())
 	if err != nil {
-		return []byte{}, "", fmt.Errorf("Error creating form field 'file': %v", err)
+		return fmt.Errorf("Error creating form field 'file': %v", err)
 	}
-	_, err = w.Write(file.Data)
+	data, _, err := file.Data()
 	if err != nil {
-		return []byte{}, "", fmt.Errorf("Error writing form field 'file': %v", err)
+		return err
 	}
-	writer.Close()
-	return b.Bytes(), writer.FormDataContentType(), nil
+	defer data.Close()
+	_, err = io.Copy(w, data)
+	if err != nil {
+		return fmt.Errorf("Error writing form field 'file': %v", err)
+	}
+	return nil
+}
+
+func (c DigitizeCommand) writeMultipartBody(bodyWriter *io.PipeWriter, file *plugin.FileParameter, errorChan chan error) (string, int64) {
+	contentLength := c.calculateMultipartSize(file)
+	formWriter := multipart.NewWriter(bodyWriter)
+	go func() {
+		defer bodyWriter.Close()
+		defer formWriter.Close()
+		err := c.writeMultipartForm(formWriter, file)
+		if err != nil {
+			errorChan <- err
+			return
+		}
+	}()
+	return formWriter.FormDataContentType(), contentLength
+}
+
+func (c DigitizeCommand) send(request *http.Request, insecure bool, errorChan chan error) (*http.Response, error) {
+	responseChan := make(chan *http.Response)
+	go func(request *http.Request) {
+		response, err := c.sendRequest(request, insecure)
+		if err != nil {
+			errorChan <- err
+			return
+		}
+		responseChan <- response
+	}(request)
+
+	select {
+	case err := <-errorChan:
+		return nil, err
+	case response := <-responseChan:
+		return response, nil
+	}
 }
 
 func (c DigitizeCommand) sendRequest(request *http.Request, insecure bool) (*http.Response, error) {
@@ -206,4 +270,18 @@ func (c DigitizeCommand) getFileParameter(parameters []plugin.ExecutionParameter
 		}
 	}
 	return nil, fmt.Errorf("Could not find 'file' parameter")
+}
+
+func (c DigitizeCommand) LogRequest(logger log.Logger, request *http.Request) {
+	buffer := &bytes.Buffer{}
+	buffer.ReadFrom(request.Body)
+	body := buffer.Bytes()
+	request.Body = io.NopCloser(bytes.NewReader(body))
+	requestInfo := log.NewRequestInfo(request.Method, request.URL.String(), request.Proto, request.Header, bytes.NewReader(body))
+	logger.LogRequest(*requestInfo)
+}
+
+func (c DigitizeCommand) LogResponse(logger log.Logger, response *http.Response, body []byte) {
+	responseInfo := log.NewResponseInfo(response.StatusCode, response.Status, response.Proto, response.Header, bytes.NewReader(body))
+	logger.LogResponse(*responseInfo)
 }

--- a/plugin/execution_context.go
+++ b/plugin/execution_context.go
@@ -7,12 +7,14 @@ type ExecutionContext struct {
 	Auth       AuthResult
 	Parameters []ExecutionParameter
 	Insecure   bool
+	Debug      bool
 }
 
 func NewExecutionContext(
 	baseUri url.URL,
 	auth AuthResult,
 	parameters []ExecutionParameter,
-	insecure bool) *ExecutionContext {
-	return &ExecutionContext{baseUri, auth, parameters, insecure}
+	insecure bool,
+	debug bool) *ExecutionContext {
+	return &ExecutionContext{baseUri, auth, parameters, insecure, debug}
 }

--- a/plugin/file_parameter.go
+++ b/plugin/file_parameter.go
@@ -1,10 +1,45 @@
 package plugin
 
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+)
+
 type FileParameter struct {
-	Filename string
-	Data     []byte
+	path     string
+	filename string
+	data     []byte
 }
 
-func NewFileParameter(filename string, data []byte) *FileParameter {
-	return &FileParameter{filename, data}
+func (f FileParameter) Filename() string {
+	return f.filename
+}
+
+func (f FileParameter) Data() (io.ReadCloser, int64, error) {
+	if f.data != nil {
+		return io.NopCloser(bytes.NewReader(f.data)), int64(len(f.data)), nil
+	}
+	file, err := os.Open(f.path)
+	if err != nil && errors.Is(err, os.ErrNotExist) {
+		return nil, -1, fmt.Errorf("File '%s' not found", f.path)
+	}
+	if err != nil {
+		return nil, -1, fmt.Errorf("Error reading file '%s': %v", f.path, err)
+	}
+	fileStat, err := file.Stat()
+	if err != nil {
+		return nil, -1, fmt.Errorf("Error reading file size '%s': %v", f.path, err)
+	}
+	return file, fileStat.Size(), nil
+}
+
+func NewFileParameter(path string, filename string, data []byte) *FileParameter {
+	return &FileParameter{
+		path:     path,
+		filename: filename,
+		data:     data,
+	}
 }

--- a/test/plugin_digitizer_test.go
+++ b/test/plugin_digitizer_test.go
@@ -131,6 +131,16 @@ func TestDigitizeSuccessfully(t *testing.T) {
 `
 
 	definition := `
+servers:
+- url: https://cloud.uipath.com/{organization}/{tenant}/du_/api/digitizer
+  description: The production url
+  variables:
+    organization:
+      description: The organization name (or id)
+      default: my-org
+    tenant:
+      description: The tenant name (or id)
+      default: my-tenant
 paths:
   /digitize:
     get:

--- a/test/plugin_test.go
+++ b/test/plugin_test.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"bytes"
 	"fmt"
 	"strings"
 	"testing"
@@ -280,7 +281,7 @@ func (c SimplePluginCommand) Command() plugin.Command {
 
 func (c SimplePluginCommand) Execute(context plugin.ExecutionContext, writer output.OutputWriter, logger log.Logger) error {
 	logger.Log("Simple plugin logging output")
-	return writer.WriteResponse(*output.NewResponseInfo(200, "200 OK", "https", map[string][]string{}, []byte("Simple plugin output")))
+	return writer.WriteResponse(*output.NewResponseInfo(200, "200 OK", "https", map[string][]string{}, bytes.NewReader([]byte("Simple plugin output"))))
 }
 
 type ContextPluginCommand struct {

--- a/utils/progress.go
+++ b/utils/progress.go
@@ -1,4 +1,4 @@
-package executor
+package utils
 
 type Progress struct {
 	BytesRead      int64

--- a/utils/progress_bar.go
+++ b/utils/progress_bar.go
@@ -1,7 +1,8 @@
-package executor
+package utils
 
 import (
 	"fmt"
+	"math"
 	"strings"
 	"unicode/utf8"
 
@@ -31,7 +32,7 @@ func (b *ProgressBar) Remove() {
 }
 
 func (b ProgressBar) render(text string, currentBytes int64, totalBytes int64, bytesPerSecond int64) int {
-	percent := float64(currentBytes) / float64(totalBytes) * 100.0
+	percent := math.Min(float64(currentBytes)/float64(totalBytes)*100.0, 100.0)
 	barCount := int(percent / 5.0)
 	bar := strings.Repeat("█", barCount) + strings.Repeat(" ", 20-barCount)
 	totalBytesFormatted, unit := b.formatBytes(totalBytes)

--- a/utils/progress_reader.go
+++ b/utils/progress_reader.go
@@ -1,4 +1,4 @@
-package executor
+package utils
 
 import (
 	"io"


### PR DESCRIPTION
Refactored the code to use readers and writers where possible in order to avoid loading large files in memory. This allows the user to upload/download multi GB files to storage.

Extended the file reference struct to take a file path. The file will only be opened when the HTTP request is made in the executor. The file will be directly streamed avoiding loading files in memory.