### PR TITLE
Configure org/tenant before auth

### DIFF
--- a/commandline/config_command_handler.go
+++ b/commandline/config_command_handler.go
@@ -39,17 +39,7 @@ func (h ConfigCommandHandler) configureCredentials(profileName string) error {
 	config := h.getOrCreateProfile(profileName)
 	reader := bufio.NewReader(h.StdIn)
 
-	message := fmt.Sprintf("Enter client id [%s]:", h.getDisplayValue(config.ClientId(), true))
-	clientId, err := h.readUserInput(message, reader)
-	if err != nil {
-		return nil
-	}
-	message = fmt.Sprintf("Enter client secret [%s]:", h.getDisplayValue(config.ClientSecret(), true))
-	clientSecret, err := h.readUserInput(message, reader)
-	if err != nil {
-		return nil
-	}
-	message = fmt.Sprintf("Enter organization [%s]:", h.getDisplayValue(config.Organization, false))
+	message := fmt.Sprintf("Enter organization [%s]:", h.getDisplayValue(config.Organization, false))
 	organization, err := h.readUserInput(message, reader)
 	if err != nil {
 		return nil
@@ -59,11 +49,21 @@ func (h ConfigCommandHandler) configureCredentials(profileName string) error {
 	if err != nil {
 		return nil
 	}
+	message = fmt.Sprintf("Enter client id [%s]:", h.getDisplayValue(config.ClientId(), true))
+	clientId, err := h.readUserInput(message, reader)
+	if err != nil {
+		return nil
+	}
+	message = fmt.Sprintf("Enter client secret [%s]:", h.getDisplayValue(config.ClientSecret(), true))
+	clientSecret, err := h.readUserInput(message, reader)
+	if err != nil {
+		return nil
+	}
 
-	authChanged := config.ConfigureCredentialsAuth(clientId, clientSecret)
 	orgTenantChanged := config.ConfigureOrgTenant(organization, tenant)
+	authChanged := config.ConfigureCredentialsAuth(clientId, clientSecret)
 
-	if authChanged || orgTenantChanged {
+	if orgTenantChanged || authChanged {
 		err = h.ConfigProvider.Update(profileName, config)
 		if err != nil {
 			return err
@@ -77,7 +77,17 @@ func (h ConfigCommandHandler) configureLogin(profileName string) error {
 	config := h.getOrCreateProfile(profileName)
 	reader := bufio.NewReader(h.StdIn)
 
-	message := fmt.Sprintf("Enter client id [%s]:", h.getDisplayValue(config.ClientId(), true))
+	message := fmt.Sprintf("Enter organization [%s]:", h.getDisplayValue(config.Organization, false))
+	organization, err := h.readUserInput(message, reader)
+	if err != nil {
+		return nil
+	}
+	message = fmt.Sprintf("Enter tenant [%s]:", h.getDisplayValue(config.Tenant, false))
+	tenant, err := h.readUserInput(message, reader)
+	if err != nil {
+		return nil
+	}
+	message = fmt.Sprintf("Enter client id [%s]:", h.getDisplayValue(config.ClientId(), true))
 	clientId, err := h.readUserInput(message, reader)
 	if err != nil {
 		return nil
@@ -92,21 +102,11 @@ func (h ConfigCommandHandler) configureLogin(profileName string) error {
 	if err != nil {
 		return nil
 	}
-	message = fmt.Sprintf("Enter organization [%s]:", h.getDisplayValue(config.Organization, false))
-	organization, err := h.readUserInput(message, reader)
-	if err != nil {
-		return nil
-	}
-	message = fmt.Sprintf("Enter tenant [%s]:", h.getDisplayValue(config.Tenant, false))
-	tenant, err := h.readUserInput(message, reader)
-	if err != nil {
-		return nil
-	}
 
-	authChanged := config.ConfigureLoginAuth(clientId, redirectUri, scopes)
 	orgTenantChanged := config.ConfigureOrgTenant(organization, tenant)
+	authChanged := config.ConfigureLoginAuth(clientId, redirectUri, scopes)
 
-	if authChanged || orgTenantChanged {
+	if orgTenantChanged || authChanged {
 		err = h.ConfigProvider.Update(profileName, config)
 		if err != nil {
 			return err
@@ -120,12 +120,7 @@ func (h ConfigCommandHandler) configurePat(profileName string) error {
 	config := h.getOrCreateProfile(profileName)
 	reader := bufio.NewReader(h.StdIn)
 
-	message := fmt.Sprintf("Enter personal access token [%s]:", h.getDisplayValue(config.Pat(), true))
-	pat, err := h.readUserInput(message, reader)
-	if err != nil {
-		return nil
-	}
-	message = fmt.Sprintf("Enter organization [%s]:", h.getDisplayValue(config.Organization, false))
+	message := fmt.Sprintf("Enter organization [%s]:", h.getDisplayValue(config.Organization, false))
 	organization, err := h.readUserInput(message, reader)
 	if err != nil {
 		return nil
@@ -135,11 +130,16 @@ func (h ConfigCommandHandler) configurePat(profileName string) error {
 	if err != nil {
 		return nil
 	}
+	message = fmt.Sprintf("Enter personal access token [%s]:", h.getDisplayValue(config.Pat(), true))
+	pat, err := h.readUserInput(message, reader)
+	if err != nil {
+		return nil
+	}
 
-	authChanged := config.ConfigurePatAuth(pat)
 	orgTenantChanged := config.ConfigureOrgTenant(organization, tenant)
+	authChanged := config.ConfigurePatAuth(pat)
 
-	if authChanged || orgTenantChanged {
+	if orgTenantChanged || authChanged {
 		err = h.ConfigProvider.Update(profileName, config)
 		if err != nil {
 			return err

--- a/test/config_update_test.go
+++ b/test/config_update_test.go
@@ -33,7 +33,7 @@ func TestConfiguresCredentialsAuth(t *testing.T) {
 	configFile := createFile(t)
 
 	stdIn := bytes.Buffer{}
-	stdIn.Write([]byte("client-id\nclient-secret\nmy-org\nmy-tenant\n"))
+	stdIn.Write([]byte("my-org\nmy-tenant\nclient-id\nclient-secret\n"))
 	context := NewContextBuilder().
 		WithStdIn(stdIn).
 		WithConfigFile(configFile).
@@ -62,7 +62,7 @@ func TestConfiguresLoginAuth(t *testing.T) {
 	configFile := createFile(t)
 
 	stdIn := bytes.Buffer{}
-	stdIn.Write([]byte("ffe5141f-60fc-4fb9-8717-3969f303aedf\nhttp://localhost:27100\nOR.Users\nmy-org\nmy-tenant\n"))
+	stdIn.Write([]byte("my-org\nmy-tenant\nffe5141f-60fc-4fb9-8717-3969f303aedf\nhttp://localhost:27100\nOR.Users\n"))
 	context := NewContextBuilder().
 		WithStdIn(stdIn).
 		WithConfigFile(configFile).
@@ -92,7 +92,7 @@ func TestConfiguresPatAuth(t *testing.T) {
 	configFile := createFile(t)
 
 	stdIn := bytes.Buffer{}
-	stdIn.Write([]byte("rt_mypersonalaccesstoken\nmy-org\nmy-tenant\n"))
+	stdIn.Write([]byte("my-org\nmy-tenant\nrt_mypersonalaccesstoken\n"))
 	context := NewContextBuilder().
 		WithStdIn(stdIn).
 		WithConfigFile(configFile).
@@ -126,7 +126,7 @@ profiles:
 `
 
 	stdIn := bytes.Buffer{}
-	stdIn.Write([]byte("rt_mypersonalaccesstoken\nmy-org\nmy-tenant\n"))
+	stdIn.Write([]byte("my-org\nmy-tenant\nrt_mypersonalaccesstoken\n"))
 
 	context := NewContextBuilder().
 		WithConfig(config).
@@ -165,7 +165,7 @@ profiles:
 `
 
 	stdIn := bytes.Buffer{}
-	stdIn.Write([]byte("updated-token\nmy-updated-org\nmy-updated-tenant\n"))
+	stdIn.Write([]byte("my-updated-org\nmy-updated-tenant\nupdated-token\n"))
 
 	context := NewContextBuilder().
 		WithConfig(config).
@@ -202,7 +202,7 @@ profiles:
 `
 
 	stdIn := bytes.Buffer{}
-	stdIn.Write([]byte("\nmy-updated-org\n\n"))
+	stdIn.Write([]byte("my-updated-org\n\n\n"))
 
 	context := NewContextBuilder().
 		WithConfig(config).
@@ -237,7 +237,7 @@ profiles:
 `
 
 	stdIn := bytes.Buffer{}
-	stdIn.Write([]byte("rt_mypersonalaccesstoken\nmy-org\nmy-tenant\n"))
+	stdIn.Write([]byte("my-org\nmy-tenant\nrt_mypersonalaccesstoken\n"))
 
 	context := NewContextBuilder().
 		WithConfig(config).
@@ -279,7 +279,7 @@ profiles:
 `
 
 	stdIn := bytes.Buffer{}
-	stdIn.Write([]byte("my-new-token\n\n\n"))
+	stdIn.Write([]byte("\n\nmy-new-token\n"))
 
 	context := NewContextBuilder().
 		WithConfig(config).
@@ -315,7 +315,7 @@ func TestCredentialsAuthOutputNotSet(t *testing.T) {
 		Build()
 	result := runCli([]string{"config"}, context)
 
-	expectedOutput := `Enter client id [not set]: Enter client secret [not set]: Enter organization [not set]: Enter tenant [not set]: `
+	expectedOutput := `Enter organization [not set]: Enter tenant [not set]: Enter client id [not set]: Enter client secret [not set]: `
 	if result.StdOut != expectedOutput {
 		t.Errorf("Expected prompt %v, but got %v", expectedOutput, result.StdOut)
 	}
@@ -343,7 +343,7 @@ profiles:
 		Build()
 	result := runCli([]string{"config"}, context)
 
-	expectedOutput := `Enter client id [*******e871]: Enter client secret [*******vifo]: Enter organization [my-org]: Enter tenant [my-tenant]: `
+	expectedOutput := `Enter organization [my-org]: Enter tenant [my-tenant]: Enter client id [*******e871]: Enter client secret [*******vifo]: `
 	if result.StdOut != expectedOutput {
 		t.Errorf("Expected prompt %v, but got %v", expectedOutput, result.StdOut)
 	}
@@ -371,7 +371,7 @@ profiles:
 		Build()
 	result := runCli([]string{"config"}, context)
 
-	expectedOutput := `Enter client id [*******]: Enter client secret [*******]: Enter organization [my-org]: Enter tenant [my-tenant]: `
+	expectedOutput := `Enter organization [my-org]: Enter tenant [my-tenant]: Enter client id [*******]: Enter client secret [*******]: `
 	if result.StdOut != expectedOutput {
 		t.Errorf("Expected prompt %v, but got %v", expectedOutput, result.StdOut)
 	}
@@ -398,7 +398,7 @@ profiles:
 		Build()
 	result := runCli([]string{"config", "--auth", "pat"}, context)
 
-	expectedOutput := `Enter personal access token [*******a827]: Enter organization [my-org]: Enter tenant [my-tenant]: `
+	expectedOutput := `Enter organization [my-org]: Enter tenant [my-tenant]: Enter personal access token [*******a827]: `
 	if result.StdOut != expectedOutput {
 		t.Errorf("Expected prompt %v, but got %v", expectedOutput, result.StdOut)
 	}
@@ -427,7 +427,7 @@ profiles:
 		Build()
 	result := runCli([]string{"config", "--auth", "login"}, context)
 
-	expectedOutput := `Enter client id [*******dd35]: Enter redirect uri [http://localhost:27100]: Enter scopes [OR.Users.Read OR.Users.Write]: Enter organization [my-org]: Enter tenant [my-tenant]: `
+	expectedOutput := `Enter organization [my-org]: Enter tenant [my-tenant]: Enter client id [*******dd35]: Enter redirect uri [http://localhost:27100]: Enter scopes [OR.Users.Read OR.Users.Write]: `
 	if result.StdOut != expectedOutput {
 		t.Errorf("Expected prompt %v, but got %v", expectedOutput, result.StdOut)
 	}


### PR DESCRIPTION
Switch configuring organization and tenant with auth. Changed the interactive config command to ask for org and tenant before auth parameters.