### PR TITLE
Add support for configurable grant types

### DIFF
--- a/README.md
+++ b/README.md
@@ -503,6 +503,7 @@ profiles:
     auth:
       clientId: <your-client-id>
       clientSecret: <your-client-secret>
+    uri: https://sfdev1234567-cluster.infra-sf-ea.infra.uipath-dev.com
     insecure: true
 ```
 
@@ -510,6 +511,66 @@ And you simply call the CLI with the `--profile automationsuite` parameter:
 
 ```bash
 uipath du metering ping --profile automationsuite
+```
+
+### How to bootstrap a new on Automation Suite?
+
+As a prerequisite, you need to create a client secret on the server which allows grant type `password`. After that you can configure the CLI to retrieve bearer tokens for the `Host` admin user:
+
+```yaml
+profiles:
+  - name: automationsuite
+    organization: Host
+    auth:
+      clientId: <your-client-id>
+      clientSecret: <your-client-secret>
+      grantType: password
+      properties:
+        username: admin
+        password: <your-admin-password>
+        acr_values: tenant:Host
+    uri: https://sfdev1234567-cluster.infra-sf-ea.infra.uipath-dev.com
+    insecure: true
+```
+
+After that you can create a new organization:
+
+```bash
+uipath oms on-prem-organization create-organization-on-prem
+  --profile "automationsuite" \
+  --organization-name "testorg" \
+  --admin-email "test.user@uipath.com" \
+  --admin-user-name "testuser" \
+  --admin-first-name "Test" \
+  --admin-last-name "User" \
+  --admin-password "<your-testuser-password>" \
+  --language "en"
+```
+
+Once the organization has been created, you can create a new profile which uses the org admin:
+
+```yaml
+profiles:
+  - name: automationsuite_testorg
+    organization: testorg
+    auth:
+      clientId: <your-client-id>
+      clientSecret: <your-client-secret>
+      grantType: password
+      properties:
+        username: testuser
+        password: <your-testuser-password>
+        acr_values: tenant:<your-org-id>
+    uri: https://sfdev1234567-cluster.infra-sf-ea.infra.uipath-dev.com
+    insecure: true
+```
+
+The following command activates the new org:
+
+```bash
+uipath oms license activate \
+  --profile "automationsuite_testorg" \
+  --license "<your-license-code>"
 ```
 
 ### How to contribute?

--- a/auth/bearer_authenticator_config.go
+++ b/auth/bearer_authenticator_config.go
@@ -3,14 +3,20 @@ package auth
 import "net/url"
 
 type BearerAuthenticatorConfig struct {
+	GrantType    string
+	Scopes       string
 	ClientId     string
 	ClientSecret string
+	Properties   map[string]string
 	IdentityUri  *url.URL
 }
 
 func NewBearerAuthenticatorConfig(
+	grantType string,
+	scopes string,
 	clientId string,
 	clientSecret string,
+	properties map[string]string,
 	identityUri *url.URL) *BearerAuthenticatorConfig {
-	return &BearerAuthenticatorConfig{clientId, clientSecret, identityUri}
+	return &BearerAuthenticatorConfig{grantType, scopes, clientId, clientSecret, properties, identityUri}
 }

--- a/auth/token_request.go
+++ b/auth/token_request.go
@@ -5,18 +5,20 @@ import "net/url"
 type tokenRequest struct {
 	BaseUri      url.URL
 	GrantType    string
+	Scopes       string
 	ClientId     string
 	ClientSecret string
 	Code         string
 	CodeVerifier string
 	RedirectUri  string
+	Properties   map[string]string
 	Insecure     bool
 }
 
-func newClientCredentialTokenRequest(baseUri url.URL, clientId string, clientSecret string, insecure bool) *tokenRequest {
-	return &tokenRequest{baseUri, "client_credentials", clientId, clientSecret, "", "", "", insecure}
+func newTokenRequest(baseUri url.URL, grantType string, scopes string, clientId string, clientSecret string, properties map[string]string, insecure bool) *tokenRequest {
+	return &tokenRequest{baseUri, grantType, scopes, clientId, clientSecret, "", "", "", properties, insecure}
 }
 
 func newAuthorizationCodeTokenRequest(baseUri url.URL, clientId string, code string, codeVerifier string, redirectUrl string, insecure bool) *tokenRequest {
-	return &tokenRequest{baseUri, "authorization_code", clientId, "", code, codeVerifier, redirectUrl, insecure}
+	return &tokenRequest{baseUri, "authorization_code", "", clientId, "", code, codeVerifier, redirectUrl, map[string]string{}, insecure}
 }

--- a/definitions/oms.license.yaml
+++ b/definitions/oms.license.yaml
@@ -1,0 +1,28 @@
+openapi: 3.0.1
+info:
+  title: Organization Management Service API
+  version: "1.0"
+servers:
+  - url: https://cloud.uipath.com/{organization}/portal_
+    description: The production url
+    variables:
+      organization:
+        description: The organization name (or id)
+        default: my-org
+paths:
+  /api/license/management/activate/online/license/{license}:
+    put:
+      tags:
+        - License
+      operationId: Activate
+      parameters:
+        - name: license
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Success
+security:
+  - bearerAuth: []


### PR DESCRIPTION
- Extended the identity client to support different grant types and additional properties

- The beraer authenticator parses now grantType and properties from the config and passes them along to the get token call

This change allows us to use password grants (and other types) with custom properties attached, e.g.

```
profiles:
  - name: automationsuite 
    organization: Host 
    auth:
      clientId: <your-client-id>
      clientSecret: <your-client-secret>
      grantType: password
      properties:
        username: admin
        password: <your-admin-password>
        acr_values: tenant:Host
```