### PR TITLE
Implement command to set configuration values

### DIFF
--- a/commandline/command_builder.go
+++ b/commandline/command_builder.go
@@ -562,6 +562,9 @@ func (b CommandBuilder) createConfigCommand() *cli.Command {
 		Name:        "config",
 		Description: "Interactive command to configure the CLI",
 		Flags:       flags,
+		Subcommands: []*cli.Command{
+			b.createConfigSetCommand(),
+		},
 		Action: func(context *cli.Context) error {
 			auth := context.String(authFlagName)
 			profileName := context.String(profileFlagName)
@@ -571,6 +574,47 @@ func (b CommandBuilder) createConfigCommand() *cli.Command {
 				ConfigProvider: b.ConfigProvider,
 			}
 			return handler.Configure(auth, profileName)
+		},
+		HideHelp: true,
+	}
+}
+
+func (b CommandBuilder) createConfigSetCommand() *cli.Command {
+	keyFlagName := "key"
+	valueFlagName := "value"
+	flags := []cli.Flag{
+		&cli.StringFlag{
+			Name:     keyFlagName,
+			Usage:    "The key",
+			Required: true,
+		},
+		&cli.StringFlag{
+			Name:     valueFlagName,
+			Usage:    "The value to set",
+			Required: true,
+		},
+		&cli.StringFlag{
+			Name:    profileFlagName,
+			Usage:   "Profile to configure",
+			EnvVars: []string{"UIPATH_PROFILE"},
+			Value:   config.DefaultProfile,
+		},
+		b.HelpFlag(),
+	}
+	return &cli.Command{
+		Name:        "set",
+		Description: "Set config parameters",
+		Flags:       flags,
+		Action: func(context *cli.Context) error {
+			profileName := context.String(profileFlagName)
+			key := context.String(keyFlagName)
+			value := context.String(valueFlagName)
+			handler := ConfigCommandHandler{
+				StdIn:          b.StdIn,
+				StdOut:         b.StdOut,
+				ConfigProvider: b.ConfigProvider,
+			}
+			return handler.Set(key, value, profileName)
 		},
 		HideHelp: true,
 	}

--- a/config/config_provider.go
+++ b/config/config_provider.go
@@ -38,9 +38,15 @@ func (cp *ConfigProvider) Update(profileName string, config Config) error {
 			profile = p
 		}
 	}
+	profile.Uri = urlYaml{config.Uri}
+	profile.Insecure = config.Insecure
+	profile.Debug = config.Debug
 	profile.Organization = config.Organization
 	profile.Tenant = config.Tenant
 	profile.Auth = config.Auth.Config
+	profile.Header = config.Header
+	profile.Path = config.Path
+	profile.Query = config.Query
 
 	if index == -1 {
 		cp.profiles = append(cp.profiles, profile)

--- a/test/config_set_test.go
+++ b/test/config_set_test.go
@@ -1,0 +1,343 @@
+package test
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestConfigSetUnknownKey(t *testing.T) {
+	context := NewContextBuilder().
+		Build()
+
+	result := runCli([]string{"config", "set", "--key", "unknown", "--value", "my-value"}, context)
+
+	if result.StdErr != "Unknown config key 'unknown'\n" {
+		t.Errorf("Expected unknown config key error, but got %v", result.StdErr)
+	}
+}
+
+func TestConfigSetCreatesNewProfile(t *testing.T) {
+	configFile := createFile(t)
+	existingConfig := `profiles:
+- name: default
+  organization: initial-org
+`
+	context := NewContextBuilder().
+		WithConfig(existingConfig).
+		WithConfigFile(configFile).
+		Build()
+
+	runCli([]string{"config", "set", "--key", "organization", "--value", "my-org", "--profile", "new"}, context)
+
+	config, err := os.ReadFile(configFile)
+	if err != nil {
+		t.Errorf("Config file does not exist: %v", err)
+	}
+	expectedConfig := `profiles:
+- name: default
+  organization: initial-org
+- name: new
+  organization: my-org
+`
+	if string(config) != expectedConfig {
+		t.Errorf("Expected generated config %v, but got %v", expectedConfig, string(config))
+	}
+}
+
+func TestConfigSetUpdatesExistingProfile(t *testing.T) {
+	configFile := createFile(t)
+	existingConfig := `profiles:
+- name: existing
+  organization: initial-org
+`
+	context := NewContextBuilder().
+		WithConfig(existingConfig).
+		WithConfigFile(configFile).
+		Build()
+
+	runCli([]string{"config", "set", "--key", "organization", "--value", "updated-org", "--profile", "existing"}, context)
+
+	config, err := os.ReadFile(configFile)
+	if err != nil {
+		t.Errorf("Config file does not exist: %v", err)
+	}
+	expectedConfig := `profiles:
+- name: existing
+  organization: updated-org
+`
+	if string(config) != expectedConfig {
+		t.Errorf("Expected generated config %v, but got %v", expectedConfig, string(config))
+	}
+}
+
+func TestConfigSetOrganization(t *testing.T) {
+	configFile := createFile(t)
+	context := NewContextBuilder().
+		WithConfigFile(configFile).
+		Build()
+
+	runCli([]string{"config", "set", "--key", "organization", "--value", "my-org"}, context)
+
+	config, err := os.ReadFile(configFile)
+	if err != nil {
+		t.Errorf("Config file does not exist: %v", err)
+	}
+	expectedConfig := `profiles:
+- name: default
+  organization: my-org
+`
+	if string(config) != expectedConfig {
+		t.Errorf("Expected generated config %v, but got %v", expectedConfig, string(config))
+	}
+}
+
+func TestConfigSetTenant(t *testing.T) {
+	configFile := createFile(t)
+	context := NewContextBuilder().
+		WithConfigFile(configFile).
+		Build()
+
+	runCli([]string{"config", "set", "--key", "tenant", "--value", "my-tenant"}, context)
+
+	config, err := os.ReadFile(configFile)
+	if err != nil {
+		t.Errorf("Config file does not exist: %v", err)
+	}
+	expectedConfig := `profiles:
+- name: default
+  tenant: my-tenant
+`
+	if string(config) != expectedConfig {
+		t.Errorf("Expected generated config %v, but got %v", expectedConfig, string(config))
+	}
+}
+
+func TestConfigSetUri(t *testing.T) {
+	configFile := createFile(t)
+	context := NewContextBuilder().
+		WithConfigFile(configFile).
+		Build()
+
+	runCli([]string{"config", "set", "--key", "uri", "--value", "https://alpha.uipath.com"}, context)
+
+	config, err := os.ReadFile(configFile)
+	if err != nil {
+		t.Errorf("Config file does not exist: %v", err)
+	}
+	expectedConfig := `profiles:
+- name: default
+  uri: https://alpha.uipath.com
+`
+	if string(config) != expectedConfig {
+		t.Errorf("Expected generated config %v, but got %v", expectedConfig, string(config))
+	}
+}
+
+func TestConfigInvalidUri(t *testing.T) {
+	context := NewContextBuilder().
+		Build()
+
+	result := runCli([]string{"config", "set", "--key", "uri", "--value", "invalid uri\t"}, context)
+
+	if !strings.HasPrefix(result.StdErr, "Invalid value for 'uri'") {
+		t.Errorf("Expected invalid uri error, but got %v", result.StdErr)
+	}
+}
+
+func TestConfigSetInsecure(t *testing.T) {
+	configFile := createFile(t)
+	context := NewContextBuilder().
+		WithConfigFile(configFile).
+		Build()
+
+	runCli([]string{"config", "set", "--key", "insecure", "--value", "true"}, context)
+
+	config, err := os.ReadFile(configFile)
+	if err != nil {
+		t.Errorf("Config file does not exist: %v", err)
+	}
+	expectedConfig := `profiles:
+- name: default
+  insecure: true
+`
+	if string(config) != expectedConfig {
+		t.Errorf("Expected generated config %v, but got %v", expectedConfig, string(config))
+	}
+}
+
+func TestConfigSetDebug(t *testing.T) {
+	configFile := createFile(t)
+	context := NewContextBuilder().
+		WithConfigFile(configFile).
+		Build()
+
+	runCli([]string{"config", "set", "--key", "debug", "--value", "TRUE"}, context)
+
+	config, err := os.ReadFile(configFile)
+	if err != nil {
+		t.Errorf("Config file does not exist: %v", err)
+	}
+	expectedConfig := `profiles:
+- name: default
+  debug: true
+`
+	if string(config) != expectedConfig {
+		t.Errorf("Expected generated config %v, but got %v", expectedConfig, string(config))
+	}
+}
+
+func TestConfigInvalidInsecure(t *testing.T) {
+	context := NewContextBuilder().
+		Build()
+
+	result := runCli([]string{"config", "set", "--key", "insecure", "--value", "invalid"}, context)
+
+	if !strings.HasPrefix(result.StdErr, "Invalid value for 'insecure'") {
+		t.Errorf("Expected invalid insecure error, but got %v", result.StdErr)
+	}
+}
+
+func TestConfigInvalidDebug(t *testing.T) {
+	context := NewContextBuilder().
+		Build()
+
+	result := runCli([]string{"config", "set", "--key", "debug", "--value", "invalid"}, context)
+
+	if !strings.HasPrefix(result.StdErr, "Invalid value for 'debug'") {
+		t.Errorf("Expected invalid debug error, but got %v", result.StdErr)
+	}
+}
+
+func TestConfigSetHeader(t *testing.T) {
+	configFile := createFile(t)
+	context := NewContextBuilder().
+		WithConfigFile(configFile).
+		Build()
+
+	runCli([]string{"config", "set", "--key", "header.x-uipath-license", "--value", "my-api-key"}, context)
+
+	config, err := os.ReadFile(configFile)
+	if err != nil {
+		t.Errorf("Config file does not exist: %v", err)
+	}
+	expectedConfig := `profiles:
+- name: default
+  header:
+    x-uipath-license: my-api-key
+`
+	if string(config) != expectedConfig {
+		t.Errorf("Expected generated config %v, but got %v", expectedConfig, string(config))
+	}
+}
+
+func TestConfigSetPath(t *testing.T) {
+	configFile := createFile(t)
+	context := NewContextBuilder().
+		WithConfigFile(configFile).
+		Build()
+
+	runCli([]string{"config", "set", "--key", "path.org", "--value", "my-org"}, context)
+
+	config, err := os.ReadFile(configFile)
+	if err != nil {
+		t.Errorf("Config file does not exist: %v", err)
+	}
+	expectedConfig := `profiles:
+- name: default
+  path:
+    org: my-org
+`
+	if string(config) != expectedConfig {
+		t.Errorf("Expected generated config %v, but got %v", expectedConfig, string(config))
+	}
+}
+
+func TestConfigSetQuery(t *testing.T) {
+	configFile := createFile(t)
+	context := NewContextBuilder().
+		WithConfigFile(configFile).
+		Build()
+
+	runCli([]string{"config", "set", "--key", "query.filter", "--value", "my-filter"}, context)
+
+	config, err := os.ReadFile(configFile)
+	if err != nil {
+		t.Errorf("Config file does not exist: %v", err)
+	}
+	expectedConfig := `profiles:
+- name: default
+  query:
+    filter: my-filter
+`
+	if string(config) != expectedConfig {
+		t.Errorf("Expected generated config %v, but got %v", expectedConfig, string(config))
+	}
+}
+
+func TestConfigSetAuthGrantType(t *testing.T) {
+	configFile := createFile(t)
+	context := NewContextBuilder().
+		WithConfigFile(configFile).
+		Build()
+
+	runCli([]string{"config", "set", "--key", "auth.grantType", "--value", "password"}, context)
+
+	config, err := os.ReadFile(configFile)
+	if err != nil {
+		t.Errorf("Config file does not exist: %v", err)
+	}
+	expectedConfig := `profiles:
+- name: default
+  auth:
+    grantType: password
+`
+	if string(config) != expectedConfig {
+		t.Errorf("Expected generated config %v, but got %v", expectedConfig, string(config))
+	}
+}
+
+func TestConfigSetAuthScopes(t *testing.T) {
+	configFile := createFile(t)
+	context := NewContextBuilder().
+		WithConfigFile(configFile).
+		Build()
+
+	runCli([]string{"config", "set", "--key", "auth.scopes", "--value", "MyScope"}, context)
+
+	config, err := os.ReadFile(configFile)
+	if err != nil {
+		t.Errorf("Config file does not exist: %v", err)
+	}
+	expectedConfig := `profiles:
+- name: default
+  auth:
+    scopes: MyScope
+`
+	if string(config) != expectedConfig {
+		t.Errorf("Expected generated config %v, but got %v", expectedConfig, string(config))
+	}
+}
+
+func TestConfigSetAuthProperties(t *testing.T) {
+	configFile := createFile(t)
+	context := NewContextBuilder().
+		WithConfigFile(configFile).
+		Build()
+
+	runCli([]string{"config", "set", "--key", "auth.properties.acr_values", "--value", "tenant:host"}, context)
+
+	config, err := os.ReadFile(configFile)
+	if err != nil {
+		t.Errorf("Config file does not exist: %v", err)
+	}
+	expectedConfig := `profiles:
+- name: default
+  auth:
+    properties:
+      acr_values: tenant:host
+`
+	if string(config) != expectedConfig {
+		t.Errorf("Expected generated config %v, but got %v", expectedConfig, string(config))
+	}
+}


### PR DESCRIPTION
The `uipath config set` command allows users to update values in the configuration file, e.g.

Set the organization in the default profile:

`uipath config set --key "organization" --value "myorg"`

Create profile which uses the staging environment

`uipath config set --key "uri" --value "https://staging.uipath.com" --profile staging`