### PR TITLE
Support for url encoded request data

### DIFF
--- a/definitions/identity.token.yaml
+++ b/definitions/identity.token.yaml
@@ -1,0 +1,44 @@
+openapi: 3.0.1
+info:
+  title: IdentityServer Internal API
+  version: v1
+servers:
+  - url: https://cloud.uipath.com/identity_
+paths:
+  /connect/token:
+    post:
+      tags:
+        - Token
+      summary: Creates a new token
+      operationId: Create
+      requestBody:
+        content:
+          'application/x-www-form-urlencoded':
+            schema:
+              type: object
+              properties:
+                client_id: 
+                  description: The client id
+                  type: string
+                client_secret:
+                  description: The client secret
+                  type: string
+                grant_type:
+                  description: The grant type
+                  type: string
+                scope:
+                  description: The scopes
+                  type: string
+                username:
+                  description: The user name
+                  type: string
+                password:
+                  description: The user name
+                  type: string
+              required:
+                - client_id
+                - client_secret
+                - grant_type
+      responses:
+        "200":
+          description: Success

--- a/definitions/identity.yaml
+++ b/definitions/identity.yaml
@@ -3,7 +3,7 @@ info:
   title: IdentityServer Internal API
   version: v1
 servers:
-  - url: https://alpha.uipath.com/identity_
+  - url: https://cloud.uipath.com/identity_
 paths:
   /api/Account/Profile:
     get:

--- a/executor/type_formatter.go
+++ b/executor/type_formatter.go
@@ -43,7 +43,20 @@ func (f TypeFormatter) arrayToCommaSeparatedString(array interface{}) string {
 	}
 }
 
-func (f TypeFormatter) FormatQueryString(parameter ExecutionParameter) string {
+func (f TypeFormatter) FormatQueryString(parameters []ExecutionParameter) string {
+	result := ""
+	for _, parameter := range parameters {
+		param := f.formatQueryStringParam(parameter)
+		if result == "" {
+			result = param
+		} else {
+			result = result + "&" + param
+		}
+	}
+	return result
+}
+
+func (f TypeFormatter) formatQueryStringParam(parameter ExecutionParameter) string {
 	switch value := parameter.Value.(type) {
 	case []int:
 		return f.integerArrayToQueryString(parameter.Name, value)

--- a/parser/openapi_parser.go
+++ b/parser/openapi_parser.go
@@ -190,6 +190,11 @@ func (p OpenApiParser) parseRequestBodyParameters(requestBody *openapi3.RequestB
 		propertiesSchemas := p.getPropertiesSchemas(content.Schema.Value)
 		return "application/json", p.parseSchemas(propertiesSchemas, ParameterInBody, content.Schema.Value.Required)
 	}
+	content = requestBody.Value.Content.Get("application/x-www-form-urlencoded")
+	if content != nil {
+		propertiesSchemas := p.getPropertiesSchemas(content.Schema.Value)
+		return "application/x-www-form-urlencoded", p.parseSchemas(propertiesSchemas, ParameterInBody, content.Schema.Value.Required)
+	}
 	content = requestBody.Value.Content.Get("multipart/form-data")
 	if content != nil {
 		propertiesSchemas := p.getPropertiesSchemas(content.Schema.Value)

--- a/test/parser_test.go
+++ b/test/parser_test.go
@@ -1251,3 +1251,30 @@ paths:
 		t.Errorf("stdout contains operation from wrong category, expected: %v, got: %v", expected, result.StdOut)
 	}
 }
+
+func TestUrlEncodedParameterDescription(t *testing.T) {
+	definition := `
+paths:
+  /validate:
+    post:
+      operationId: validate
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              properties:
+                username:
+                  type: string
+                  description: The user name
+`
+	context := NewContextBuilder().
+		WithDefinition("myservice", definition).
+		Build()
+
+	result := runCli([]string{"myservice", "validate", "--help"}, context)
+
+	expected := "The user name"
+	if !strings.Contains(result.StdOut, expected) {
+		t.Errorf("stdout does not contain form parameter description, expected: %v, got: %v", expected, result.StdOut)
+	}
+}


### PR DESCRIPTION
- Added support for form urlencoded requests

Extended the parser to read body parameters for
application/x-www-form-urlencoded. Added support to the executor for converting body parameters to url encoded request bodies.

e.g. `client_id=...&client_secret=...`

- Added OpenAPI specification for create token operation

```
uipath identity token create --client-id "my-client-id" \
                             --client-secret "my-client-secret" \
                             --grant-type "client_credentials"
```