### PR TITLE
Handle parameters with same name

### DIFF
--- a/commandline/flag_builder.go
+++ b/commandline/flag_builder.go
@@ -1,0 +1,36 @@
+package commandline
+
+import (
+	"github.com/urfave/cli/v2"
+)
+
+type flagBuilder struct {
+	flags map[string]cli.Flag
+	order []string
+}
+
+func (b *flagBuilder) AddFlag(flag cli.Flag) {
+	name := flag.Names()[0]
+	if _, found := b.flags[name]; !found {
+		b.flags[name] = flag
+		b.order = append(b.order, name)
+	}
+}
+
+func (b *flagBuilder) AddFlags(flags []cli.Flag) {
+	for _, flag := range flags {
+		b.AddFlag(flag)
+	}
+}
+
+func (b flagBuilder) ToList() []cli.Flag {
+	flags := []cli.Flag{}
+	for _, name := range b.order {
+		flags = append(flags, b.flags[name])
+	}
+	return flags
+}
+
+func newFlagBuilder() *flagBuilder {
+	return &flagBuilder{map[string]cli.Flag{}, []string{}}
+}

--- a/test/execution_test.go
+++ b/test/execution_test.go
@@ -1361,3 +1361,39 @@ paths:
 		t.Errorf("Wrong data type conversion for url encoded data, expected: %v, got: %v", expected, result.RequestBody)
 	}
 }
+
+func TestSameParameterNameIsOnlyDefinedOnce(t *testing.T) {
+	definition := `
+paths:
+  /create/{my-param}:
+    get:
+      operationId: create
+      parameters:
+        - name: my-param
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                my-param:
+                  type: string
+`
+
+	context := NewContextBuilder().
+		WithDefinition("myservice", definition).
+		WithResponse(200, "").
+		Build()
+
+	result := RunCli([]string{"myservice", "create", "--my-param", "my-value"}, context)
+
+	if result.RequestUrl != "/create/my-value" {
+		t.Errorf("Expected parameter in request url, but got: %v", result.RequestUrl)
+	}
+	if result.RequestBody != `{"my-param":"my-value"}` {
+		t.Errorf("Expected parameter in request body, but got: %v", result.RequestBody)
+	}
+}


### PR DESCRIPTION
Only add parameters with the same name once as a flag. This does not handle all the cases where parameters are clashing and might even have different definitions and data types but fixes unexpected panics. The value of the argument will be passed for each parameter.