### PR TITLE
Simplify execution parameters

### DIFF
--- a/executor/execution_context.go
+++ b/executor/execution_context.go
@@ -18,7 +18,7 @@ type ExecutionContext struct {
 	Route        string
 	ContentType  string
 	Input        utils.Stream
-	Parameters   ExecutionContextParameters
+	Parameters   ExecutionParameters
 	AuthConfig   config.AuthConfig
 	Insecure     bool
 	Debug        bool
@@ -33,7 +33,7 @@ func NewExecutionContext(
 	route string,
 	contentType string,
 	input utils.Stream,
-	parameters ExecutionContextParameters,
+	parameters []ExecutionParameter,
 	authConfig config.AuthConfig,
 	insecure bool,
 	debug bool,

--- a/executor/execution_parameter.go
+++ b/executor/execution_parameter.go
@@ -6,8 +6,9 @@ package executor
 type ExecutionParameter struct {
 	Name  string
 	Value interface{}
+	In    string
 }
 
-func NewExecutionParameter(name string, value interface{}) *ExecutionParameter {
-	return &ExecutionParameter{name, value}
+func NewExecutionParameter(name string, value interface{}, in string) *ExecutionParameter {
+	return &ExecutionParameter{name, value, in}
 }

--- a/executor/execution_parameters.go
+++ b/executor/execution_parameters.go
@@ -1,0 +1,35 @@
+package executor
+
+import "github.com/UiPath/uipathcli/parser"
+
+type ExecutionParameters []ExecutionParameter
+
+func (p ExecutionParameters) Path() []ExecutionParameter {
+	return p.filter(parser.ParameterInPath)
+}
+
+func (p ExecutionParameters) Query() []ExecutionParameter {
+	return p.filter(parser.ParameterInQuery)
+}
+
+func (p ExecutionParameters) Header() []ExecutionParameter {
+	return p.filter(parser.ParameterInHeader)
+}
+
+func (p ExecutionParameters) Body() []ExecutionParameter {
+	return p.filter(parser.ParameterInBody)
+}
+
+func (p ExecutionParameters) Form() []ExecutionParameter {
+	return p.filter(parser.ParameterInForm)
+}
+
+func (p ExecutionParameters) filter(in string) []ExecutionParameter {
+	result := []ExecutionParameter{}
+	for _, p := range p {
+		if p.In == in {
+			result = append(result, p)
+		}
+	}
+	return result
+}

--- a/executor/plugin_executor.go
+++ b/executor/plugin_executor.go
@@ -38,20 +38,10 @@ func (e PluginExecutor) executeAuthenticators(baseUri url.URL, authConfig config
 func (e PluginExecutor) convertToPluginParameters(parameters []ExecutionParameter) []plugin.ExecutionParameter {
 	result := []plugin.ExecutionParameter{}
 	for _, parameter := range parameters {
-		name := parameter.Name
-		value := parameter.Value
-		result = append(result, *plugin.NewExecutionParameter(name, value))
+		param := plugin.NewExecutionParameter(parameter.Name, parameter.Value)
+		result = append(result, *param)
 	}
 	return result
-}
-
-func (e PluginExecutor) pluginParameters(context ExecutionContext) []plugin.ExecutionParameter {
-	params := context.Parameters.Path
-	params = append(params, context.Parameters.Query...)
-	params = append(params, context.Parameters.Header...)
-	params = append(params, context.Parameters.Body...)
-	params = append(params, context.Parameters.Form...)
-	return e.convertToPluginParameters(params)
 }
 
 func (e PluginExecutor) pluginAuth(auth *auth.AuthenticatorResult) plugin.AuthResult {
@@ -67,7 +57,7 @@ func (e PluginExecutor) Call(context ExecutionContext, writer output.OutputWrite
 	}
 
 	pluginAuth := e.pluginAuth(auth)
-	pluginParams := e.pluginParameters(context)
+	pluginParams := e.convertToPluginParameters(context.Parameters)
 	pluginContext := plugin.NewExecutionContext(
 		context.Organization,
 		context.Tenant,

--- a/executor/uri_formatter_test.go
+++ b/executor/uri_formatter_test.go
@@ -26,7 +26,7 @@ func TestAddsMissingSlashSeparator(t *testing.T) {
 func TestFormatPathReplacesPlaceholder(t *testing.T) {
 	formatter := newUriFormatter(toUrl("https://cloud.uipath.com"), "/{organization}/{tenant}/my-service")
 
-	formatter.FormatPath(*NewExecutionParameter("organization", "my-org"))
+	formatter.FormatPath(*NewExecutionParameter("organization", "my-org", "path"))
 
 	uri := formatter.Uri()
 	if uri != "https://cloud.uipath.com/my-org/{tenant}/my-service" {
@@ -37,8 +37,8 @@ func TestFormatPathReplacesPlaceholder(t *testing.T) {
 func TestFormatPathReplacesMultiplePlaceholders(t *testing.T) {
 	formatter := newUriFormatter(toUrl("https://cloud.uipath.com"), "/{organization}/{tenant}/my-service")
 
-	formatter.FormatPath(*NewExecutionParameter("organization", "my-org"))
-	formatter.FormatPath(*NewExecutionParameter("tenant", "my-tenant"))
+	formatter.FormatPath(*NewExecutionParameter("organization", "my-org", "path"))
+	formatter.FormatPath(*NewExecutionParameter("tenant", "my-tenant", "path"))
 
 	uri := formatter.Uri()
 	if uri != "https://cloud.uipath.com/my-org/my-tenant/my-service" {
@@ -67,7 +67,7 @@ func TestFormatPathDataTypes(t *testing.T) {
 func FormatPathDataTypes(t *testing.T, value interface{}, expected string) {
 	formatter := newUriFormatter(toUrl("https://cloud.uipath.com"), "/{param}")
 
-	formatter.FormatPath(*NewExecutionParameter("param", value))
+	formatter.FormatPath(*NewExecutionParameter("param", value, "path"))
 
 	uri := formatter.Uri()
 	if uri != "https://cloud.uipath.com/"+expected {
@@ -79,7 +79,7 @@ func TestAddQueryString(t *testing.T) {
 	formatter := newUriFormatter(toUrl("https://cloud.uipath.com"), "/my-service")
 
 	parameters := []ExecutionParameter{
-		*NewExecutionParameter("filter", "my-value"),
+		*NewExecutionParameter("filter", "my-value", "query"),
 	}
 	formatter.AddQueryString(parameters)
 
@@ -93,8 +93,8 @@ func TestAddMultipleQueryStringParameters(t *testing.T) {
 	formatter := newUriFormatter(toUrl("https://cloud.uipath.com"), "/my-service")
 
 	parameters := []ExecutionParameter{
-		*NewExecutionParameter("skip", 1),
-		*NewExecutionParameter("take", 5),
+		*NewExecutionParameter("skip", 1, "query"),
+		*NewExecutionParameter("take", 5, "query"),
 	}
 	formatter.AddQueryString(parameters)
 
@@ -126,7 +126,7 @@ func QueryStringDataTypes(t *testing.T, value interface{}, expected string) {
 	formatter := newUriFormatter(toUrl("https://cloud.uipath.com"), "/my-service")
 
 	parameters := []ExecutionParameter{
-		*NewExecutionParameter("param", value),
+		*NewExecutionParameter("param", value, "query"),
 	}
 	formatter.AddQueryString(parameters)
 


### PR DESCRIPTION
Keep a single list with all execution parameters instead of bucketing them in separate collections.