### PR TITLE
Extend config command with multi-auth support

### DIFF
--- a/commandline/command_builder.go
+++ b/commandline/command_builder.go
@@ -535,7 +535,6 @@ func (b CommandBuilder) createConfigCommand() *cli.Command {
 	flags := []cli.Flag{
 		&cli.StringFlag{
 			Name:  authFlagName,
-			Value: CredentialsAuth,
 			Usage: fmt.Sprintf("Authorization type: %s, %s, %s", CredentialsAuth, LoginAuth, PatAuth),
 		},
 		&cli.StringFlag{

--- a/commandline/config_command_handler.go
+++ b/commandline/config_command_handler.go
@@ -31,31 +31,67 @@ func (h ConfigCommandHandler) Configure(auth string, profileName string) error {
 		return h.configureLogin(profileName)
 	case PatAuth:
 		return h.configurePat(profileName)
+	case "":
+		return h.configure(profileName)
 	}
 	return fmt.Errorf("Invalid auth, supported values: %s, %s, %s", CredentialsAuth, LoginAuth, PatAuth)
+}
+
+func (h ConfigCommandHandler) configure(profileName string) error {
+	config := h.getOrCreateProfile(profileName)
+	reader := bufio.NewReader(h.StdIn)
+
+	organization, tenant, err := h.readOrgTenantInput(config, reader)
+	if err != nil {
+		return nil
+	}
+	authType, err := h.readAuthTypeInput(config, reader)
+	if err != nil {
+		return nil
+	}
+
+	authChanged := false
+	if authType == CredentialsAuth {
+		clientId, clientSecret, err := h.readCredentialsInput(config, reader)
+		if err != nil {
+			return nil
+		}
+		authChanged = config.ConfigureCredentialsAuth(clientId, clientSecret)
+	} else if authType == LoginAuth {
+		clientId, redirectUri, scopes, err := h.readLoginInput(config, reader)
+		if err != nil {
+			return nil
+		}
+		authChanged = config.ConfigureLoginAuth(clientId, redirectUri, scopes)
+	} else if authType == PatAuth {
+		pat, err := h.readPatInput(config, reader)
+		if err != nil {
+			return nil
+		}
+		authChanged = config.ConfigurePatAuth(pat)
+	}
+
+	orgTenantChanged := config.ConfigureOrgTenant(organization, tenant)
+
+	if orgTenantChanged || authChanged {
+		err = h.ConfigProvider.Update(profileName, config)
+		if err != nil {
+			return err
+		}
+		fmt.Fprintln(h.StdOut, successMessage)
+	}
+	return nil
 }
 
 func (h ConfigCommandHandler) configureCredentials(profileName string) error {
 	config := h.getOrCreateProfile(profileName)
 	reader := bufio.NewReader(h.StdIn)
 
-	message := fmt.Sprintf("Enter organization [%s]:", h.getDisplayValue(config.Organization, false))
-	organization, err := h.readUserInput(message, reader)
+	organization, tenant, err := h.readOrgTenantInput(config, reader)
 	if err != nil {
 		return nil
 	}
-	message = fmt.Sprintf("Enter tenant [%s]:", h.getDisplayValue(config.Tenant, false))
-	tenant, err := h.readUserInput(message, reader)
-	if err != nil {
-		return nil
-	}
-	message = fmt.Sprintf("Enter client id [%s]:", h.getDisplayValue(config.ClientId(), true))
-	clientId, err := h.readUserInput(message, reader)
-	if err != nil {
-		return nil
-	}
-	message = fmt.Sprintf("Enter client secret [%s]:", h.getDisplayValue(config.ClientSecret(), true))
-	clientSecret, err := h.readUserInput(message, reader)
+	clientId, clientSecret, err := h.readCredentialsInput(config, reader)
 	if err != nil {
 		return nil
 	}
@@ -77,28 +113,11 @@ func (h ConfigCommandHandler) configureLogin(profileName string) error {
 	config := h.getOrCreateProfile(profileName)
 	reader := bufio.NewReader(h.StdIn)
 
-	message := fmt.Sprintf("Enter organization [%s]:", h.getDisplayValue(config.Organization, false))
-	organization, err := h.readUserInput(message, reader)
+	organization, tenant, err := h.readOrgTenantInput(config, reader)
 	if err != nil {
 		return nil
 	}
-	message = fmt.Sprintf("Enter tenant [%s]:", h.getDisplayValue(config.Tenant, false))
-	tenant, err := h.readUserInput(message, reader)
-	if err != nil {
-		return nil
-	}
-	message = fmt.Sprintf("Enter client id [%s]:", h.getDisplayValue(config.ClientId(), true))
-	clientId, err := h.readUserInput(message, reader)
-	if err != nil {
-		return nil
-	}
-	message = fmt.Sprintf("Enter redirect uri [%s]:", h.getDisplayValue(config.RedirectUri(), false))
-	redirectUri, err := h.readUserInput(message, reader)
-	if err != nil {
-		return nil
-	}
-	message = fmt.Sprintf("Enter scopes [%s]:", h.getDisplayValue(config.Scopes(), false))
-	scopes, err := h.readUserInput(message, reader)
+	clientId, redirectUri, scopes, err := h.readLoginInput(config, reader)
 	if err != nil {
 		return nil
 	}
@@ -120,18 +139,11 @@ func (h ConfigCommandHandler) configurePat(profileName string) error {
 	config := h.getOrCreateProfile(profileName)
 	reader := bufio.NewReader(h.StdIn)
 
-	message := fmt.Sprintf("Enter organization [%s]:", h.getDisplayValue(config.Organization, false))
-	organization, err := h.readUserInput(message, reader)
+	organization, tenant, err := h.readOrgTenantInput(config, reader)
 	if err != nil {
 		return nil
 	}
-	message = fmt.Sprintf("Enter tenant [%s]:", h.getDisplayValue(config.Tenant, false))
-	tenant, err := h.readUserInput(message, reader)
-	if err != nil {
-		return nil
-	}
-	message = fmt.Sprintf("Enter personal access token [%s]:", h.getDisplayValue(config.Pat(), true))
-	pat, err := h.readUserInput(message, reader)
+	pat, err := h.readPatInput(config, reader)
 	if err != nil {
 		return nil
 	}
@@ -147,6 +159,19 @@ func (h ConfigCommandHandler) configurePat(profileName string) error {
 		fmt.Fprintln(h.StdOut, successMessage)
 	}
 	return nil
+}
+
+func (h ConfigCommandHandler) getAuthType(config config.Config) string {
+	if config.Pat() != "" {
+		return PatAuth
+	}
+	if config.ClientId() != "" && config.RedirectUri() != "" && config.Scopes() != "" {
+		return LoginAuth
+	}
+	if config.ClientId() != "" && config.ClientSecret() != "" {
+		return CredentialsAuth
+	}
+	return ""
 }
 
 func (h ConfigCommandHandler) getOrCreateProfile(profileName string) config.Config {
@@ -181,4 +206,86 @@ func (h ConfigCommandHandler) readUserInput(message string, reader *bufio.Reader
 		return "", err
 	}
 	return strings.Trim(value, " \r\n\t"), nil
+}
+
+func (h ConfigCommandHandler) readOrgTenantInput(config config.Config, reader *bufio.Reader) (string, string, error) {
+	message := fmt.Sprintf("Enter organization [%s]:", h.getDisplayValue(config.Organization, false))
+	organization, err := h.readUserInput(message, reader)
+	if err != nil {
+		return "", "", err
+	}
+
+	message = fmt.Sprintf("Enter tenant [%s]:", h.getDisplayValue(config.Tenant, false))
+	tenant, err := h.readUserInput(message, reader)
+	if err != nil {
+		return "", "", err
+	}
+
+	return organization, tenant, nil
+}
+
+func (h ConfigCommandHandler) readCredentialsInput(config config.Config, reader *bufio.Reader) (string, string, error) {
+	message := fmt.Sprintf("Enter client id [%s]:", h.getDisplayValue(config.ClientId(), true))
+	clientId, err := h.readUserInput(message, reader)
+	if err != nil {
+		return "", "", err
+	}
+
+	message = fmt.Sprintf("Enter client secret [%s]:", h.getDisplayValue(config.ClientSecret(), true))
+	clientSecret, err := h.readUserInput(message, reader)
+	if err != nil {
+		return "", "", err
+	}
+
+	return clientId, clientSecret, nil
+}
+
+func (h ConfigCommandHandler) readLoginInput(config config.Config, reader *bufio.Reader) (string, string, string, error) {
+	message := fmt.Sprintf("Enter client id [%s]:", h.getDisplayValue(config.ClientId(), true))
+	clientId, err := h.readUserInput(message, reader)
+	if err != nil {
+		return "", "", "", err
+	}
+	message = fmt.Sprintf("Enter redirect uri [%s]:", h.getDisplayValue(config.RedirectUri(), false))
+	redirectUri, err := h.readUserInput(message, reader)
+	if err != nil {
+		return "", "", "", err
+	}
+	message = fmt.Sprintf("Enter scopes [%s]:", h.getDisplayValue(config.Scopes(), false))
+	scopes, err := h.readUserInput(message, reader)
+	if err != nil {
+		return "", "", "", err
+	}
+
+	return clientId, redirectUri, scopes, nil
+}
+
+func (h ConfigCommandHandler) readPatInput(config config.Config, reader *bufio.Reader) (string, error) {
+	message := fmt.Sprintf("Enter personal access token [%s]:", h.getDisplayValue(config.Pat(), true))
+	return h.readUserInput(message, reader)
+}
+
+func (h ConfigCommandHandler) readAuthTypeInput(config config.Config, reader *bufio.Reader) (string, error) {
+	authType := h.getAuthType(config)
+	for {
+		message := fmt.Sprintf(`Authentication type [%s]:
+  [1] credentials - Client Id and Client Secret
+  [2] login - OAuth login using the browser
+  [3] pat - Personal Access Token
+Select:`, h.getDisplayValue(authType, false))
+		input, err := h.readUserInput(message, reader)
+		if err != nil {
+			return "", nil
+		}
+		switch input {
+		case "":
+			return authType, nil
+		case "1":
+			return CredentialsAuth, nil
+		case "2":
+			return LoginAuth, nil
+		case "3":
+			return PatAuth, nil
+		}
+	}
 }

--- a/test/config_update_test.go
+++ b/test/config_update_test.go
@@ -39,7 +39,7 @@ func TestConfiguresCredentialsAuth(t *testing.T) {
 		WithConfigFile(configFile).
 		Build()
 
-	runCli([]string{"config"}, context)
+	runCli([]string{"config", "--auth", "credentials"}, context)
 
 	config, err := os.ReadFile(configFile)
 	if err != nil {
@@ -313,7 +313,7 @@ func TestCredentialsAuthOutputNotSet(t *testing.T) {
 	context := NewContextBuilder().
 		WithStdIn(stdIn).
 		Build()
-	result := runCli([]string{"config"}, context)
+	result := runCli([]string{"config", "--auth", "credentials"}, context)
 
 	expectedOutput := `Enter organization [not set]: Enter tenant [not set]: Enter client id [not set]: Enter client secret [not set]: `
 	if result.StdOut != expectedOutput {
@@ -341,7 +341,7 @@ profiles:
 		WithConfigFile(configFile).
 		WithStdIn(stdIn).
 		Build()
-	result := runCli([]string{"config"}, context)
+	result := runCli([]string{"config", "--auth", "credentials"}, context)
 
 	expectedOutput := `Enter organization [my-org]: Enter tenant [my-tenant]: Enter client id [*******e871]: Enter client secret [*******vifo]: `
 	if result.StdOut != expectedOutput {
@@ -369,7 +369,7 @@ profiles:
 		WithConfigFile(configFile).
 		WithStdIn(stdIn).
 		Build()
-	result := runCli([]string{"config"}, context)
+	result := runCli([]string{"config", "--auth", "credentials"}, context)
 
 	expectedOutput := `Enter organization [my-org]: Enter tenant [my-tenant]: Enter client id [*******]: Enter client secret [*******]: `
 	if result.StdOut != expectedOutput {
@@ -389,7 +389,7 @@ profiles:
 `
 
 	stdIn := bytes.Buffer{}
-	stdIn.Write([]byte("\n\n\n\n"))
+	stdIn.Write([]byte("\n\n\n"))
 
 	context := NewContextBuilder().
 		WithConfig(config).
@@ -430,5 +430,314 @@ profiles:
 	expectedOutput := `Enter organization [my-org]: Enter tenant [my-tenant]: Enter client id [*******dd35]: Enter redirect uri [http://localhost:27100]: Enter scopes [OR.Users.Read OR.Users.Write]: `
 	if result.StdOut != expectedOutput {
 		t.Errorf("Expected prompt %v, but got %v", expectedOutput, result.StdOut)
+	}
+}
+
+func TestConfigureMultiAuthCredentialsAuth(t *testing.T) {
+	configFile := createFile(t)
+
+	stdIn := bytes.Buffer{}
+	stdIn.Write([]byte("my-org\nmy-tenant\n1\nclient-id\nclient-secret\n"))
+	context := NewContextBuilder().
+		WithStdIn(stdIn).
+		WithConfigFile(configFile).
+		Build()
+
+	runCli([]string{"config"}, context)
+
+	config, err := os.ReadFile(configFile)
+	if err != nil {
+		t.Errorf("Config file does not exist: %v", err)
+	}
+	expectedConfig := `profiles:
+- name: default
+  organization: my-org
+  tenant: my-tenant
+  auth:
+    clientId: client-id
+    clientSecret: client-secret
+`
+	if string(config) != expectedConfig {
+		t.Errorf("Expected generated config %v, but got %v", expectedConfig, string(config))
+	}
+}
+
+func TestConfigureMultiAuthLoginAuth(t *testing.T) {
+	configFile := createFile(t)
+
+	stdIn := bytes.Buffer{}
+	stdIn.Write([]byte("my-org\nmy-tenant\n2\nffe5141f-60fc-4fb9-8717-3969f303aedf\nhttp://localhost:27100\nOR.Users\n"))
+	context := NewContextBuilder().
+		WithStdIn(stdIn).
+		WithConfigFile(configFile).
+		Build()
+
+	runCli([]string{"config"}, context)
+
+	config, err := os.ReadFile(configFile)
+	if err != nil {
+		t.Errorf("Config file does not exist: %v", err)
+	}
+	expectedConfig := `profiles:
+- name: default
+  organization: my-org
+  tenant: my-tenant
+  auth:
+    clientId: ffe5141f-60fc-4fb9-8717-3969f303aedf
+    redirectUri: http://localhost:27100
+    scopes: OR.Users
+`
+	if string(config) != expectedConfig {
+		t.Errorf("Expected generated config %v, but got %v", expectedConfig, string(config))
+	}
+}
+
+func TestConfigureMultiAuthPatAuth(t *testing.T) {
+	configFile := createFile(t)
+
+	stdIn := bytes.Buffer{}
+	stdIn.Write([]byte("my-org\nmy-tenant\n3\nrt_mypersonalaccesstoken\n"))
+	context := NewContextBuilder().
+		WithStdIn(stdIn).
+		WithConfigFile(configFile).
+		Build()
+
+	runCli([]string{"config"}, context)
+
+	config, err := os.ReadFile(configFile)
+	if err != nil {
+		t.Errorf("Config file does not exist: %v", err)
+	}
+	expectedConfig := `profiles:
+- name: default
+  organization: my-org
+  tenant: my-tenant
+  auth:
+    pat: rt_mypersonalaccesstoken
+`
+	if string(config) != expectedConfig {
+		t.Errorf("Expected generated config %v, but got %v", expectedConfig, string(config))
+	}
+}
+
+func TestConfigureMultiAuthShowsExistingCredentialsAuth(t *testing.T) {
+	configFile := createFile(t)
+	config := `
+profiles:
+- name: default
+  organization: my-org
+  tenant: my-tenant
+  auth:
+    clientId: my-client-id
+    clientSecret: my-secret
+`
+
+	stdIn := bytes.Buffer{}
+	stdIn.Write([]byte("\n\n\n\n"))
+
+	context := NewContextBuilder().
+		WithConfig(config).
+		WithConfigFile(configFile).
+		WithStdIn(stdIn).
+		Build()
+	result := runCli([]string{"config"}, context)
+
+	if !strings.Contains(result.StdOut, "Authentication type [credentials]:") {
+		t.Errorf("Expected existing authentication type credentials, but got %v", result.StdOut)
+	}
+}
+
+func TestConfigureMultiAuthShowsExistingLoginAuth(t *testing.T) {
+	configFile := createFile(t)
+	config := `
+profiles:
+- name: default
+  organization: my-org
+  tenant: my-tenant
+  auth:
+    clientId: my-client-id
+    redirectUri: http://localhost:12700
+    scopes: OR.users
+`
+
+	stdIn := bytes.Buffer{}
+	stdIn.Write([]byte("\n\n\n\n\n"))
+
+	context := NewContextBuilder().
+		WithConfig(config).
+		WithConfigFile(configFile).
+		WithStdIn(stdIn).
+		Build()
+	result := runCli([]string{"config"}, context)
+
+	if !strings.Contains(result.StdOut, "Authentication type [login]:") {
+		t.Errorf("Expected existing authentication type login, but got %v", result.StdOut)
+	}
+}
+
+func TestConfigureMultiAuthShowsExistingPatAuth(t *testing.T) {
+	configFile := createFile(t)
+	config := `
+profiles:
+- name: default
+  organization: my-org
+  tenant: my-tenant
+  auth:
+    pat: my-pat
+`
+
+	stdIn := bytes.Buffer{}
+	stdIn.Write([]byte("\n\n\n"))
+
+	context := NewContextBuilder().
+		WithConfig(config).
+		WithConfigFile(configFile).
+		WithStdIn(stdIn).
+		Build()
+	result := runCli([]string{"config"}, context)
+
+	if !strings.Contains(result.StdOut, "Authentication type [pat]:") {
+		t.Errorf("Expected existing authentication type pat, but got %v", result.StdOut)
+	}
+}
+
+func TestConfigureMultiAuthShowsNoAuthSet(t *testing.T) {
+	configFile := createFile(t)
+	config := `
+profiles:
+- name: default
+  organization: my-org
+  tenant: my-tenant
+`
+
+	stdIn := bytes.Buffer{}
+	stdIn.Write([]byte("\n\n\n"))
+
+	context := NewContextBuilder().
+		WithConfig(config).
+		WithConfigFile(configFile).
+		WithStdIn(stdIn).
+		Build()
+	result := runCli([]string{"config"}, context)
+
+	if !strings.Contains(result.StdOut, "Authentication type [not set]:") {
+		t.Errorf("Expected no authentication type, but got %v", result.StdOut)
+	}
+}
+
+func TestConfigureMultiAuthModifiesExistingPatAuth(t *testing.T) {
+	configFile := createFile(t)
+	existingConfig := `
+profiles:
+- name: default
+  organization: my-org
+  tenant: my-tenant
+  auth:
+    pat: f73b2edb-b37b-4426-8cc8-e7f98b09a827
+`
+
+	stdIn := bytes.Buffer{}
+	stdIn.Write([]byte("\n\n\nnew-pat\n"))
+
+	context := NewContextBuilder().
+		WithConfig(existingConfig).
+		WithConfigFile(configFile).
+		WithStdIn(stdIn).
+		Build()
+	runCli([]string{"config"}, context)
+
+	config, err := os.ReadFile(configFile)
+	if err != nil {
+		t.Errorf("Config file does not exist: %v", err)
+	}
+	expectedConfig := `profiles:
+- name: default
+  organization: my-org
+  tenant: my-tenant
+  auth:
+    pat: new-pat
+`
+	if string(config) != expectedConfig {
+		t.Errorf("Expected generated config %v, but got %v", expectedConfig, string(config))
+	}
+}
+
+func TestConfigureMultiAuthModifiesExistingCredentialsAuth(t *testing.T) {
+	configFile := createFile(t)
+	existingConfig := `
+profiles:
+- name: default
+  organization: my-org
+  tenant: my-tenant
+  auth:
+    clientId: my-client-id
+    clientSecret: my-client-secret
+`
+
+	stdIn := bytes.Buffer{}
+	stdIn.Write([]byte("\n\n\nnew-client-id\nnew-client-secret\n"))
+
+	context := NewContextBuilder().
+		WithConfig(existingConfig).
+		WithConfigFile(configFile).
+		WithStdIn(stdIn).
+		Build()
+	runCli([]string{"config"}, context)
+
+	config, err := os.ReadFile(configFile)
+	if err != nil {
+		t.Errorf("Config file does not exist: %v", err)
+	}
+	expectedConfig := `profiles:
+- name: default
+  organization: my-org
+  tenant: my-tenant
+  auth:
+    clientId: new-client-id
+    clientSecret: new-client-secret
+`
+	if string(config) != expectedConfig {
+		t.Errorf("Expected generated config %v, but got %v", expectedConfig, string(config))
+	}
+}
+
+func TestConfigureMultiAuthModifiesExistingLoginAuth(t *testing.T) {
+	configFile := createFile(t)
+	existingConfig := `
+profiles:
+- name: default
+  organization: my-org
+  tenant: my-tenant
+  auth:
+    clientId: ffe5141f-60fc-4fb9-8717-3969f303aedf
+    redirectUri: http://localhost:27100
+    scopes: OR.Users
+`
+
+	stdIn := bytes.Buffer{}
+	stdIn.Write([]byte("\n\n\nb2f0fa8a-8a79-4733-b810-fe9989e39334\nhttp://new-url:8080\nOR.Machines\n"))
+
+	context := NewContextBuilder().
+		WithConfig(existingConfig).
+		WithConfigFile(configFile).
+		WithStdIn(stdIn).
+		Build()
+	runCli([]string{"config"}, context)
+
+	config, err := os.ReadFile(configFile)
+	if err != nil {
+		t.Errorf("Config file does not exist: %v", err)
+	}
+	expectedConfig := `profiles:
+- name: default
+  organization: my-org
+  tenant: my-tenant
+  auth:
+    clientId: b2f0fa8a-8a79-4733-b810-fe9989e39334
+    redirectUri: http://new-url:8080
+    scopes: OR.Machines
+`
+	if string(config) != expectedConfig {
+		t.Errorf("Expected generated config %v, but got %v", expectedConfig, string(config))
 	}
 }


### PR DESCRIPTION
`uipath config` will now provide an option to choose the type of authentication, e.g.

Enter organization [not set]: my-org
Enter tenant [not set]: my-tenant
Authentication type [not set]:
  [1] credentials - Client Id and Client Secret
  [2] login - OAuth login using the browser
  [3] pat - Personal Access Token
Select: 2
Enter client id [not set]: my-client-id
Enter redirect uri [not set]: http://localhost:12700 Enter scopes [not set]: OR.Users