### PR TITLE
Use single enum value as default

### DIFF
--- a/parser/openapi_parser.go
+++ b/parser/openapi_parser.go
@@ -128,6 +128,9 @@ func (p OpenApiParser) parseSchema(fieldName string, schemaRef *openapi3.SchemaR
 		description = schemaRef.Value.Description
 		defaultValue = p.getDefaultValue(schemaRef.Value)
 		allowedValues = p.getAllowedValues(schemaRef.Value)
+		if required && defaultValue == nil && len(allowedValues) == 1 {
+			defaultValue = allowedValues[0]
+		}
 		propertiesSchemas := p.getPropertiesSchemas(schemaRef.Value)
 		parameters = p.parseSchemas(propertiesSchemas, in, schemaRef.Value.Required)
 	}
@@ -215,6 +218,9 @@ func (p OpenApiParser) parseParameter(param openapi3.Parameter) Parameter {
 	if param.Schema != nil {
 		defaultValue = p.getDefaultValue(param.Schema.Value)
 		allowedValues = p.getAllowedValues(param.Schema.Value)
+		if required && defaultValue == nil && len(allowedValues) == 1 {
+			defaultValue = allowedValues[0]
+		}
 		propertiesSchemas := p.getPropertiesSchemas(param.Schema.Value)
 		parameters = p.parseSchemas(propertiesSchemas, param.In, param.Schema.Value.Required)
 	}

--- a/test/parser_test.go
+++ b/test/parser_test.go
@@ -580,6 +580,36 @@ paths:
 	}
 }
 
+func TestHelpShowsParameterWithSingleEnumValueAsDefault(t *testing.T) {
+	definition := `
+paths:
+  /validate:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                myparameter:
+                  type: string
+                  description: This is my parameter
+                  enum:
+                  - '1'
+              required:
+                - myparameter
+`
+	context := NewContextBuilder().
+		WithDefinition("myservice", definition).
+		Build()
+
+	result := runCli([]string{"myservice", "post-validate", "--help"}, context)
+
+	expected := "This is my parameter (default: 1)"
+	if !strings.Contains(result.StdOut, expected) {
+		t.Errorf("stdout does not contain request body parameter, expected: %v, got: %v", expected, result.StdOut)
+	}
+}
+
 func TestParameterWithoutType(t *testing.T) {
 	definition := `
 paths:


### PR DESCRIPTION
Extend the parser to use the enum value as default in case there is only
one single value to choose from. This simplifies some use-cases where
the user does not need to specify a parameter explicitly in case there
is only one available option.