### PR TITLE
Use uipath CLI without config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -480,6 +480,12 @@ You can either pass global arguments as CLI parameters, set an env variable or s
 | `--profile` | `UIPATH_PROFILE` | `string` | `default` | Use profile from configuration file |
 | `--query` | | `string` | | [JMESPath queries](https://jmespath.org/) for transforming the output |
 | `--uri` | `UIPATH_URI` | `uri` | `https://cloud.uipath.com` | URL override |
+| `--organization` | `UIPATH_ORGANIZATION` | `string` | | Organization name |
+| `--tenant` | `UIPATH_TENANT` | `string` | | Tenant name |
+| | `UIPATH_CLIENT_ID` | `string` | | Client Id |
+| | `UIPATH_CLIENT_SECRET` | `string` | | Client Secret |
+| | `UIPATH_PAT` | `string` | | Personal Access Token |
+
 
 ## FAQ
 

--- a/auth/pat_authenticator.go
+++ b/auth/pat_authenticator.go
@@ -2,7 +2,10 @@ package auth
 
 import (
 	"fmt"
+	"os"
 )
+
+const PatEnvVarName = "UIPATH_PAT"
 
 type PatAuthenticator struct{}
 
@@ -19,14 +22,17 @@ func (a PatAuthenticator) Auth(ctx AuthenticatorContext) AuthenticatorResult {
 }
 
 func (a PatAuthenticator) enabled(ctx AuthenticatorContext) bool {
-	return ctx.Config["pat"] != nil
+	return os.Getenv(PatEnvVarName) != "" || ctx.Config["pat"] != nil
 }
 
 func (a PatAuthenticator) getPat(ctx AuthenticatorContext) (string, error) {
-	return a.parseRequiredString(ctx.Config, "pat")
+	return a.parseRequiredString(ctx.Config, "pat", os.Getenv(PatEnvVarName))
 }
 
-func (a PatAuthenticator) parseRequiredString(config map[string]interface{}, name string) (string, error) {
+func (a PatAuthenticator) parseRequiredString(config map[string]interface{}, name string, override string) (string, error) {
+	if override != "" {
+		return override, nil
+	}
 	value := config[name]
 	result, valid := value.(string)
 	if !valid || result == "" {

--- a/commandline/command_builder.go
+++ b/commandline/command_builder.go
@@ -21,6 +21,8 @@ const insecureFlagName = "insecure"
 const debugFlagName = "debug"
 const profileFlagName = "profile"
 const uriFlagName = "uri"
+const organizationFlagName = "organization"
+const tenantFlagName = "tenant"
 const helpFlagName = "help"
 
 const outputFormatFlagName = "output"
@@ -331,6 +333,14 @@ func (b CommandBuilder) createOperationCommand(definition parser.Definition, ope
 			if err != nil {
 				return err
 			}
+			organization := context.String(organizationFlagName)
+			if organization == "" {
+				organization = config.Organization
+			}
+			tenant := context.String(tenantFlagName)
+			if tenant == "" {
+				tenant = config.Tenant
+			}
 			insecure := context.Bool(insecureFlagName) || config.Insecure
 			debug := context.Bool(debugFlagName) || config.Debug
 			parameters := executor.NewExecutionContextParameters(
@@ -340,8 +350,8 @@ func (b CommandBuilder) createOperationCommand(definition parser.Definition, ope
 				bodyParameters,
 				formParameters)
 			executionContext := executor.NewExecutionContext(
-				config.Organization,
-				config.Tenant,
+				organization,
+				tenant,
 				operation.Method,
 				baseUri,
 				operation.Route,
@@ -497,6 +507,8 @@ func (b CommandBuilder) createAutoCompleteCompleteCommand() *cli.Command {
 				"--" + helpFlagName,
 				"--" + outputFormatFlagName,
 				"--" + queryFlagName,
+				"--" + organizationFlagName,
+				"--" + tenantFlagName,
 			}
 			args := strings.Split(commandText, " ")
 			definitions, err := b.loadAutocompleteDefinitions(args)
@@ -623,6 +635,18 @@ func (b CommandBuilder) CreateDefaultFlags(hidden bool) []cli.Flag {
 			Name:    uriFlagName,
 			Usage:   "Server Base-URI",
 			EnvVars: []string{"UIPATH_URI"},
+			Hidden:  hidden,
+		},
+		&cli.StringFlag{
+			Name:    organizationFlagName,
+			Usage:   "Organization name",
+			EnvVars: []string{"UIPATH_ORGANIZATION"},
+			Hidden:  hidden,
+		},
+		&cli.StringFlag{
+			Name:    tenantFlagName,
+			Usage:   "Tenant name",
+			EnvVars: []string{"UIPATH_TENANT"},
 			Hidden:  hidden,
 		},
 		&cli.BoolFlag{


### PR DESCRIPTION
- Added `organization` and `tenant` arguments so they can be passed as part of the command instead of configuring the values in the profile.

- Organization and tenant can also be provided using the env variables:
  UIPATH_ORGANIZATION
  UIPATH_TENANT

- Added env variable support for clientId and clientSecret:
  UIPATH_CLIENT_ID
  UIPATH_CLIENT_SECRET

- Added env variable support for Personal Access Tokens:
  UIPATH_PAT

These features allow users to use the CLI without calling `uipath config`

e.g.

UIPATH_CLIENT_ID=my-client-id UIPATH_CLIENT_SECRET=my-client-secret uipath du metering ping --organization my-org --tenant my-tenant