### PR TITLE
Retry failed HTTP requests

### DIFF
--- a/commandline/type_converter.go
+++ b/commandline/type_converter.go
@@ -173,9 +173,9 @@ func (c TypeConverter) convertToObjectArray(value string, parameter parser.Param
 }
 
 func (c TypeConverter) splitEscaped(str string, separator byte) []string {
-	var result []string
-	var item []byte
-	var escaping = false
+	result := []string{}
+	item := []byte{}
+	escaping := false
 	for i := 0; i < len(str); i++ {
 		char := str[i]
 		if char == '\\' && !escaping {

--- a/utils/progress_reader.go
+++ b/utils/progress_reader.go
@@ -18,7 +18,7 @@ type ProgressReader struct {
 	lastProgress time.Time
 }
 
-var debounceInterval = 100 * time.Nanosecond
+const debounceInterval = 100 * time.Nanosecond
 
 func (r *ProgressReader) Read(p []byte) (n int, err error) {
 	n, err = r.Reader.Read(p)

--- a/utils/retry.go
+++ b/utils/retry.go
@@ -1,0 +1,20 @@
+// Package utils contains command functionality which is reused across
+// multiple other packages.
+package utils
+
+import "time"
+
+const MaxAttempts = 3
+
+// Retries the given function up to 3 times when it returns an RetryableError.
+func Retry(f func() error) error {
+	var err error
+	for i := 1; ; i++ {
+		err = f()
+		_, retryable := err.(*RetryableError)
+		if !retryable || i == MaxAttempts {
+			return err
+		}
+		time.Sleep(1 * time.Second)
+	}
+}

--- a/utils/retryable_error.go
+++ b/utils/retryable_error.go
@@ -1,0 +1,15 @@
+package utils
+
+// RetryableError can be returned inside of the Retry() block to indicate
+// that the function failed and should be retried.
+type RetryableError struct {
+	err error
+}
+
+func (e RetryableError) Error() string {
+	return e.err.Error()
+}
+
+func Retryable(err error) *RetryableError {
+	return &RetryableError{err}
+}


### PR DESCRIPTION
- Added retry logic for sending HTTP requests

- Retrying up to 3 times when sending the request failed, the body could not be read or the service returned 5xx status code.