### PR TITLE
Add validation for organization and tenant

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,19 +244,18 @@ After that the CLI should be ready and you can validate that it is working by in
 
 ### Configuration File
 
-You can also manually create or edit the configuration file `.uipathcli/config` in your home directory. The following config file sets up the default profile with clientId, clientSecret so that the CLI can generate a bearer token before calling any of the services. It also sets the organization and tenant in the route for services which require it.
+You can also manually create or edit the configuration file `.uipathcli/config` in your home directory. The following config file sets up the default profile with clientId, clientSecret so that the CLI can generate a bearer token before calling any of the services. It also sets the organization and tenant for services which require it.
 
 ```bash
 cat <<EOT > $HOME/.uipathcli/config
 ---
 profiles:
   - name: default
+    organization: <organization-name>
+    tenant: <tenant-name>
     auth:
       clientId: <your-client-id>
       clientSecret: <your-client-secret>
-    path:
-      organization: <organization-name>
-      tenant: <tenant-name>
 EOT
 ```
 
@@ -437,12 +436,11 @@ You can also define multiple configuration profiles to target different environm
 ```yaml
 profiles:
   - name: default
+    organization: uipatcleitzc
+    tenant: DefaultTenant
     auth:
       clientId: <your-client-id>
       clientSecret: <your-client-secret>
-    path:
-      organization: uipatcleitzc
-      tenant: DefaultTenant
   - name: apikey
     uri: https://du.uipath.com/metering/
     header:
@@ -451,12 +449,11 @@ profiles:
     output: text
   - name: alpha
     uri: https://alpha.uipath.com
+    organization: UiPatricjvjx
+    tenant: DefaultTenant
     auth:
       clientId: <your-client-id>
       clientSecret: <your-client-secret>
-    path:
-      organization: UiPatricjvjx
-      tenant: DefaultTenant
 ```
 
 If you do not provide the `--profile` parameter, the `default` profile is automatically selected. Otherwise it will use the settings from the provided profile. The following command will send a request to the alpha.uipath.com environment:
@@ -495,12 +492,11 @@ You can set up a separate profile for automation suite which configures the URI 
 ```yaml
 profiles:
   - name: automationsuite
+    organization: test
+    tenant: DefaultTenant
     auth:
       clientId: <your-client-id>
       clientSecret: <your-client-secret>
-    path:
-      organization: test
-      tenant: DefaultTenant
     insecure: true
 ```
 

--- a/commandline/command_builder.go
+++ b/commandline/command_builder.go
@@ -333,17 +333,21 @@ func (b CommandBuilder) createOperationCommand(definition parser.Definition, ope
 			}
 			insecure := context.Bool(insecureFlagName) || config.Insecure
 			debug := context.Bool(debugFlagName) || config.Debug
+			parameters := executor.NewExecutionContextParameters(
+				pathParameters,
+				queryParameters,
+				headerParameters,
+				bodyParameters,
+				formParameters)
 			executionContext := executor.NewExecutionContext(
+				config.Organization,
+				config.Tenant,
 				operation.Method,
 				baseUri,
 				operation.Route,
 				operation.ContentType,
 				input,
-				pathParameters,
-				queryParameters,
-				headerParameters,
-				bodyParameters,
-				formParameters,
+				*parameters,
 				config.Auth,
 				insecure,
 				debug,

--- a/commandline/config_command_handler.go
+++ b/commandline/config_command_handler.go
@@ -49,12 +49,12 @@ func (h ConfigCommandHandler) configureCredentials(profileName string) error {
 	if err != nil {
 		return nil
 	}
-	message = fmt.Sprintf("Enter organization [%s]:", h.getDisplayValue(config.Organization(), false))
+	message = fmt.Sprintf("Enter organization [%s]:", h.getDisplayValue(config.Organization, false))
 	organization, err := h.readUserInput(message, reader)
 	if err != nil {
 		return nil
 	}
-	message = fmt.Sprintf("Enter tenant [%s]:", h.getDisplayValue(config.Tenant(), false))
+	message = fmt.Sprintf("Enter tenant [%s]:", h.getDisplayValue(config.Tenant, false))
 	tenant, err := h.readUserInput(message, reader)
 	if err != nil {
 		return nil
@@ -64,7 +64,7 @@ func (h ConfigCommandHandler) configureCredentials(profileName string) error {
 	orgTenantChanged := config.ConfigureOrgTenant(organization, tenant)
 
 	if authChanged || orgTenantChanged {
-		err = h.ConfigProvider.Update(profileName, config.Auth.Config, config.Path)
+		err = h.ConfigProvider.Update(profileName, config)
 		if err != nil {
 			return err
 		}
@@ -92,12 +92,12 @@ func (h ConfigCommandHandler) configureLogin(profileName string) error {
 	if err != nil {
 		return nil
 	}
-	message = fmt.Sprintf("Enter organization [%s]:", h.getDisplayValue(config.Organization(), false))
+	message = fmt.Sprintf("Enter organization [%s]:", h.getDisplayValue(config.Organization, false))
 	organization, err := h.readUserInput(message, reader)
 	if err != nil {
 		return nil
 	}
-	message = fmt.Sprintf("Enter tenant [%s]:", h.getDisplayValue(config.Tenant(), false))
+	message = fmt.Sprintf("Enter tenant [%s]:", h.getDisplayValue(config.Tenant, false))
 	tenant, err := h.readUserInput(message, reader)
 	if err != nil {
 		return nil
@@ -107,7 +107,7 @@ func (h ConfigCommandHandler) configureLogin(profileName string) error {
 	orgTenantChanged := config.ConfigureOrgTenant(organization, tenant)
 
 	if authChanged || orgTenantChanged {
-		err = h.ConfigProvider.Update(profileName, config.Auth.Config, config.Path)
+		err = h.ConfigProvider.Update(profileName, config)
 		if err != nil {
 			return err
 		}
@@ -125,12 +125,12 @@ func (h ConfigCommandHandler) configurePat(profileName string) error {
 	if err != nil {
 		return nil
 	}
-	message = fmt.Sprintf("Enter organization [%s]:", h.getDisplayValue(config.Organization(), false))
+	message = fmt.Sprintf("Enter organization [%s]:", h.getDisplayValue(config.Organization, false))
 	organization, err := h.readUserInput(message, reader)
 	if err != nil {
 		return nil
 	}
-	message = fmt.Sprintf("Enter tenant [%s]:", h.getDisplayValue(config.Tenant(), false))
+	message = fmt.Sprintf("Enter tenant [%s]:", h.getDisplayValue(config.Tenant, false))
 	tenant, err := h.readUserInput(message, reader)
 	if err != nil {
 		return nil
@@ -140,7 +140,7 @@ func (h ConfigCommandHandler) configurePat(profileName string) error {
 	orgTenantChanged := config.ConfigureOrgTenant(organization, tenant)
 
 	if authChanged || orgTenantChanged {
-		err = h.ConfigProvider.Update(profileName, config.Auth.Config, config.Path)
+		err = h.ConfigProvider.Update(profileName, config)
 		if err != nil {
 			return err
 		}

--- a/config/config.go
+++ b/config/config.go
@@ -6,14 +6,16 @@ import (
 )
 
 type Config struct {
-	Uri      *url.URL
-	Path     map[string]string
-	Query    map[string]string
-	Header   map[string]string
-	Auth     AuthConfig
-	Insecure bool
-	Debug    bool
-	Output   string
+	Uri          *url.URL
+	Organization string
+	Tenant       string
+	Path         map[string]string
+	Query        map[string]string
+	Header       map[string]string
+	Auth         AuthConfig
+	Insecure     bool
+	Debug        bool
+	Output       string
 }
 
 type AuthConfig struct {
@@ -21,22 +23,11 @@ type AuthConfig struct {
 	Config map[string]interface{}
 }
 
-const organizationKey = "organization"
-const tenantKey = "tenant"
-
 const clientIdKey = "clientId"
 const clientSecretKey = "clientSecret"
 const redirectUriKey = "redirectUri"
 const scopesKey = "scopes"
 const patKey = "pat"
-
-func (c Config) Organization() string {
-	return c.Path[organizationKey]
-}
-
-func (c Config) Tenant() string {
-	return c.Path[tenantKey]
-}
 
 func (c Config) ClientId() string {
 	clientId := c.Auth.Config[clientIdKey]
@@ -78,12 +69,12 @@ func (c Config) Pat() string {
 	return fmt.Sprintf("%v", pat)
 }
 
-func (c Config) ConfigureOrgTenant(organization string, tenant string) bool {
+func (c *Config) ConfigureOrgTenant(organization string, tenant string) bool {
 	if organization != "" {
-		c.Path[organizationKey] = organization
+		c.Organization = organization
 	}
 	if tenant != "" {
-		c.Path[tenantKey] = tenant
+		c.Tenant = tenant
 	}
 
 	return organization != "" || tenant != ""

--- a/config/config_provider.go
+++ b/config/config_provider.go
@@ -27,7 +27,7 @@ func (cp *ConfigProvider) Load() error {
 	return nil
 }
 
-func (cp *ConfigProvider) Update(profileName string, auth map[string]interface{}, path map[string]string) error {
+func (cp *ConfigProvider) Update(profileName string, config Config) error {
 	profile := profileYaml{
 		Name: profileName,
 	}
@@ -38,8 +38,9 @@ func (cp *ConfigProvider) Update(profileName string, auth map[string]interface{}
 			profile = p
 		}
 	}
-	profile.Auth = auth
-	profile.Path = path
+	profile.Organization = config.Organization
+	profile.Tenant = config.Tenant
+	profile.Auth = config.Auth.Config
 
 	if index == -1 {
 		cp.profiles = append(cp.profiles, profile)
@@ -68,10 +69,12 @@ func (cp ConfigProvider) convertToConfig(profile profileYaml) Config {
 		profile.Query = map[string]string{}
 	}
 	return Config{
-		Uri:    profile.Uri.URL,
-		Path:   profile.Path,
-		Query:  profile.Query,
-		Header: profile.Header,
+		Organization: profile.Organization,
+		Tenant:       profile.Tenant,
+		Uri:          profile.Uri.URL,
+		Path:         profile.Path,
+		Query:        profile.Query,
+		Header:       profile.Header,
 		Auth: AuthConfig{
 			Type:   fmt.Sprintf("%v", profile.Auth["type"]),
 			Config: profile.Auth,

--- a/config/profile_yaml.go
+++ b/config/profile_yaml.go
@@ -1,13 +1,15 @@
 package config
 
 type profileYaml struct {
-	Name     string                 `yaml:"name"`
-	Uri      urlYaml                `yaml:"uri,omitempty"`
-	Path     map[string]string      `yaml:"path,omitempty"`
-	Query    map[string]string      `yaml:"query,omitempty"`
-	Header   map[string]string      `yaml:"header,omitempty"`
-	Auth     map[string]interface{} `yaml:"auth,omitempty"`
-	Insecure bool                   `yaml:"insecure,omitempty"`
-	Debug    bool                   `yaml:"debug,omitempty"`
-	Output   string                 `yaml:"output,omitempty"`
+	Name         string                 `yaml:"name"`
+	Organization string                 `yaml:"organization,omitempty"`
+	Tenant       string                 `yaml:"tenant,omitempty"`
+	Uri          urlYaml                `yaml:"uri,omitempty"`
+	Path         map[string]string      `yaml:"path,omitempty"`
+	Query        map[string]string      `yaml:"query,omitempty"`
+	Header       map[string]string      `yaml:"header,omitempty"`
+	Auth         map[string]interface{} `yaml:"auth,omitempty"`
+	Insecure     bool                   `yaml:"insecure,omitempty"`
+	Debug        bool                   `yaml:"debug,omitempty"`
+	Output       string                 `yaml:"output,omitempty"`
 }

--- a/executor/execution_context.go
+++ b/executor/execution_context.go
@@ -8,36 +8,32 @@ import (
 )
 
 type ExecutionContext struct {
-	Method           string
-	BaseUri          url.URL
-	Route            string
-	ContentType      string
-	Input            *FileReference
-	PathParameters   []ExecutionParameter
-	QueryParameters  []ExecutionParameter
-	HeaderParameters []ExecutionParameter
-	BodyParameters   []ExecutionParameter
-	FormParameters   []ExecutionParameter
-	AuthConfig       config.AuthConfig
-	Insecure         bool
-	Debug            bool
-	Plugin           plugin.CommandPlugin
+	Organization string
+	Tenant       string
+	Method       string
+	BaseUri      url.URL
+	Route        string
+	ContentType  string
+	Input        *FileReference
+	Parameters   ExecutionContextParameters
+	AuthConfig   config.AuthConfig
+	Insecure     bool
+	Debug        bool
+	Plugin       plugin.CommandPlugin
 }
 
 func NewExecutionContext(
+	organization string,
+	tenant string,
 	method string,
 	uri url.URL,
 	route string,
 	contentType string,
 	input *FileReference,
-	pathParameters []ExecutionParameter,
-	queryParameters []ExecutionParameter,
-	headerParameters []ExecutionParameter,
-	bodyParameters []ExecutionParameter,
-	formParameters []ExecutionParameter,
+	parameters ExecutionContextParameters,
 	authConfig config.AuthConfig,
 	insecure bool,
 	debug bool,
 	plugin plugin.CommandPlugin) *ExecutionContext {
-	return &ExecutionContext{method, uri, route, contentType, input, pathParameters, queryParameters, headerParameters, bodyParameters, formParameters, authConfig, insecure, debug, plugin}
+	return &ExecutionContext{organization, tenant, method, uri, route, contentType, input, parameters, authConfig, insecure, debug, plugin}
 }

--- a/executor/execution_context_parameters.go
+++ b/executor/execution_context_parameters.go
@@ -1,0 +1,18 @@
+package executor
+
+type ExecutionContextParameters struct {
+	Path   []ExecutionParameter
+	Query  []ExecutionParameter
+	Header []ExecutionParameter
+	Body   []ExecutionParameter
+	Form   []ExecutionParameter
+}
+
+func NewExecutionContextParameters(
+	path []ExecutionParameter,
+	query []ExecutionParameter,
+	header []ExecutionParameter,
+	body []ExecutionParameter,
+	form []ExecutionParameter) *ExecutionContextParameters {
+	return &ExecutionContextParameters{path, query, header, body, form}
+}

--- a/executor/plugin_executor.go
+++ b/executor/plugin_executor.go
@@ -45,11 +45,11 @@ func (e PluginExecutor) convertToPluginParameters(parameters []ExecutionParamete
 }
 
 func (e PluginExecutor) pluginParameters(context ExecutionContext) []plugin.ExecutionParameter {
-	params := context.PathParameters
-	params = append(params, context.QueryParameters...)
-	params = append(params, context.HeaderParameters...)
-	params = append(params, context.BodyParameters...)
-	params = append(params, context.FormParameters...)
+	params := context.Parameters.Path
+	params = append(params, context.Parameters.Query...)
+	params = append(params, context.Parameters.Header...)
+	params = append(params, context.Parameters.Body...)
+	params = append(params, context.Parameters.Form...)
 	return e.convertToPluginParameters(params)
 }
 
@@ -72,6 +72,8 @@ func (e PluginExecutor) Call(context ExecutionContext, writer output.OutputWrite
 	pluginAuth := e.pluginAuth(auth)
 	pluginParams := e.pluginParameters(context)
 	pluginContext := plugin.NewExecutionContext(
+		context.Organization,
+		context.Tenant,
 		context.BaseUri,
 		pluginAuth,
 		pluginInput,

--- a/main_test.go
+++ b/main_test.go
@@ -81,9 +81,8 @@ func TestMainCallsService(t *testing.T) {
 profiles:
 - name: default
   uri: `+srv.URL+`
-  path:
-    organization: my-org
-    tenant: defaulttenant
+  organization: my-org
+  tenant: defaulttenant
   auth:
     clientId: 71b784bc-3f7b-4e5a-a731-db25bb829025
     clientSecret: NGI&4b(chsHcsX^C

--- a/plugin/execution_context.go
+++ b/plugin/execution_context.go
@@ -3,20 +3,24 @@ package plugin
 import "net/url"
 
 type ExecutionContext struct {
-	BaseUri    url.URL
-	Auth       AuthResult
-	Input      *FileParameter
-	Parameters []ExecutionParameter
-	Insecure   bool
-	Debug      bool
+	Organization string
+	Tenant       string
+	BaseUri      url.URL
+	Auth         AuthResult
+	Input        *FileParameter
+	Parameters   []ExecutionParameter
+	Insecure     bool
+	Debug        bool
 }
 
 func NewExecutionContext(
+	organization string,
+	tenant string,
 	baseUri url.URL,
 	auth AuthResult,
 	input *FileParameter,
 	parameters []ExecutionParameter,
 	insecure bool,
 	debug bool) *ExecutionContext {
-	return &ExecutionContext{baseUri, auth, input, parameters, insecure, debug}
+	return &ExecutionContext{organization, tenant, baseUri, auth, input, parameters, insecure, debug}
 }

--- a/plugin/orchestrator/download_command.go
+++ b/plugin/orchestrator/download_command.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/tls"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -109,13 +110,11 @@ func (c DownloadCommand) getReadUrl(context plugin.ExecutionContext, writer outp
 }
 
 func (c DownloadCommand) createReadUrlRequest(context plugin.ExecutionContext, requestError chan error) (*http.Request, error) {
-	org, err := c.getStringParameter("organization", context.Parameters)
-	if err != nil {
-		return nil, err
+	if context.Organization == "" {
+		return nil, errors.New("Organization is not set")
 	}
-	tenant, err := c.getStringParameter("tenant", context.Parameters)
-	if err != nil {
-		return nil, err
+	if context.Tenant == "" {
+		return nil, errors.New("Tenant is not set")
 	}
 	folderId, err := c.getIntParameter("folder-id", context.Parameters)
 	if err != nil {
@@ -130,7 +129,7 @@ func (c DownloadCommand) createReadUrlRequest(context plugin.ExecutionContext, r
 		return nil, err
 	}
 
-	uri := c.formatUri(context.BaseUri, org, tenant) + fmt.Sprintf("/odata/Buckets(%d)/UiPath.Server.Configuration.OData.GetReadUri?path=%s", bucketId, path)
+	uri := c.formatUri(context.BaseUri, context.Organization, context.Tenant) + fmt.Sprintf("/odata/Buckets(%d)/UiPath.Server.Configuration.OData.GetReadUri?path=%s", bucketId, path)
 	request, err := http.NewRequest("GET", uri, &bytes.Buffer{})
 	if err != nil {
 		return nil, err

--- a/plugin/orchestrator/upload_command.go
+++ b/plugin/orchestrator/upload_command.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/tls"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -153,13 +154,11 @@ func (c UploadCommand) getWriteUrl(context plugin.ExecutionContext, writer outpu
 }
 
 func (c UploadCommand) createWriteUrlRequest(context plugin.ExecutionContext, requestError chan error) (*http.Request, error) {
-	org, err := c.getStringParameter("organization", context.Parameters)
-	if err != nil {
-		return nil, err
+	if context.Organization == "" {
+		return nil, errors.New("Organization is not set")
 	}
-	tenant, err := c.getStringParameter("tenant", context.Parameters)
-	if err != nil {
-		return nil, err
+	if context.Tenant == "" {
+		return nil, errors.New("Tenant is not set")
 	}
 	folderId, err := c.getIntParameter("folder-id", context.Parameters)
 	if err != nil {
@@ -174,7 +173,7 @@ func (c UploadCommand) createWriteUrlRequest(context plugin.ExecutionContext, re
 		return nil, err
 	}
 
-	uri := c.formatUri(context.BaseUri, org, tenant) + fmt.Sprintf("/odata/Buckets(%d)/UiPath.Server.Configuration.OData.GetWriteUri?path=%s", bucketId, path)
+	uri := c.formatUri(context.BaseUri, context.Organization, context.Tenant) + fmt.Sprintf("/odata/Buckets(%d)/UiPath.Server.Configuration.OData.GetWriteUri?path=%s", bucketId, path)
 	request, err := http.NewRequest("GET", uri, &bytes.Buffer{})
 	if err != nil {
 		return nil, err

--- a/test/config_test.go
+++ b/test/config_test.go
@@ -5,6 +5,106 @@ import (
 	"testing"
 )
 
+func TestOrganizationConfig(t *testing.T) {
+	config := `
+profiles:
+  - name: default
+    organization: my-org
+`
+	definition := `
+paths:
+  "{organization}/ping":
+    get:
+      operationId: ping
+`
+	context := NewContextBuilder().
+		WithDefinition("myservice", definition).
+		WithConfig(config).
+		WithResponse(200, "").
+		Build()
+
+	result := runCli([]string{"myservice", "ping"}, context)
+
+	if result.RequestUrl != "/my-org/ping" {
+		t.Errorf("Did not set organization from config, got: %v", result.RequestUrl)
+	}
+}
+
+func TestMissingOrganizationConfigShowsError(t *testing.T) {
+	config := `
+profiles:
+  - name: default
+`
+	definition := `
+paths:
+  "{organization}/ping":
+    get:
+      operationId: ping
+`
+	context := NewContextBuilder().
+		WithDefinition("myservice", definition).
+		WithConfig(config).
+		WithResponse(200, "").
+		Build()
+
+	result := runCli([]string{"myservice", "ping"}, context)
+
+	if !strings.HasPrefix(result.StdErr, "Missing organization parameter!") {
+		t.Errorf("Did not show organization configuration error, got: %v", result.StdErr)
+	}
+}
+
+func TestTenantConfig(t *testing.T) {
+	config := `
+profiles:
+  - name: default
+    organization: my-org
+    tenant: my-tenant
+`
+	definition := `
+paths:
+  "{organization}/{tenant}/ping":
+    get:
+      operationId: ping
+`
+	context := NewContextBuilder().
+		WithDefinition("myservice", definition).
+		WithConfig(config).
+		WithResponse(200, "").
+		Build()
+
+	result := runCli([]string{"myservice", "ping"}, context)
+
+	if result.RequestUrl != "/my-org/my-tenant/ping" {
+		t.Errorf("Did not set tenant from config, got: %v", result.RequestUrl)
+	}
+}
+
+func TestMissingTenantConfigShowsError(t *testing.T) {
+	config := `
+profiles:
+  - name: default
+    organization: my-org
+`
+	definition := `
+paths:
+  "{organization}/{tenant}/ping":
+    get:
+      operationId: ping
+`
+	context := NewContextBuilder().
+		WithDefinition("myservice", definition).
+		WithConfig(config).
+		WithResponse(200, "").
+		Build()
+
+	result := runCli([]string{"myservice", "ping"}, context)
+
+	if !strings.HasPrefix(result.StdErr, "Missing tenant parameter!") {
+		t.Errorf("Did not show tenant configuration error, got: %v", result.StdErr)
+	}
+}
+
 func TestPathConfig(t *testing.T) {
 	config := `
 profiles:

--- a/test/config_update_test.go
+++ b/test/config_update_test.go
@@ -47,9 +47,8 @@ func TestConfiguresCredentialsAuth(t *testing.T) {
 	}
 	expectedConfig := `profiles:
 - name: default
-  path:
-    organization: my-org
-    tenant: my-tenant
+  organization: my-org
+  tenant: my-tenant
   auth:
     clientId: client-id
     clientSecret: client-secret
@@ -77,9 +76,8 @@ func TestConfiguresLoginAuth(t *testing.T) {
 	}
 	expectedConfig := `profiles:
 - name: default
-  path:
-    organization: my-org
-    tenant: my-tenant
+  organization: my-org
+  tenant: my-tenant
   auth:
     clientId: ffe5141f-60fc-4fb9-8717-3969f303aedf
     redirectUri: http://localhost:27100
@@ -108,9 +106,8 @@ func TestConfiguresPatAuth(t *testing.T) {
 	}
 	expectedConfig := `profiles:
 - name: default
-  path:
-    organization: my-org
-    tenant: my-tenant
+  organization: my-org
+  tenant: my-tenant
   auth:
     pat: rt_mypersonalaccesstoken
 `
@@ -144,9 +141,8 @@ profiles:
 	}
 	expectedConfig := `profiles:
 - name: default
-  path:
-    organization: my-org
-    tenant: my-tenant
+  organization: my-org
+  tenant: my-tenant
   header:
     x-uipath-test: abc
   auth:
@@ -162,9 +158,8 @@ func TestReconfiguresPatAuth(t *testing.T) {
 	config := `
 profiles:
 - name: default
-  path:
-    organization: my-org
-    tenant: my-tenant
+  organization: my-org
+  tenant: my-tenant
   auth:
     pat: rt_mypersonalaccesstoken
 `
@@ -185,9 +180,8 @@ profiles:
 	}
 	expectedConfig := `profiles:
 - name: default
-  path:
-    organization: my-updated-org
-    tenant: my-updated-tenant
+  organization: my-updated-org
+  tenant: my-updated-tenant
   auth:
     pat: updated-token
 `
@@ -201,9 +195,8 @@ func TestReconfiguresPatAuthPartially(t *testing.T) {
 	config := `
 profiles:
 - name: default
-  path:
-    organization: my-org
-    tenant: my-tenant
+  organization: my-org
+  tenant: my-tenant
   auth:
     pat: rt_mypersonalaccesstoken
 `
@@ -224,9 +217,8 @@ profiles:
 	}
 	expectedConfig := `profiles:
 - name: default
-  path:
-    organization: my-updated-org
-    tenant: my-tenant
+  organization: my-updated-org
+  tenant: my-tenant
   auth:
     pat: rt_mypersonalaccesstoken
 `
@@ -263,9 +255,8 @@ profiles:
   header:
     x-uipath-test: abc
 - name: pat
-  path:
-    organization: my-org
-    tenant: my-tenant
+  organization: my-org
+  tenant: my-tenant
   auth:
     pat: rt_mypersonalaccesstoken
 `
@@ -282,8 +273,7 @@ profiles:
   header:
     x-uipath-test: abc
 - name: pat
-  path:
-    organization: my-org
+  organization: my-org
   auth:
     pat: rt_mypersonalaccesstoken
 `
@@ -307,8 +297,7 @@ profiles:
   header:
     x-uipath-test: abc
 - name: pat
-  path:
-    organization: my-org
+  organization: my-org
   auth:
     pat: my-new-token
 `
@@ -337,9 +326,8 @@ func TestCredentialsAuthMasksSecrets(t *testing.T) {
 	config := `
 profiles:
 - name: default
-  path:
-    organization: my-org
-    tenant: my-tenant
+  organization: my-org
+  tenant: my-tenant
   auth:
     clientId: 433d7778-8440-4e74-81f0-d88351bde871
     clientSecret: UaX#Fen)8mvifo
@@ -366,9 +354,8 @@ func TestCredentialsAuthMasksShortSecretsCompletely(t *testing.T) {
 	config := `
 profiles:
 - name: default
-  path:
-    organization: my-org
-    tenant: my-tenant
+  organization: my-org
+  tenant: my-tenant
   auth:
     clientId: very
     clientSecret: short
@@ -395,9 +382,8 @@ func TestPatAuthMasksSecrets(t *testing.T) {
 	config := `
 profiles:
 - name: default
-  path:
-    organization: my-org
-    tenant: my-tenant
+  organization: my-org
+  tenant: my-tenant
   auth:
     pat: f73b2edb-b37b-4426-8cc8-e7f98b09a827
 `
@@ -423,9 +409,8 @@ func TestLoginAuthMasksSecrets(t *testing.T) {
 	config := `
 profiles:
 - name: default
-  path:
-    organization: my-org
-    tenant: my-tenant
+  organization: my-org
+  tenant: my-tenant
   auth:
     clientId: 891979c1-68e2-46bb-9016-e5f2241fdd35
     redirectUri: http://localhost:27100

--- a/test/plugin_digitizer_test.go
+++ b/test/plugin_digitizer_test.go
@@ -74,9 +74,8 @@ paths:
 func TestDigitizeFileDoesNotExistShowsValidationError(t *testing.T) {
 	config := `profiles:
 - name: default
-  path:
-    organization: my-org
-    tenant: my-tenant
+  organization: my-org
+  tenant: my-tenant
 `
 
 	definition := `
@@ -114,7 +113,7 @@ paths:
 
 	result := runCli([]string{"du", "digitization", "digitize", "--file", "hello-world"}, context)
 
-	if !strings.Contains(result.StdErr, "Could not find 'organization' parameter") {
+	if !strings.Contains(result.StdErr, "Organization is not set") {
 		t.Errorf("Expected stderr to show that organization parameter is missing, but got: %v", result.StdErr)
 	}
 }
@@ -125,9 +124,8 @@ func TestDigitizeWithFailedResponseReturnsError(t *testing.T) {
 
 	config := `profiles:
 - name: default
-  path:
-    organization: my-org
-    tenant: my-tenant
+  organization: my-org
+  tenant: my-tenant
 `
 
 	definition := `
@@ -157,9 +155,8 @@ func TestDigitizeSuccessfully(t *testing.T) {
 
 	config := `profiles:
 - name: default
-  path:
-    organization: my-org
-    tenant: my-tenant
+  organization: my-org
+  tenant: my-tenant
 `
 
 	definition := `
@@ -204,9 +201,8 @@ func TestDigitizeSuccessfullyWithDebugFlag(t *testing.T) {
 
 	config := `profiles:
 - name: default
-  path:
-    organization: my-org
-    tenant: my-tenant
+  organization: my-org
+  tenant: my-tenant
 `
 
 	definition := `
@@ -237,9 +233,8 @@ paths:
 func TestDigitizeSuccessfullyWithStdIn(t *testing.T) {
 	config := `profiles:
 - name: default
-  path:
-    organization: my-org
-    tenant: my-tenant
+  organization: my-org
+  tenant: my-tenant
 `
 
 	definition := `

--- a/test/plugin_orchestrator_test.go
+++ b/test/plugin_orchestrator_test.go
@@ -66,9 +66,8 @@ func TestUploadWithoutFileParameterShowsValidationError(t *testing.T) {
 func TestUploadFileDoesNotExistShowsValidationError(t *testing.T) {
 	config := `profiles:
 - name: default
-  path:
-    organization: my-org
-    tenant: my-tenant
+  organization: my-org
+  tenant: my-tenant
 `
 
 	context := NewContextBuilder().
@@ -93,7 +92,7 @@ func TestUploadWithoutOrganizationShowsValidationError(t *testing.T) {
 
 	result := runCli([]string{"orchestrator", "buckets", "upload", "--folder-id", "1", "--key", "2", "--path", "file.txt", "--file", "hello-world"}, context)
 
-	if !strings.Contains(result.StdErr, "Could not find 'organization' parameter") {
+	if !strings.Contains(result.StdErr, "Organization is not set") {
 		t.Errorf("Expected stderr to show that organization parameter is missing, but got: %v", result.StdErr)
 	}
 }
@@ -104,9 +103,8 @@ func TestUploadWithFailedResponseReturnsError(t *testing.T) {
 
 	config := `profiles:
 - name: default
-  path:
-    organization: my-org
-    tenant: my-tenant
+  organization: my-org
+  tenant: my-tenant
 `
 
 	context := NewContextBuilder().
@@ -151,9 +149,8 @@ func TestUploadSuccessfully(t *testing.T) {
 
 	config := `profiles:
 - name: default
-  path:
-    organization: my-org
-    tenant: my-tenant
+  organization: my-org
+  tenant: my-tenant
 `
 
 	definition := `
@@ -233,7 +230,7 @@ func TestDownloadWithoutOrganizationShowsValidationError(t *testing.T) {
 
 	result := runCli([]string{"orchestrator", "buckets", "download", "--folder-id", "1", "--key", "2", "--path", "file.txt"}, context)
 
-	if !strings.Contains(result.StdErr, "Could not find 'organization' parameter") {
+	if !strings.Contains(result.StdErr, "Organization is not set") {
 		t.Errorf("Expected stderr to show that organization parameter is missing, but got: %v", result.StdErr)
 	}
 }
@@ -241,9 +238,8 @@ func TestDownloadWithoutOrganizationShowsValidationError(t *testing.T) {
 func TestDownloadWithFailedResponseReturnsError(t *testing.T) {
 	config := `profiles:
 - name: default
-  path:
-    organization: my-org
-    tenant: my-tenant
+  organization: my-org
+  tenant: my-tenant
 `
 
 	context := NewContextBuilder().
@@ -274,9 +270,8 @@ func TestDownloadSuccessfully(t *testing.T) {
 
 	config := `profiles:
 - name: default
-  path:
-    organization: my-org
-    tenant: my-tenant
+  organization: my-org
+  tenant: my-tenant
 `
 
 	definition := `


### PR DESCRIPTION
- Add validation to make sure the CLI has been properly configured

- Show detailed error message when CLI is not configured to help users getting started

- Refactored the code base to make organization and tenant a first class configuration value

You can now configure profiles with an organization and tenant key on the root in the profile yaml.

```
profiles:
- name: default
  organization: uipatcleitzc
  tenant: defaulttenant
```