### PR TITLE
Handle error when file was not found

### DIFF
--- a/executor/http_executor.go
+++ b/executor/http_executor.go
@@ -218,7 +218,9 @@ func (e HttpExecutor) writeBody(context ExecutionContext, errorChan chan error) 
 		e.writeJsonBody(bodyWriter, context.BodyParameters, errorChan)
 		return bodyReader, context.ContentType, -1
 	}
-	bodyWriter.Close()
+	go func() {
+		defer bodyWriter.Close()
+	}()
 	return bodyReader, context.ContentType, -1
 }
 

--- a/plugin/digitizer/digitize_command.go
+++ b/plugin/digitizer/digitize_command.go
@@ -186,8 +186,10 @@ func (c DigitizeCommand) createDigitizeStatusRequest(operationId string, context
 }
 
 func (c DigitizeCommand) calculateMultipartSize(file *plugin.FileParameter) int64 {
-	data, size, _ := file.Data()
-	defer data.Close()
+	data, size, err := file.Data()
+	if err == nil {
+		defer data.Close()
+	}
 	return size
 }
 

--- a/test/plugin_digitizer_test.go
+++ b/test/plugin_digitizer_test.go
@@ -70,6 +70,34 @@ paths:
 	}
 }
 
+func TestDigitizeFileDoesNotExistShowsValidationError(t *testing.T) {
+	config := `profiles:
+- name: default
+  path:
+    organization: my-org
+    tenant: my-tenant
+`
+
+	definition := `
+paths:
+  /digitize:
+    get:
+      operationId: digitize
+`
+
+	context := NewContextBuilder().
+		WithConfig(config).
+		WithDefinition("du-digitizer", definition).
+		WithCommandPlugin(plugin_digitizer.DigitizeCommand{}).
+		Build()
+
+	result := runCli([]string{"du-digitizer", "digitize", "--file", "file://does-not-exist"}, context)
+
+	if !strings.Contains(result.StdErr, "Error sending request: File 'does-not-exist' not found") {
+		t.Errorf("Expected stderr to show that file was not found, but got: %v", result.StdErr)
+	}
+}
+
 func TestDigitizeWithoutOrganizationShowsValidationError(t *testing.T) {
 	definition := `
 paths:


### PR DESCRIPTION
- Do not close file if there was an error opening it.
- Add test to validate that an error message is shown when file was not found.
- Close body writer in separate go routing to avoid blocking the stream reading