### PR TITLE
Rename uipathcli to uipath

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
+uipath
 uipathcli
 *.exe
-*.osx
 build/
 coverage.out
 coverage.html

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,16 +40,16 @@ You need the [Go Compiler](https://go.dev/dl/) toolchain to build this project. 
 
 ### Windows
 ```powershell
-go build .
+go build -o uipath.exe
 
-.\uipathcli.exe --help
+.\uipath.exe --help
 ```
 
 ### Linux
 ```bash
-go build .
+go build -o uipath
 
-./uipathcli --help
+./uipath --help
 ```
 
 ### Test
@@ -77,10 +77,10 @@ Here are a few things you can do to make code reviews go as smooth as possible:
 
 ### How to integrate my service with the CLI?
 
-If you just want to try out a service, you can copy the OpenAPI specfication in the `definition/` folder next to the `uipathcli` executable. The CLI automatically picks up all the OpenAPI definitions and shows them as top-level commands. The file name of the definition will be the command name. You can see all installed definitions by running:
+If you just want to try out a service, you can copy the OpenAPI specfication in the `definition/` folder next to the `uipath` executable. The CLI automatically picks up all the OpenAPI definitions and shows them as top-level commands. The file name of the definition will be the command name. You can see all installed definitions by running:
 
 ```bash
-uipathcli --help
+uipath --help
 ```
 
 If you would like to publish your service definition bundled together with the CLI, you can simply copy it in the [definitions](definitions) folder of this repository and create a PR with your change.
@@ -94,25 +94,23 @@ You can also cross-compile the CLI using the PowerShell script (`build.ps1`) on 
 .\build.ps1
 
 # Generates
-# - build/uipathcli        for Linux
-# - build/uipathcli.exe    for Windows
-# - build/uipathcli.osx    for MacOS
+# - build/uipath-linux-amd64          for Linux   (x86-64)
+# - build/uipath-windows-amd64.exe    for Windows (x86-64)
+# - build/uipath-darwin-amd64         for MacOS   (x86-64)
+# - build/uipath-linux-arm64          for Linux   (ARM)
+# - build/uipath-windows-arm64.exe    for Windows (ARM)
+# - build/uipath-darwin-arm64         for MacOS   (ARM)
 
 # Run the CLI (on windows)
-.\build\uipathcli.exe --help
+.\build\uipath-windows-amd64.exe --help
 ```
 
 ```bash
 # Cross-compile the CLI on Linux for all supported platforms
 ./build.sh
 
-# Generates
-# - build/uipathcli        for Linux
-# - build/uipathcli.exe    for Windows
-# - build/uipathcli.osx    for MacOS
-
 # Run the CLI (on linux)
-./build/uipathcli --help
+./build/uipath-linux-amd64 --help
 ```
 
 ### How to generate code coverage?
@@ -130,7 +128,7 @@ go tool cover --html=coverage.out
 The CLI supports a pluggable infrastructure which allows you to implement complex custom commands. The [`DigitizeCommand`](plugin/digitizer/digitize_command.go) is an example for a custom command which abstracts away the complexity of the async digitization API. The digitizer API requires you to upload a file, followed by polling the status API until the digitization finished in order to retrieve the digitization result. The `DigitizeCommand` allows the user to just invoke one command for uploading the file and retrieving the result:
 
 ```bash
-uipathcli digitizer digitize --file documents/invoice.pdf
+uipath digitizer digitize --file documents/invoice.pdf
 ```
 
 returns
@@ -182,7 +180,7 @@ func (c CreateCommand) Command() plugin.Command {
 
 3. Implement `Execute(...)` function which performs the operation of the command. The `context` parameters gives you all the input provided by the user and `writer` can be used to write information on standard output and `logger` for debug output.
 
-4. Register the command with the `uipathcli` in [`main.go`](main.go)
+4. Register the command with the `uipath` CLI in [`main.go`](main.go)
 
 ```go
 cli := commandline.Cli{
@@ -195,9 +193,9 @@ cli := commandline.Cli{
 4. You can call your new command:
 
 ```bash
-uipathcli myservice create-product --id "1" --name "tv" --description "40 inch Smart TV"
+uipath myservice create-product --id "1" --name "tv" --description "40 inch Smart TV"
 
-uipathcli myservice create-product --id "2" --name "table"
+uipath myservice create-product --id "2" --name "table"
 ```
 
 **Hide existing command**
@@ -220,7 +218,7 @@ func (c StatusCommand) Execute(context plugin.ExecutionContext, writer output.Ou
 }
 ```
 
-2. Register the command with the `uipathcli` in [`main.go`](main.go)
+2. Register the command with the `uipath` CLI in [`main.go`](main.go)
 
 ```go
 cli := commandline.Cli{

--- a/README.md
+++ b/README.md
@@ -62,18 +62,18 @@ curl --silent "https://du-nst-cdn.azureedge.net/uipathcli/uipathcli-darwin-arm64
   <summary>Enable command completion</summary>
   <p>
 
-For autocompletion to work, the `uipathcli` executable needs to be in your PATH. Make sure the following commands output the path to the `uipathcli` executable:
+For autocompletion to work, the `uipath` executable needs to be in your PATH. Make sure the following commands output the path to the `uipath` executable:
 
 ### PowerShell
 
 ```powershell
-(Get-Command uipathcli).Path
+(Get-Command uipath).Path
 ```
 
 ### Bash
 
 ```bash
-which uipathcli
+which uipath
 ```
 
 You can enable autocompletion by running the following commands depending on which shell you are using:
@@ -81,13 +81,13 @@ You can enable autocompletion by running the following commands depending on whi
 ### PowerShell
 
 ```powershell
-uipathcli autocomplete enable --shell "powershell"
+uipath autocomplete enable --shell "powershell"
 ```
 
 ### Bash
 
 ```bash
-uipathcli autocomplete enable --shell "bash"
+uipath autocomplete enable --shell "bash"
 ```
 
   </p>
@@ -95,10 +95,10 @@ uipathcli autocomplete enable --shell "bash"
 
 <br />
 
-After installing the `uipathcli` executable, you can run the interactive config command to finish setting up your CLI:
+After installing the `uipath` executable, you can run the interactive config command to finish setting up your CLI:
 
 ```
-uipathcli config
+uipath config
 ```
 
 More details about how to configure the CLI can be found in the following sections.
@@ -133,7 +133,7 @@ In order to use client credentials, you need to set up an [External Application 
 5. Run the interactive CLI configuration:
 
 ```bash
-uipathcli config
+uipath config
 ```
 
 The CLI will ask you to enter the main config settings like
@@ -145,13 +145,13 @@ Enter client id [*******9026]: <your-client-id>
 Enter client secret [*******pcnN]: <your-client-secret>
 Enter organization [not set]: uipatcleitzc
 Enter tenant [not set]: DefaultTenant
-Successfully configured uipathcli
+Successfully configured uipath CLI
 ```
 
 After that the CLI should be ready and you can validate that it is working by invoking one of the services:
 
 ```bash
-uipathcli du metering ping
+uipath du metering ping
 ```
 
 Response:
@@ -186,7 +186,7 @@ In order to use oauth login, you need to set up an [External Application (Non-Co
 5. Run the interactive CLI configuration:
 
 ```bash
-uipathcli config --auth login
+uipath config --auth login
 ```
 
 The CLI will ask you to enter the main config settings like
@@ -199,13 +199,13 @@ Enter redirect uri [not set]: http://localhost:12700
 Enter scopes [not set]: OR.Users
 Enter organization [not set]: uipatcleitzc
 Enter tenant [not set]: DefaultTenant
-Successfully configured uipathcli
+Successfully configured uipath CLI
 ```
 
 5. After that the CLI should be ready and you can validate that it is working by invoking one of the services:
 
 ```bash
-uipathcli orchestrator Users_Get
+uipath orchestrator Users_Get
 ```
 
 ### Personal Access Token
@@ -226,7 +226,7 @@ You need to generate a personal access token (PAT) and configure the CLI to use 
 4. Run the interactive CLI configuration:
 
 ```bash
-uipathcli config -- auth pat
+uipath config -- auth pat
 ```
 
 The CLI will ask you to enter the main config settings like
@@ -237,17 +237,17 @@ The CLI will ask you to enter the main config settings like
 Enter personal access token [*******9026]: <your-pat>
 Enter organization [not set]: uipatcleitzc
 Enter tenant [not set]: DefaultTenant
-Successfully configured uipathcli
+Successfully configured uipath CLI
 ```
 
 After that the CLI should be ready and you can validate that it is working by invoking one of the services.
 
 ### Configuration File
 
-You can also manually create or edit the configuration file `.uipathcli/config` in your home directory. The following config file sets up the default profile with clientId, clientSecret so that the CLI can generate a bearer token before calling any of the services. It also sets the organization and tenant for services which require it.
+You can also manually create or edit the configuration file `.uipath/config` in your home directory. The following config file sets up the default profile with clientId, clientSecret so that the CLI can generate a bearer token before calling any of the services. It also sets the organization and tenant for services which require it.
 
 ```bash
-cat <<EOT > $HOME/.uipathcli/config
+cat <<EOT > $HOME/.uipath/config
 ---
 profiles:
   - name: default
@@ -262,7 +262,7 @@ EOT
 Once you have created the configuration file with the proper secrets, org and tenant information, you should be able to successfully call the services, e.g.
 
 ```bash
-uipathcli du metering ping
+uipath du metering ping
 ```
 
 ## Commands and arguments
@@ -270,7 +270,7 @@ uipathcli du metering ping
 CLI commands consist of three main parts:
 
 ```bash
-uipathcli <service-name> <operation-name> <arguments>
+uipath <service-name> <operation-name> <arguments>
 ```
 
 - `<service-name>`: The CLI discovers the existing OpenAPI specifications and shows each of them as a separate service
@@ -280,7 +280,7 @@ uipathcli <service-name> <operation-name> <arguments>
 Example:
 
 ```bash
-uipathcli du metering validate --product-name "DU" --model-name "my-model"
+uipath du metering validate --product-name "DU" --model-name "my-model"
 ```
 
 ### Basic arguments
@@ -288,7 +288,7 @@ uipathcli du metering validate --product-name "DU" --model-name "my-model"
 The CLI supports string, integer, floating point and boolean arguments. The arguments are automatically converted to the type defined in the OpenAPI specification:
 
 ```bash
-uipathcli product create --name "new-product" --stock "5" --price "1.4" --deleted "false"
+uipath product create --name "new-product" --stock "5" --price "1.4" --deleted "false"
 ```
 
 ### Array arguments
@@ -296,7 +296,7 @@ uipathcli product create --name "new-product" --stock "5" --price "1.4" --delete
 Array arguments can be passed as comma-separated strings and are automatically converted to arrays in the JSON body. The CLI supports string, integer, floating point, boolean and object arrays.
 
 ```bash
-uipathcli product list --name-filter "my-product,new-product"
+uipath product list --name-filter "my-product,new-product"
 ```
 
 ### Nested Object arguments
@@ -304,7 +304,7 @@ uipathcli product list --name-filter "my-product,new-product"
 More complex nested objects can be passed as semi-colon separated list of property assigments:
 
 ```bash
-uipathcli product create --product "name=my-product;price.value=340;price.sale.discount=10;price.sale.value=306"
+uipath product create --product "name=my-product;price.value=340;price.sale.discount=10;price.sale.value=306"
 ```
 
 The command creates the following JSON body in the HTTP request:
@@ -328,7 +328,7 @@ The command creates the following JSON body in the HTTP request:
 CLI arguments can also refer to files on disk. This command reads the invoice from `/documents/invoice.pdf` and uploads it to the digitize endpoint:
 
 ```bash
-uipathcli digitizer digitize ---file documents/invoice.pdf
+uipath digitizer digitize ---file documents/invoice.pdf
 ```
 
 ## Standard input (stdin) / Pipes
@@ -336,7 +336,7 @@ uipathcli digitizer digitize ---file documents/invoice.pdf
 You can pipe JSON into the CLI as stdin and it will be used as the request body instead of CLI parameters. The following example reads an orchestrator setting, modifies the value using `jq` and pipes the output back into to the CLI to update it:
 
 ```bash
-uipathcli orchestrator settings-get | jq '.value[] | select(.Id == "Alerts.Email.Enabled") | .Value = "FALSE"' | uipathcli orchestrator settings-putbyid
+uipath orchestrator settings-get | jq '.value[] | select(.Id == "Alerts.Email.Enabled") | .Value = "FALSE"' | uipath orchestrator settings-putbyid
 ```
 
 ## Output formats
@@ -350,13 +350,13 @@ The CLI supports multiple output formats:
 In order to switch to text output, you can either set the environment variable `UIPATH_OUTPUT` to `text`, change the setting in your profile or pass it as an argument to the CLI:
 
 ```bash
-uipathcli du metering ping --output text
+uipath du metering ping --output text
 
 du-prod-du-we-g-dns westeurope  westeurope  2023-01-27T10:56:59.8477522Z  23.1-105-main.v3105ad
 ```
 
 ```bash
-uipathcli orchestrator users-get --query "value[].[Name, CreationTime]" --output text | while IFS=$'\t' read -r name creation_time; do
+uipath orchestrator users-get --query "value[].[Name, CreationTime]" --output text | while IFS=$'\t' read -r name creation_time; do
     echo "User ${name} was created at ${creation_time}"
 done
 
@@ -372,7 +372,7 @@ Examples:
 
 ```bash
 # Select only the name of all returned users
-uipathcli orchestrator users-get --query "value[].Name"
+uipath orchestrator users-get --query "value[].Name"
 
 [
   "Administrator",
@@ -383,7 +383,7 @@ uipathcli orchestrator users-get --query "value[].Name"
 
 ```bash
 # Select the first user with the name "Administrator"
-uipathcli orchestrator users-get --query "value[?Name == 'Administrator'] | [0]"
+uipath orchestrator users-get --query "value[?Name == 'Administrator'] | [0]"
 
 {
   "Id": 123456,
@@ -395,7 +395,7 @@ uipathcli orchestrator users-get --query "value[?Name == 'Administrator'] | [0]"
 
 ```bash
 # Sort the users by creation time and get the name of last created user
-uipathcli orchestrator users-get --query "sort_by(value, &CreationTime) | [-1].Name"
+uipath orchestrator users-get --query "sort_by(value, &CreationTime) | [-1].Name"
 
 "Automation Developer"
 ```
@@ -407,7 +407,7 @@ uipathcli orchestrator users-get --query "sort_by(value, &CreationTime) | [-1].N
 You can set the environment variable `UIPATH_DEBUG=true` or pass the parameter `--debug` in order to see detailed output of the request and response messages:
 
 ```bash
-uipathcli du metering ping --debug
+uipath du metering ping --debug
 ```
 
 ```bash
@@ -459,13 +459,13 @@ profiles:
 If you do not provide the `--profile` parameter, the `default` profile is automatically selected. Otherwise it will use the settings from the provided profile. The following command will send a request to the alpha.uipath.com environment:
 
 ```bash
-uipathcli du metering ping --profile alpha
+uipath du metering ping --profile alpha
 ```
 
 You can also change the profile using an environment variable (`UIPATH_PROFILE`):
 
 ```bash
-UIPATH_PROFILE=alpha uipathcli du metering ping
+UIPATH_PROFILE=alpha uipath du metering ping
 ```
 
 ## Global Arguments
@@ -503,7 +503,7 @@ profiles:
 And you simply call the CLI with the `--profile automationsuite` parameter:
 
 ```bash
-uipathcli du metering ping --profile automationsuite
+uipath du metering ping --profile automationsuite
 ```
 
 ### How to contribute?

--- a/auth/oauth_authenticator_html.go
+++ b/auth/oauth_authenticator_html.go
@@ -58,7 +58,7 @@ const LOGGED_IN_PAGE_HTML = `
             </path>
           </svg>
         </div>
-        <div class="card">Successfully logged in, you can use the <code><b>uipathcli</b></code> now</div>
+        <div class="card">Successfully logged in, you can use the <code><b>uipath</b></code> CLI now</div>
       </div>
     </div>
   </body>

--- a/build.ps1
+++ b/build.ps1
@@ -4,21 +4,21 @@ Copy-Item definitions/* -Destination build/definitions/
 Copy-Item README.md -Destination build/README.md
 
 Write-Host "Building Linux (amd64) executable"
-pwsh -Command { $env:GOOS = "linux"; $env:GOARCH = "amd64"; go build -o build/uipathcli-linux-amd64 }
+pwsh -Command { $env:GOOS = "linux"; $env:GOARCH = "amd64"; go build -o build/uipath-linux-amd64 }
 
 Write-Host "Building Windows (amd64) executable"
-pwsh -Command { $env:GOOS = "windows"; $env:GOARCH = "amd64"; go build -o build/uipathcli-windows-amd64.exe }
+pwsh -Command { $env:GOOS = "windows"; $env:GOARCH = "amd64"; go build -o build/uipath-windows-amd64.exe }
 
 Write-Host "Building MacOS (amd64) executable"
-pwsh -Command { $env:GOOS = "darwin"; $env:GOARCH = "amd64"; go build -o build/uipathcli-darwin-amd64 }
+pwsh -Command { $env:GOOS = "darwin"; $env:GOARCH = "amd64"; go build -o build/uipath-darwin-amd64 }
 
 Write-Host "Building Linux (arm64) executable"
-pwsh -Command { $env:GOOS = "linux"; $env:GOARCH = "arm64"; go build -o build/uipathcli-linux-arm64 }
+pwsh -Command { $env:GOOS = "linux"; $env:GOARCH = "arm64"; go build -o build/uipath-linux-arm64 }
 
 Write-Host "Building Windows (arm64) executable"
-pwsh -Command { $env:GOOS = "windows"; $env:GOARCH = "arm64"; go build -o build/uipathcli-windows-arm64.exe }
+pwsh -Command { $env:GOOS = "windows"; $env:GOARCH = "arm64"; go build -o build/uipath-windows-arm64.exe }
 
 Write-Host "Building MacOS (arm64) executable"
-pwsh -Command { $env:GOOS = "darwin"; $env:GOARCH = "arm64"; go build -o build//uipathcli-darwin-arm64 }
+pwsh -Command { $env:GOOS = "darwin"; $env:GOARCH = "arm64"; go build -o build//uipath-darwin-arm64 }
 
 Write-Host "Successfully completed"

--- a/build.sh
+++ b/build.sh
@@ -7,21 +7,21 @@ cp definitions/* build/definitions/
 cp README.md build/README.md
 
 echo "Building Linux (amd64) executable"
-GOOS=linux GOARCH=amd64 go build -o build/uipathcli-linux-amd64
+GOOS=linux GOARCH=amd64 go build -o build/uipath-linux-amd64
 
 echo "Building Windows (amd64) executable"
-GOOS=windows GOARCH=amd64 go build -o build/uipathcli-windows-amd64.exe
+GOOS=windows GOARCH=amd64 go build -o build/uipath-windows-amd64.exe
 
 echo "Building MacOS (amd64) executable"
-GOOS=darwin GOARCH=amd64 go build -o build/uipathcli-darwin-amd64
+GOOS=darwin GOARCH=amd64 go build -o build/uipath-darwin-amd64
 
 echo "Building Linux (arm64) executable"
-GOOS=linux GOARCH=arm64 go build -o build/uipathcli-linux-arm64
+GOOS=linux GOARCH=arm64 go build -o build/uipath-linux-arm64
 
 echo "Building Windows (arm64) executable"
-GOOS=windows GOARCH=arm64 go build -o build/uipathcli-windows-arm64.exe
+GOOS=windows GOARCH=arm64 go build -o build/uipath-windows-arm64.exe
 
 echo "Building MacOS (arm64) executable"
-GOOS=darwin GOARCH=arm64 go build -o build/uipathcli-darwin-arm64
+GOOS=darwin GOARCH=arm64 go build -o build/uipath-darwin-arm64
 
 echo "Successfully completed"

--- a/cache/file_cache.go
+++ b/cache/file_cache.go
@@ -13,7 +13,7 @@ import (
 
 const cacheFilePermissions = 0600
 const cacheDirectoryPermissions = 0700
-const cacheDirectory = "uipathcli"
+const cacheDirectory = "uipath"
 const separator = "|"
 
 type FileCache struct{}

--- a/commandline/autocomplete_handler.go
+++ b/commandline/autocomplete_handler.go
@@ -16,10 +16,10 @@ const filePermissions = 0644
 const Powershell = "powershell"
 const Bash = "bash"
 
-const completeHandlerEnabledCheck = "uipathcli_auto_complete"
+const completeHandlerEnabledCheck = "uipath_auto_complete"
 
 const powershellCompleteHandler = `
-$uipathcli_auto_complete = {
+$uipath_auto_complete = {
     param($wordToComplete, $commandAst, $cursorPosition)
     $padLength = $cursorPosition - $commandAst.Extent.StartOffset
     $textToComplete = $commandAst.ToString().PadRight($padLength, ' ').Substring(0, $padLength)
@@ -28,11 +28,11 @@ $uipathcli_auto_complete = {
         [system.management.automation.completionresult]::new($_, $_, 'parametervalue', $_)
     }
 }
-Register-ArgumentCompleter -Native -CommandName uipathcli -ScriptBlock $uipathcli_auto_complete
+Register-ArgumentCompleter -Native -CommandName uipath -ScriptBlock $uipath_auto_complete
 `
 
 const bashCompleteHandler = `
-function _uipathcli_auto_complete()
+function _uipath_auto_complete()
 {
   local executable="${COMP_WORDS[0]}"
   local cur="${COMP_WORDS[COMP_CWORD]}" IFS=$'\n'
@@ -40,7 +40,7 @@ function _uipathcli_auto_complete()
   read -d '' -ra candidates < <($executable autocomplete complete --command "${COMP_LINE}" 2>/dev/null)
   read -d '' -ra COMPREPLY < <(compgen -W "${candidates[*]:-}" -- "$cur")
 }
-complete -f -F _uipathcli_auto_complete uipathcli
+complete -f -F _uipath_auto_complete uipath
 `
 
 type AutoCompleteHandler struct {
@@ -135,7 +135,7 @@ func (a AutoCompleteHandler) Find(commandText string, commands []*cli.Command, e
 	}
 
 	command := &cli.Command{
-		Name:        "uipathcli",
+		Name:        "uipath",
 		Subcommands: commands,
 	}
 

--- a/commandline/cli.go
+++ b/commandline/cli.go
@@ -43,9 +43,9 @@ func (c Cli) run(args []string, input []byte) error {
 	}
 
 	app := &cli.App{
-		Name:            "uipathcli",
+		Name:            "uipath",
 		Usage:           "Command-Line Interface for UiPath Services",
-		UsageText:       "uipathcli <service> <operation> --parameter",
+		UsageText:       "uipath <service> <operation> --parameter",
 		Version:         "1.0",
 		Flags:           flags,
 		Commands:        commands,

--- a/commandline/config_command_handler.go
+++ b/commandline/config_command_handler.go
@@ -17,7 +17,7 @@ type ConfigCommandHandler struct {
 
 const notSetMessage = "not set"
 const maskMessage = "*******"
-const successMessage = "Successfully configured uipathcli"
+const successMessage = "Successfully configured uipath CLI"
 
 const CredentialsAuth = "credentials"
 const LoginAuth = "login"

--- a/config/config_store.go
+++ b/config/config_store.go
@@ -57,6 +57,6 @@ func (s ConfigStore) configurationFilePath() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("Error reading configuration file: %v", err)
 	}
-	filename := filepath.Join(homeDir, ".uipathcli", "config")
+	filename := filepath.Join(homeDir, ".uipath", "config")
 	return filename, nil
 }

--- a/config/plugin_config_store.go
+++ b/config/plugin_config_store.go
@@ -31,6 +31,6 @@ func (s PluginConfigStore) pluginsFilePath() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("Error reading plugins file: %v", err)
 	}
-	filename := filepath.Join(homeDir, ".uipathcli", "plugins")
+	filename := filepath.Join(homeDir, ".uipath", "plugins")
 	return filename, nil
 }

--- a/executor/http_executor.go
+++ b/executor/http_executor.go
@@ -23,11 +23,11 @@ import (
 
 const NotConfiguredErrorTemplate = `Run config command to set organization and tenant:
 
-    uipathcli config
+    uipath config
 
 For more information you can view the help:
 
-    uipathcli config --help
+    uipath config --help
 `
 
 type HttpExecutor struct {

--- a/main.go
+++ b/main.go
@@ -57,7 +57,7 @@ func readStdIn() []byte {
 func main() {
 	configProvider := config.ConfigProvider{
 		ConfigStore: config.ConfigStore{
-			ConfigFile: os.Getenv("UIPATHCLI_CONFIGURATION_PATH"),
+			ConfigFile: os.Getenv("UIPATH_CONFIGURATION_PATH"),
 		},
 	}
 	err := configProvider.Load()
@@ -67,7 +67,7 @@ func main() {
 	}
 	pluginConfigProvider := config.PluginConfigProvider{
 		PluginConfigStore: config.PluginConfigStore{
-			PluginFile: os.Getenv("UIPATHCLI_PLUGINS_PATH"),
+			PluginFile: os.Getenv("UIPATH_PLUGINS_PATH"),
 		},
 	}
 	err = pluginConfigProvider.Load()
@@ -85,7 +85,7 @@ func main() {
 		ColoredOutput: colorsSupported(),
 		DefinitionProvider: commandline.DefinitionProvider{
 			DefinitionStore: commandline.DefinitionStore{
-				DefinitionDirectory: os.Getenv("UIPATHCLI_DEFINITIONS_PATH"),
+				DefinitionDirectory: os.Getenv("UIPATH_DEFINITIONS_PATH"),
 			},
 			Parser: parser.OpenApiParser{},
 			CommandPlugins: []plugin.CommandPlugin{

--- a/main_test.go
+++ b/main_test.go
@@ -18,13 +18,13 @@ func init() {
 }
 
 func TestMainReadsDefinitions(t *testing.T) {
-	config := createFile(t, ".uipathcli", "config")
+	config := createFile(t, ".uipath", "config")
 	definition := createFile(t, "definitions", "service-a.yaml")
 
-	t.Setenv("UIPATHCLI_CONFIGURATION_PATH", config)
-	t.Setenv("UIPATHCLI_DEFINITIONS_PATH", filepath.Dir(definition))
+	t.Setenv("UIPATH_CONFIGURATION_PATH", config)
+	t.Setenv("UIPATH_DEFINITIONS_PATH", filepath.Dir(definition))
 
-	os.Args = []string{"uipathcli", "--help"}
+	os.Args = []string{"uipath", "--help"}
 	output := captureOutput(t, func() {
 		main()
 	})
@@ -36,7 +36,7 @@ func TestMainReadsDefinitions(t *testing.T) {
 }
 
 func TestMainParsesDefinition(t *testing.T) {
-	config := createFile(t, ".uipathcli", "config")
+	config := createFile(t, ".uipath", "config")
 	definition := createFile(t, "definitions", "service-a.yaml")
 	os.WriteFile(definition, []byte(`
 paths:
@@ -46,10 +46,10 @@ paths:
       operationId: ping
 `), 0600)
 
-	t.Setenv("UIPATHCLI_CONFIGURATION_PATH", config)
-	t.Setenv("UIPATHCLI_DEFINITIONS_PATH", filepath.Dir(definition))
+	t.Setenv("UIPATH_CONFIGURATION_PATH", config)
+	t.Setenv("UIPATH_DEFINITIONS_PATH", filepath.Dir(definition))
 
-	os.Args = []string{"uipathcli", "service-a", "--help"}
+	os.Args = []string{"uipath", "service-a", "--help"}
 	output := captureOutput(t, func() {
 		main()
 	})
@@ -76,7 +76,7 @@ func TestMainCallsService(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	config := createFile(t, ".uipathcli", "config")
+	config := createFile(t, ".uipath", "config")
 	os.WriteFile(config, []byte(`
 profiles:
 - name: default
@@ -97,10 +97,10 @@ paths:
       operationId: ping
 `), 0600)
 
-	t.Setenv("UIPATHCLI_CONFIGURATION_PATH", config)
-	t.Setenv("UIPATHCLI_DEFINITIONS_PATH", filepath.Dir(definition))
+	t.Setenv("UIPATH_CONFIGURATION_PATH", config)
+	t.Setenv("UIPATH_DEFINITIONS_PATH", filepath.Dir(definition))
 
-	os.Args = []string{"uipathcli", "service-a", "ping"}
+	os.Args = []string{"uipath", "service-a", "ping"}
 	output := captureOutput(t, func() {
 		main()
 	})
@@ -114,7 +114,7 @@ paths:
 }
 
 func TestMainAutocompletesCommand(t *testing.T) {
-	config := createFile(t, ".uipathcli", "config")
+	config := createFile(t, ".uipath", "config")
 	definition := createFile(t, "definitions", "service-a.yaml")
 	os.WriteFile(definition, []byte(`
 paths:
@@ -124,10 +124,10 @@ paths:
       operationId: ping
 `), 0600)
 
-	t.Setenv("UIPATHCLI_CONFIGURATION_PATH", config)
-	t.Setenv("UIPATHCLI_DEFINITIONS_PATH", filepath.Dir(definition))
+	t.Setenv("UIPATH_CONFIGURATION_PATH", config)
+	t.Setenv("UIPATH_DEFINITIONS_PATH", filepath.Dir(definition))
 
-	os.Args = []string{"uipathcli", "autocomplete", "complete", "--command", "upathcli service-a p"}
+	os.Args = []string{"uipath", "autocomplete", "complete", "--command", "upathcli service-a p"}
 	output := captureOutput(t, func() {
 		main()
 	})
@@ -157,9 +157,9 @@ func TestMainParsesBuiltInDefinitions(t *testing.T) {
 
 func MainParsesBuiltInDefinitions(t *testing.T, command string, expected string) {
 	definitionDir, _ := os.Getwd()
-	t.Setenv("UIPATHCLI_DEFINITIONS_PATH", filepath.Join(definitionDir, "definitions/"))
+	t.Setenv("UIPATH_DEFINITIONS_PATH", filepath.Join(definitionDir, "definitions/"))
 
-	os.Args = strings.Split("uipathcli "+command, " ")
+	os.Args = strings.Split("uipath "+command, " ")
 	output := captureOutput(t, func() {
 		main()
 	})

--- a/package.sh
+++ b/package.sh
@@ -7,25 +7,24 @@ rm --force build/packages/*
 pushd build/ > /dev/null
 
 echo "Create Linux (amd64) Package"
-tar --create --gzip --overwrite --file=packages/uipathcli-linux-amd64.tar.gz --transform='flags=r;s|uipathcli-linux-amd64|uipathcli|' uipathcli-linux-amd64 definitions
+tar --create --gzip --overwrite --file=packages/uipathcli-linux-amd64.tar.gz --transform='flags=r;s|uipath-linux-amd64|uipath|' uipath-linux-amd64 definitions
 
 echo "Create Windows (amd64) Package"
-zip -q packages/uipathcli-windows-amd64.zip uipathcli-windows-amd64.exe definitions/*
-printf "@ uipathcli-windows-amd64.exe\n@=uipathcli.exe\n" | zipnote -w packages/uipathcli-windows-amd64.zip
+zip -q packages/uipathcli-windows-amd64.zip uipath-windows-amd64.exe definitions/*
+printf "@ uipath-windows-amd64.exe\n@=uipath.exe\n" | zipnote -w packages/uipathcli-windows-amd64.zip
 
 echo "Create MacOS (amd64) Package"
-tar --create --gzip --overwrite --file=packages/uipathcli-darwin-amd64.tar.gz --transform='flags=r;s|uipathcli-darwin-amd64|uipathcli|' uipathcli-darwin-amd64 definitions
+tar --create --gzip --overwrite --file=packages/uipathcli-darwin-amd64.tar.gz --transform='flags=r;s|uipath-darwin-amd64|uipath|' uipath-darwin-amd64 definitions
 
 echo "Create Linux (arm64) Package"
-tar --create --gzip --overwrite --file=packages/uipathcli-linux-arm64.tar.gz --transform='flags=r;s|uipathcli-linux-arm64|uipathcli|' uipathcli-linux-arm64 definitions
+tar --create --gzip --overwrite --file=packages/uipathcli-linux-arm64.tar.gz --transform='flags=r;s|uipath-linux-arm64|uipath|' uipath-linux-arm64 definitions
 
 echo "Create Windows (arm64) Package"
-zip -q packages/uipathcli-windows-arm64.zip uipathcli-windows-arm64.exe definitions/*
-printf "@ uipathcli-windows-arm64.exe\n@=uipathcli.exe\n" | zipnote -w packages/uipathcli-windows-arm64.zip
+zip -q packages/uipathcli-windows-arm64.zip uipath-windows-arm64.exe definitions/*
+printf "@ uipath-windows-arm64.exe\n@=uipath.exe\n" | zipnote -w packages/uipathcli-windows-arm64.zip
 
 echo "Create MacOS (arm64) Package"
-tar --create --gzip --overwrite --file=packages/uipathcli-darwin-arm64.tar.gz --transform='flags=r;s|uipathcli-darwin-arm64|uipathcli|' uipathcli-darwin-arm64 definitions
-
+tar --create --gzip --overwrite --file=packages/uipathcli-darwin-arm64.tar.gz --transform='flags=r;s|uipath-darwin-arm64|uipath|' uipath-darwin-arm64 definitions
 
 popd > /dev/null
 echo "Successfully created packages"

--- a/test/autocomplete_enable_test.go
+++ b/test/autocomplete_enable_test.go
@@ -49,7 +49,7 @@ func TestEnableAutocompletePowershellCreatesProfileFile(t *testing.T) {
 	content, _ := os.ReadFile(profilePath)
 
 	expectedFileContent := `
-$uipathcli_auto_complete = {
+$uipath_auto_complete = {
     param($wordToComplete, $commandAst, $cursorPosition)
     $padLength = $cursorPosition - $commandAst.Extent.StartOffset
     $textToComplete = $commandAst.ToString().PadRight($padLength, ' ').Substring(0, $padLength)
@@ -58,7 +58,7 @@ $uipathcli_auto_complete = {
         [system.management.automation.completionresult]::new($_, $_, 'parametervalue', $_)
     }
 }
-Register-ArgumentCompleter -Native -CommandName uipathcli -ScriptBlock $uipathcli_auto_complete
+Register-ArgumentCompleter -Native -CommandName uipath -ScriptBlock $uipath_auto_complete
 `
 	if string(content) != expectedFileContent {
 		t.Errorf("Should create profile file with correct content, got: %v", string(content))
@@ -79,7 +79,7 @@ func TestEnableAutocompletePowershellUpdatesExistingProfileFile(t *testing.T) {
 
 	expectedFileContent := `existing content
 should not change
-$uipathcli_auto_complete = {
+$uipath_auto_complete = {
     param($wordToComplete, $commandAst, $cursorPosition)
     $padLength = $cursorPosition - $commandAst.Extent.StartOffset
     $textToComplete = $commandAst.ToString().PadRight($padLength, ' ').Substring(0, $padLength)
@@ -88,7 +88,7 @@ $uipathcli_auto_complete = {
         [system.management.automation.completionresult]::new($_, $_, 'parametervalue', $_)
     }
 }
-Register-ArgumentCompleter -Native -CommandName uipathcli -ScriptBlock $uipathcli_auto_complete
+Register-ArgumentCompleter -Native -CommandName uipath -ScriptBlock $uipath_auto_complete
 `
 	if string(content) != expectedFileContent {
 		t.Errorf("Should update profile file with correct content, got: %v", string(content))
@@ -98,14 +98,14 @@ Register-ArgumentCompleter -Native -CommandName uipathcli -ScriptBlock $uipathcl
 func TestEnableAutocompletePowershellNoChangesIfEnabledAlready(t *testing.T) {
 	profilePath := createFile(t)
 	initialContent := `
-$uipathcli_auto_complete = {
+$uipath_auto_complete = {
     param($wordToComplete, $commandAst, $cursorPosition)
     $command, $params = $commandAst.ToString() -split " ", 2
     & $command autocomplete complete --command "$commandAst" | foreach-object {
         [system.management.automation.completionresult]::new($_, $_, 'parametervalue', $_)
     }
 }
-Register-ArgumentCompleter -Native -CommandName uipathcli -ScriptBlock $uipathcli_auto_complete
+Register-ArgumentCompleter -Native -CommandName uipath -ScriptBlock $uipath_auto_complete
 `
 	os.WriteFile(profilePath, []byte(initialContent), 0644)
 
@@ -124,14 +124,14 @@ Register-ArgumentCompleter -Native -CommandName uipathcli -ScriptBlock $uipathcl
 func TestEnableAutocompletePowershellShowsAlreadyEnabledOutput(t *testing.T) {
 	profilePath := createFile(t)
 	initialContent := `
-$uipathcli_auto_complete = {
+$uipath_auto_complete = {
     param($wordToComplete, $commandAst, $cursorPosition)
     $command, $params = $commandAst.ToString() -split " ", 2
     & $command autocomplete complete --command "$commandAst" | foreach-object {
         [system.management.automation.completionresult]::new($_, $_, 'parametervalue', $_)
     }
 }
-Register-ArgumentCompleter -Native -CommandName uipathcli -ScriptBlock $uipathcli_auto_complete
+Register-ArgumentCompleter -Native -CommandName uipath -ScriptBlock $uipath_auto_complete
 `
 	os.WriteFile(profilePath, []byte(initialContent), 0644)
 
@@ -182,7 +182,7 @@ func TestEnableAutocompleteBashCreatesProfileFile(t *testing.T) {
 	content, _ := os.ReadFile(profilePath)
 
 	expectedFileContent := `
-function _uipathcli_auto_complete()
+function _uipath_auto_complete()
 {
   local executable="${COMP_WORDS[0]}"
   local cur="${COMP_WORDS[COMP_CWORD]}" IFS=$'\n'
@@ -190,7 +190,7 @@ function _uipathcli_auto_complete()
   read -d '' -ra candidates < <($executable autocomplete complete --command "${COMP_LINE}" 2>/dev/null)
   read -d '' -ra COMPREPLY < <(compgen -W "${candidates[*]:-}" -- "$cur")
 }
-complete -f -F _uipathcli_auto_complete uipathcli
+complete -f -F _uipath_auto_complete uipath
 `
 	if string(content) != expectedFileContent {
 		t.Errorf("Should create profile file with correct content, got: %v", string(content))
@@ -213,7 +213,7 @@ func TestEnableAutocompleteBashUpdatesExistingProfileFile(t *testing.T) {
 existing content
 should not change
 
-function _uipathcli_auto_complete()
+function _uipath_auto_complete()
 {
   local executable="${COMP_WORDS[0]}"
   local cur="${COMP_WORDS[COMP_CWORD]}" IFS=$'\n'
@@ -221,7 +221,7 @@ function _uipathcli_auto_complete()
   read -d '' -ra candidates < <($executable autocomplete complete --command "${COMP_LINE}" 2>/dev/null)
   read -d '' -ra COMPREPLY < <(compgen -W "${candidates[*]:-}" -- "$cur")
 }
-complete -f -F _uipathcli_auto_complete uipathcli
+complete -f -F _uipath_auto_complete uipath
 `
 	if string(content) != expectedFileContent {
 		t.Errorf("Should update profile file with correct content, got: %v", string(content))
@@ -231,7 +231,7 @@ complete -f -F _uipathcli_auto_complete uipathcli
 func TestEnableAutocompleteBashNoChangesIfEnabledAlready(t *testing.T) {
 	profilePath := createFile(t)
 	initialContent := `
-function _uipathcli_auto_complete()
+function _uipath_auto_complete()
 {
   local executable="${COMP_WORDS[0]}"
   local cur="${COMP_WORDS[COMP_CWORD]}" IFS=$'\n'
@@ -239,7 +239,7 @@ function _uipathcli_auto_complete()
   read -d '' -ra candidates < <($executable autocomplete complete --command "${COMP_LINE}" 2>/dev/null)
   read -d '' -ra COMPREPLY < <(compgen -W "${candidates[*]:-}" -- "$cur")
 }
-complete -f -F _uipathcli_auto_complete uipathcli
+complete -f -F _uipath_auto_complete uipath
 `
 	os.WriteFile(profilePath, []byte(initialContent), 0644)
 
@@ -258,7 +258,7 @@ complete -f -F _uipathcli_auto_complete uipathcli
 func TestEnableAutocompleteBashShowsAlreadyEnabledOutput(t *testing.T) {
 	profilePath := createFile(t)
 	initialContent := `
-function _uipathcli_auto_complete()
+function _uipath_auto_complete()
 {
   local executable="${COMP_WORDS[0]}"
   local cur="${COMP_WORDS[COMP_CWORD]}" IFS=$'\n'
@@ -266,7 +266,7 @@ function _uipathcli_auto_complete()
   read -d '' -ra candidates < <($executable autocomplete complete --command "${COMP_LINE}" 2>/dev/null)
   read -d '' -ra COMPREPLY < <(compgen -W "${candidates[*]:-}" -- "$cur")
 }
-complete -f -F _uipathcli_auto_complete uipathcli
+complete -f -F _uipath_auto_complete uipath
 `
 	os.WriteFile(profilePath, []byte(initialContent), 0644)
 

--- a/test/autocomplete_test.go
+++ b/test/autocomplete_test.go
@@ -16,7 +16,7 @@ paths:
 		WithDefinition("myservice", definition).
 		Build()
 
-	result := runCli([]string{"autocomplete", "complete", "--command", "uipathcli my"}, context)
+	result := runCli([]string{"autocomplete", "complete", "--command", "uipath my"}, context)
 
 	expectedWords := "myservice\n"
 	if result.StdOut != expectedWords {
@@ -35,7 +35,7 @@ paths:
 		WithDefinition("myservice", definition).
 		Build()
 
-	result := runCli([]string{"autocomplete", "complete", "--command", "uipathcli serv"}, context)
+	result := runCli([]string{"autocomplete", "complete", "--command", "uipath serv"}, context)
 
 	expectedWords := "myservice\n"
 	if result.StdOut != expectedWords {
@@ -54,7 +54,7 @@ paths:
 		WithDefinition("myservice", definition).
 		Build()
 
-	result := runCli([]string{"autocomplete", "complete", "--command", "uipathcli myservice other"}, context)
+	result := runCli([]string{"autocomplete", "complete", "--command", "uipath myservice other"}, context)
 
 	if result.StdOut != "" {
 		t.Errorf("Should not return any autocomplete words, got: %v", result.StdOut)
@@ -72,7 +72,7 @@ paths:
 		WithDefinition("myservice", definition).
 		Build()
 
-	result := runCli([]string{"autocomplete", "complete", "--command", "uipathcli myservice pi"}, context)
+	result := runCli([]string{"autocomplete", "complete", "--command", "uipath myservice pi"}, context)
 
 	expectedWords := "ping\n"
 	if result.StdOut != expectedWords {
@@ -91,7 +91,7 @@ paths:
 		WithDefinition("myservice", definition).
 		Build()
 
-	result := runCli([]string{"autocomplete", "complete", "--command", "uipathcli myservice in"}, context)
+	result := runCli([]string{"autocomplete", "complete", "--command", "uipath myservice in"}, context)
 
 	expectedWords := "ping\n"
 	if result.StdOut != expectedWords {
@@ -113,7 +113,7 @@ paths:
 		WithDefinition("myservice", definition).
 		Build()
 
-	result := runCli([]string{"autocomplete", "complete", "--command", "uipathcli myservice ping"}, context)
+	result := runCli([]string{"autocomplete", "complete", "--command", "uipath myservice ping"}, context)
 
 	expectedWords := "ping\nother-ping\n"
 	if result.StdOut != expectedWords {
@@ -138,7 +138,7 @@ paths:
 		WithDefinition("myservice", definition).
 		Build()
 
-	result := runCli([]string{"autocomplete", "complete", "--command", "uipathcli myservice create"}, context)
+	result := runCli([]string{"autocomplete", "complete", "--command", "uipath myservice create"}, context)
 
 	expectedWords := "create\nnew-create\n"
 	if result.StdOut != expectedWords {
@@ -164,7 +164,7 @@ paths:
 		WithDefinition("myservice", definition).
 		Build()
 
-	result := runCli([]string{"autocomplete", "complete", "--command", "uipathcli myservice ping --id"}, context)
+	result := runCli([]string{"autocomplete", "complete", "--command", "uipath myservice ping --id"}, context)
 
 	expectedWords := "--identifier\n"
 	if result.StdOut != expectedWords {
@@ -190,7 +190,7 @@ paths:
 		WithDefinition("myservice", definition).
 		Build()
 
-	result := runCli([]string{"autocomplete", "complete", "--command", "uipathcli myservice ping --enti"}, context)
+	result := runCli([]string{"autocomplete", "complete", "--command", "uipath myservice ping --enti"}, context)
 
 	expectedWords := "--identifier\n"
 	if result.StdOut != expectedWords {
@@ -224,7 +224,7 @@ components:
 		WithDefinition("myservice", definition).
 		Build()
 
-	result := runCli([]string{"autocomplete", "complete", "--command", "uipathcli myservice post-validate --desc"}, context)
+	result := runCli([]string{"autocomplete", "complete", "--command", "uipath myservice post-validate --desc"}, context)
 
 	expectedWords := "--description\n--short-description\n"
 	if result.StdOut != expectedWords {
@@ -258,7 +258,7 @@ components:
 		WithDefinition("myservice", definition).
 		Build()
 
-	result := runCli([]string{"autocomplete", "complete", "--command", "uipathcli myservice post-validate --"}, context)
+	result := runCli([]string{"autocomplete", "complete", "--command", "uipath myservice post-validate --"}, context)
 
 	expectedWords := []string{
 		"--description",
@@ -297,7 +297,7 @@ components:
 		WithDefinition("myservice", definition).
 		Build()
 
-	result := runCli([]string{"autocomplete", "complete", "--command", "uipathcli myservice post-validate --description \"my description\" --"}, context)
+	result := runCli([]string{"autocomplete", "complete", "--command", "uipath myservice post-validate --description \"my description\" --"}, context)
 
 	expectedWords := []string{
 		"--other",

--- a/test/setup.go
+++ b/test/setup.go
@@ -224,7 +224,7 @@ func runCli(args []string, context Context) Result {
 }
 
 func createFile(t *testing.T) string {
-	tempFile, err := os.CreateTemp("", "uipathcli-test")
+	tempFile, err := os.CreateTemp("", "uipath-test")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
The cli postfix in uipathcli is redundant because it is obvious that the user is using a CLI. Renamed uipathcli to uipath to shorten the command and make it more readable, e.g.

uipath orchestrator users get