### PR TITLE
Add support for enums

### DIFF
--- a/commandline/definition_provider.go
+++ b/commandline/definition_provider.go
@@ -133,6 +133,7 @@ func (p DefinitionProvider) convertToParameters(parameters []plugin.CommandParam
 			p.Name,
 			p.Required,
 			nil,
+			nil,
 			[]parser.Parameter{})
 		result = append(result, parameter)
 	}

--- a/parser/parameter.go
+++ b/parser/parameter.go
@@ -1,14 +1,15 @@
 package parser
 
 type Parameter struct {
-	Name         string
-	Type         string
-	Description  string
-	In           string
-	FieldName    string
-	Required     bool
-	DefaultValue interface{}
-	Parameters   []Parameter
+	Name          string
+	Type          string
+	Description   string
+	In            string
+	FieldName     string
+	Required      bool
+	DefaultValue  interface{}
+	AllowedValues []interface{}
+	Parameters    []Parameter
 }
 
 const (
@@ -33,6 +34,6 @@ const (
 	ParameterInForm   = "form"
 )
 
-func NewParameter(name string, t string, description string, in string, fieldName string, required bool, defaultValue interface{}, parameters []Parameter) *Parameter {
-	return &Parameter{name, t, description, in, fieldName, required, defaultValue, parameters}
+func NewParameter(name string, t string, description string, in string, fieldName string, required bool, defaultValue interface{}, allowedValues []interface{}, parameters []Parameter) *Parameter {
+	return &Parameter{name, t, description, in, fieldName, required, defaultValue, allowedValues, parameters}
 }

--- a/plugin/digitizer/digitize_command.go
+++ b/plugin/digitizer/digitize_command.go
@@ -123,7 +123,6 @@ func (c DigitizeCommand) createDigitizeRequest(context plugin.ExecutionContext, 
 		return nil, err
 	}
 	file := context.Input
-	fmt.Println(file)
 	if file == nil {
 		file, err = c.getFileParameter(context.Parameters)
 		if err != nil {


### PR DESCRIPTION
- Extend openapi_parser to read enum values
- Display allowed values in help
- Sort parameters by name but display required parameters first
- Add validation for enum parameters to contain allowed value

example:

```
--type value    The user type.
   allowed values: User, Robot, DirectoryUser, DirectoryGroup
```