### PR TITLE
Enable autocomplete for powershell 7

### DIFF
--- a/commandline/autocomplete_folder_windows.go
+++ b/commandline/autocomplete_folder_windows.go
@@ -15,7 +15,7 @@ func PowershellProfilePath() (string, error) {
 		return "", err
 	}
 	documentDir := windowsDocumentDir(homeDir)
-	return filepath.Join(documentDir, "WindowsPowerShell", "profile.ps1"), nil
+	return filepath.Join(documentDir, "PowerShell", "profile.ps1"), nil
 }
 
 func BashrcPath() (string, error) {


### PR DESCRIPTION
Powershell 7 stores the profile.ps1 in the PowerShell folder instead of WindowsPowerShell. Updated the script to work with powershell 7.