### PR TITLE
Remove file:// prefix for binary uploads

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,7 +130,7 @@ go tool cover --html=coverage.out
 The CLI supports a pluggable infrastructure which allows you to implement complex custom commands. The [`DigitizeCommand`](plugin/digitizer/digitize_command.go) is an example for a custom command which abstracts away the complexity of the async digitization API. The digitizer API requires you to upload a file, followed by polling the status API until the digitization finished in order to retrieve the digitization result. The `DigitizeCommand` allows the user to just invoke one command for uploading the file and retrieving the result:
 
 ```bash
-uipathcli digitizer digitize --file file:///documents/invoice.pdf
+uipathcli digitizer digitize --file documents/invoice.pdf
 ```
 
 returns

--- a/README.md
+++ b/README.md
@@ -326,16 +326,10 @@ The command creates the following JSON body in the HTTP request:
 ```
 ### File Upload arguments
 
-File content can be uploaded directly from a command line argument. The following command will upload a file with the content `hello-world`:
-
-```bash
-uipathcli digitizer digitize --file "hello-world"
-```
-
 CLI arguments can also refer to files on disk. This command reads the invoice from `/documents/invoice.pdf` and uploads it to the digitize endpoint:
 
 ```bash
-uipathcli digitizer digitize ---file file:///documents/invoice.pdf
+uipathcli digitizer digitize ---file documents/invoice.pdf
 ```
 
 ## Standard input (stdin) / Pipes

--- a/commandline/type_converter.go
+++ b/commandline/type_converter.go
@@ -9,8 +9,6 @@ import (
 	"github.com/UiPath/uipathcli/parser"
 )
 
-const filePrefix = "file://"
-
 type TypeConverter struct{}
 
 func (c TypeConverter) trim(value string) string {
@@ -44,11 +42,7 @@ func (c TypeConverter) convertToBoolean(value string, parameter parser.Parameter
 }
 
 func (c TypeConverter) convertToBinary(value string, parameter parser.Parameter) (executor.FileReference, error) {
-	if strings.HasPrefix(value, filePrefix) {
-		path := strings.TrimPrefix(value, filePrefix)
-		return *executor.NewFileReference(path), nil
-	}
-	return *executor.NewFileReferenceData(parameter.Name, []byte(value)), nil
+	return *executor.NewFileReference(value), nil
 }
 
 func (c TypeConverter) findParameter(parameter *parser.Parameter, name string) *parser.Parameter {

--- a/test/plugin_digitizer_test.go
+++ b/test/plugin_digitizer_test.go
@@ -91,7 +91,7 @@ paths:
 		WithCommandPlugin(plugin_digitizer.DigitizeCommand{}).
 		Build()
 
-	result := runCli([]string{"du", "digitization", "digitize", "--file", "file://does-not-exist"}, context)
+	result := runCli([]string{"du", "digitization", "digitize", "--file", "does-not-exist"}, context)
 
 	if !strings.Contains(result.StdErr, "Error sending request: File 'does-not-exist' not found") {
 		t.Errorf("Expected stderr to show that file was not found, but got: %v", result.StdErr)
@@ -119,6 +119,9 @@ paths:
 }
 
 func TestDigitizeWithFailedResponseReturnsError(t *testing.T) {
+	path := createFile(t)
+	os.WriteFile(path, []byte("hello-world"), 0644)
+
 	config := `profiles:
 - name: default
   path:
@@ -140,7 +143,7 @@ paths:
 		WithResponse(400, "validation error").
 		Build()
 
-	result := runCli([]string{"du", "digitization", "digitize", "--file", "hello-world"}, context)
+	result := runCli([]string{"du", "digitization", "digitize", "--file", path}, context)
 
 	if !strings.Contains(result.StdErr, "Digitizer returned status code '400' and body 'validation error'") {
 		t.Errorf("Expected stderr to show that digitizer call failed, but got: %v", result.StdErr)
@@ -183,7 +186,7 @@ paths:
 		WithUrlResponse("/my-org/my-tenant/du_/api/digitizer/digitize/result/eb80e441-05de-4a13-9aaa-f65b1babba05?api-version=1", 200, `{"status":"Done"}`).
 		Build()
 
-	result := runCli([]string{"du", "digitization", "digitize", "--file", "file://" + path}, context)
+	result := runCli([]string{"du", "digitization", "digitize", "--file", path}, context)
 
 	expectedResult := `{
   "status": "Done"
@@ -220,7 +223,7 @@ paths:
 		WithUrlResponse("/my-org/my-tenant/du_/api/digitizer/digitize/result/eb80e441-05de-4a13-9aaa-f65b1babba05?api-version=1", 200, `{"status":"Done"}`).
 		Build()
 
-	result := runCli([]string{"du", "digitization", "digitize", "--file", "file://" + path, "--debug"}, context)
+	result := runCli([]string{"du", "digitization", "digitize", "--file", path, "--debug"}, context)
 
 	if !strings.Contains(result.StdOut, "/digitize/start") {
 		t.Errorf("Expected stdout to show the start digitize operation, but got: %v", result.StdOut)

--- a/test/validation_test.go
+++ b/test/validation_test.go
@@ -196,7 +196,7 @@ paths:
 		Build()
 	path := filepath.Join(t.TempDir(), "not-found.txt")
 
-	result := runCli([]string{"myservice", "post-validate", "--file", "file://" + path}, context)
+	result := runCli([]string{"myservice", "post-validate", "--file", path}, context)
 
 	expected := "File '" + path + "' not found"
 	if !strings.Contains(result.StdErr, expected) {


### PR DESCRIPTION
This makes the integration with the shell more natural because file paths can now be autocompleted.