### PR TITLE
Display long description for commands

### DIFF
--- a/commandline/command_builder.go
+++ b/commandline/command_builder.go
@@ -279,9 +279,10 @@ func (b CommandBuilder) createOperationCommand(definition parser.Definition, ope
 	flags = append(flags, b.createFlags(parameters)...)
 
 	return &cli.Command{
-		Name:  operation.Name,
-		Usage: operation.Description,
-		Flags: flags,
+		Name:        operation.Name,
+		Usage:       operation.Summary,
+		Description: operation.Description,
+		Flags:       flags,
 		Action: func(context *cli.Context) error {
 			profileName := context.String(profileFlagName)
 			config := b.ConfigProvider.Config(profileName)

--- a/commandline/definition_provider.go
+++ b/commandline/definition_provider.go
@@ -112,7 +112,7 @@ func (p DefinitionProvider) applyPluginCommand(plugin plugin.CommandPlugin, comm
 		category = parser.NewOperationCategory(command.Category.Name, command.Category.Description)
 	}
 	baseUri, _ := url.Parse(parser.DefaultServerBaseUrl)
-	operation := parser.NewOperation(command.Name, command.Description, "", *baseUri, "", "application/json", parameters, plugin, command.Hidden, category)
+	operation := parser.NewOperation(command.Name, command.Description, "", "", *baseUri, "", "application/json", parameters, plugin, command.Hidden, category)
 	for i := range definition.Operations {
 		if definition.Operations[i].Name == command.Name {
 			definition.Operations[i] = *operation

--- a/commandline/multi_definition.go
+++ b/commandline/multi_definition.go
@@ -15,6 +15,7 @@ func (d MultiDefinition) Merge(name string, definitions []*parser.Definition) *p
 		for _, operation := range definition.Operations {
 			category := d.getCategory(operation, definition)
 			operations = append(operations, *parser.NewOperation(operation.Name,
+				operation.Summary,
 				operation.Description,
 				operation.Method,
 				operation.BaseUri,

--- a/parser/openapi_parser.go
+++ b/parser/openapi_parser.go
@@ -253,7 +253,7 @@ func (p OpenApiParser) parseOperation(method string, baseUri url.URL, route stri
 	category := p.getCategory(operation, document)
 	name := p.getName(method, route, category, operation)
 	contentType, parameters := p.parseOperationParameters(operation, routeParameters)
-	return *NewOperation(name, operation.Summary, method, baseUri, route, contentType, parameters, nil, false, category)
+	return *NewOperation(name, operation.Summary, operation.Description, method, baseUri, route, contentType, parameters, nil, false, category)
 }
 
 func (p OpenApiParser) parsePath(baseUri url.URL, route string, pathItem openapi3.PathItem, document openapi3.T) []Operation {

--- a/parser/operation.go
+++ b/parser/operation.go
@@ -8,6 +8,7 @@ import (
 
 type Operation struct {
 	Name        string
+	Summary     string
 	Description string
 	Method      string
 	BaseUri     url.URL
@@ -19,6 +20,6 @@ type Operation struct {
 	Category    *OperationCategory
 }
 
-func NewOperation(name string, description string, method string, baseUri url.URL, route string, contentType string, parameters []Parameter, plugin plugin.CommandPlugin, hidden bool, category *OperationCategory) *Operation {
-	return &Operation{name, description, method, baseUri, route, contentType, parameters, plugin, hidden, category}
+func NewOperation(name string, summary string, description string, method string, baseUri url.URL, route string, contentType string, parameters []Parameter, plugin plugin.CommandPlugin, hidden bool, category *OperationCategory) *Operation {
+	return &Operation{name, summary, description, method, baseUri, route, contentType, parameters, plugin, hidden, category}
 }

--- a/test/parser_test.go
+++ b/test/parser_test.go
@@ -126,7 +126,7 @@ paths:
 	}
 }
 
-func TestOperationDescription(t *testing.T) {
+func TestOperationsSummary(t *testing.T) {
 	definition := `
 paths:
   /ping:
@@ -141,7 +141,47 @@ paths:
 
 	expected := "Simple ping"
 	if !strings.Contains(result.StdOut, expected) {
+		t.Errorf("stdout does not contain operation summaries, expected: %v, got: %v", expected, result.StdOut)
+	}
+}
+
+func TestOperationSummary(t *testing.T) {
+	definition := `
+paths:
+  /ping:
+    get:
+      operationId: ping
+      summary: Simple ping
+`
+	context := NewContextBuilder().
+		WithDefinition("myservice", definition).
+		Build()
+
+	result := runCli([]string{"myservice", "ping", "--help"}, context)
+
+	expected := "Simple ping"
+	if !strings.Contains(result.StdOut, expected) {
 		t.Errorf("stdout does not contain ping operation summary, expected: %v, got: %v", expected, result.StdOut)
+	}
+}
+
+func TestOperationDescription(t *testing.T) {
+	definition := `
+paths:
+  /ping:
+    get:
+      operationId: ping
+      description: This is a long description
+`
+	context := NewContextBuilder().
+		WithDefinition("myservice", definition).
+		Build()
+
+	result := runCli([]string{"myservice", "ping", "--help"}, context)
+
+	expected := "This is a long description"
+	if !strings.Contains(result.StdOut, expected) {
+		t.Errorf("stdout does not contain ping operation description, expected: %v, got: %v", expected, result.StdOut)
 	}
 }
 


### PR DESCRIPTION
Parsing the description field from OpenAPI and displaying it on the command details help output to give a more detailed description of the command.