### PR TITLE
Add missing trailing spaces to autocomplete command

### DIFF
--- a/commandline/autocomplete_handler.go
+++ b/commandline/autocomplete_handler.go
@@ -21,8 +21,10 @@ const completeHandlerEnabledCheck = "uipathcli_auto_complete"
 const powershellCompleteHandler = `
 $uipathcli_auto_complete = {
     param($wordToComplete, $commandAst, $cursorPosition)
+    $padLength = $cursorPosition - $commandAst.Extent.StartOffset
+    $textToComplete = $commandAst.ToString().PadRight($padLength, ' ').Substring(0, $padLength)
     $command, $params = $commandAst.ToString() -split " ", 2
-    & $command autocomplete complete --command "$commandAst" | foreach-object {
+    & $command autocomplete complete --command "$textToComplete" | foreach-object {
         [system.management.automation.completionresult]::new($_, $_, 'parametervalue', $_)
     }
 }

--- a/test/autocomplete_enable_test.go
+++ b/test/autocomplete_enable_test.go
@@ -51,8 +51,10 @@ func TestEnableAutocompletePowershellCreatesProfileFile(t *testing.T) {
 	expectedFileContent := `
 $uipathcli_auto_complete = {
     param($wordToComplete, $commandAst, $cursorPosition)
+    $padLength = $cursorPosition - $commandAst.Extent.StartOffset
+    $textToComplete = $commandAst.ToString().PadRight($padLength, ' ').Substring(0, $padLength)
     $command, $params = $commandAst.ToString() -split " ", 2
-    & $command autocomplete complete --command "$commandAst" | foreach-object {
+    & $command autocomplete complete --command "$textToComplete" | foreach-object {
         [system.management.automation.completionresult]::new($_, $_, 'parametervalue', $_)
     }
 }
@@ -79,8 +81,10 @@ func TestEnableAutocompletePowershellUpdatesExistingProfileFile(t *testing.T) {
 should not change
 $uipathcli_auto_complete = {
     param($wordToComplete, $commandAst, $cursorPosition)
+    $padLength = $cursorPosition - $commandAst.Extent.StartOffset
+    $textToComplete = $commandAst.ToString().PadRight($padLength, ' ').Substring(0, $padLength)
     $command, $params = $commandAst.ToString() -split " ", 2
-    & $command autocomplete complete --command "$commandAst" | foreach-object {
+    & $command autocomplete complete --command "$textToComplete" | foreach-object {
         [system.management.automation.completionresult]::new($_, $_, 'parametervalue', $_)
     }
 }


### PR DESCRIPTION
Powershell strips the trailing spaces when calling the autocomplete handler which leads to commands not probably expanded, e.g.

`uipathcli orchestrator <tab>`

This command was passed as "uipathcli orchestrator" without trailing spaces and the CLI tried to autocomplete the orchestrator word.