### PR TITLE
Add --wait flag to support waiting for conditions

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,8 +418,6 @@ uipath orchestrator users-get --query "sort_by(value, &CreationTime) | [-1].Name
 "Automation Developer"
 ```
 
-
-
 ## Debug
 
 You can set the environment variable `UIPATH_DEBUG=true` or pass the parameter `--debug` in order to see detailed output of the request and response messages:
@@ -445,6 +443,35 @@ Content-Type: application/json; charset=utf-8
   "version": "22.8-63-main.v29c916",
   "timestamp": "2022-08-23T12:23:19.0121688Z"
 }
+```
+
+## Wait for conditions
+
+You can specify JMESPath expressions on the response body to retry an operation until the provided condition evaluates to true. This allows you to write a sync call which waits for some backend operation to be carried out instead of polling manually.
+
+The following command adds the DocumentUnderstanding service to a tenant:
+
+```bash
+uipath oms tenant update-tenant --organization-guid "..." \
+                                --tenant-guid "..." \
+                                --services "du=true"
+```
+
+But the operation to add a service to the tenant is asynchronous and can take some time to complete. Instead of calling the `get-tenant` operation in a loop, you can use the `--wait` flag with a condition to wait for:
+
+```bash
+uipath oms tenant get-tenant --organization-guid "..." \
+                             --tenant-guid "..." \
+                             --wait "tenantServiceInstances[?serviceType == 'du'].status == 'Enabled'"
+```
+
+The default timeout is 30s but can be adjusted by providing the `--wait-timeout` flag, e.g.
+
+```bash
+uipath oms tenant get-tenant --organization-guid "..." \
+                             --tenant-guid "..." \
+                             --wait "tenantServiceInstances[?serviceType == 'du'].status == 'Enabled'" \
+                             --wait-timeout 300
 ```
 
 ## Multiple Profiles
@@ -503,6 +530,8 @@ You can either pass global arguments as CLI parameters, set an env variable or s
 | | `UIPATH_CLIENT_ID` | `string` | | Client Id |
 | | `UIPATH_CLIENT_SECRET` | `string` | | Client Secret |
 | | `UIPATH_PAT` | `string` | | Personal Access Token |
+| `--wait` | | `string` | | [JMESPath expression](https://jmespath.org/) to wait for |
+| `--wait-timeout` | | `integer` | 30 | Time in seconds until giving up waiting for condition  |
 
 
 ## FAQ

--- a/output/memory_output_writer.go
+++ b/output/memory_output_writer.go
@@ -1,0 +1,37 @@
+package output
+
+import (
+	"bytes"
+	"io"
+)
+
+// The MemoryOutputWriter keeps the response in memory so it can read
+// multiple times.
+type MemoryOutputWriter struct {
+	statusCode int
+	status     string
+	protocol   string
+	header     map[string][]string
+	body       []byte
+}
+
+func (w *MemoryOutputWriter) WriteResponse(response ResponseInfo) error {
+	w.statusCode = response.StatusCode
+	w.status = response.Status
+	w.protocol = response.Protocol
+	w.header = response.Header
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		return err
+	}
+	w.body = body
+	return nil
+}
+
+func (w MemoryOutputWriter) Response() ResponseInfo {
+	return *NewResponseInfo(w.statusCode, w.status, w.protocol, w.header, bytes.NewReader(w.body))
+}
+
+func NewMemoryOutputWriter() *MemoryOutputWriter {
+	return &MemoryOutputWriter{}
+}

--- a/test/wait_test.go
+++ b/test/wait_test.go
@@ -1,0 +1,154 @@
+package test
+
+import (
+	"testing"
+)
+
+func TestWaitNonBooleanExpressionReturnsError(t *testing.T) {
+	definition := `
+paths:
+  /ping:
+    get:
+      operationId: ping
+      summary: Simple ping
+`
+
+	context := NewContextBuilder().
+		WithDefinition("myservice", definition).
+		WithResponse(200, `{"version":1}`).
+		Build()
+
+	result := RunCli([]string{"myservice", "ping", "--wait", "version"}, context)
+
+	if result.Error.Error() != "Error in wait condition: JMESPath expression needs to return boolean" {
+		t.Errorf("Expected error that JMESPath needs to return boolean, but got: %v", result.Error)
+	}
+}
+func TestWaitInvalidExpressionReturnsError(t *testing.T) {
+	definition := `
+paths:
+  /ping:
+    get:
+      operationId: ping
+      summary: Simple ping
+`
+
+	context := NewContextBuilder().
+		WithDefinition("myservice", definition).
+		WithResponse(200, `{"version":1}`).
+		Build()
+
+	result := RunCli([]string{"myservice", "ping", "--wait", "invalid 2& expression"}, context)
+
+	if result.Error.Error() != "Error in query: SyntaxError: Unexpected token at the end of the expression: tNumber" {
+		t.Errorf("Expected error for invalid query, but got: %v", result.Error)
+	}
+}
+
+func TestWaitExpressionIsTrue(t *testing.T) {
+	definition := `
+paths:
+  /ping:
+    get:
+      operationId: ping
+      summary: Simple ping
+`
+
+	context := NewContextBuilder().
+		WithDefinition("myservice", definition).
+		WithResponse(200, `{"version":1}`).
+		Build()
+
+	result := RunCli([]string{"myservice", "ping", "--wait", "version == `1`"}, context)
+
+	if result.Error != nil {
+		t.Errorf("Unexpected error, got: %v", result.Error)
+	}
+	expectedOutput := `{
+  "version": 1
+}
+`
+	if result.StdOut != expectedOutput {
+		t.Errorf("Expected response body, but got: %v", result.StdOut)
+	}
+}
+
+func TestWaitForExpressionToBeTrue(t *testing.T) {
+	definition := `
+paths:
+  /ping:
+    get:
+      operationId: ping
+      summary: Simple ping
+`
+
+	context := NewContextBuilder().
+		WithDefinition("myservice", definition).
+		WithNextResponse(200, `{"version":1}`).
+		WithNextResponse(200, `{"version":1}`).
+		WithResponse(200, `{"version":2}`).
+		Build()
+
+	result := RunCli([]string{"myservice", "ping", "--wait", "version == `2`"}, context)
+
+	if result.Error != nil {
+		t.Errorf("Unexpected error, got: %v", result.Error)
+	}
+	expectedOutput := `{
+  "version": 2
+}
+`
+	if result.StdOut != expectedOutput {
+		t.Errorf("Expected response body, but got: %v", result.StdOut)
+	}
+}
+
+func TestWaitForExpressionPrintsStatusMessage(t *testing.T) {
+	definition := `
+paths:
+  /ping:
+    get:
+      operationId: ping
+      summary: Simple ping
+`
+
+	context := NewContextBuilder().
+		WithDefinition("myservice", definition).
+		WithNextResponse(200, `{"version":1}`).
+		WithNextResponse(200, `{"version":1}`).
+		WithResponse(200, `{"version":2}`).
+		Build()
+
+	result := RunCli([]string{"myservice", "ping", "--wait", "version == `2`"}, context)
+
+	if result.Error != nil {
+		t.Errorf("Unexpected error, got: %v", result.Error)
+	}
+	expected := `Condition is not met yet. Waiting...
+Condition is not met yet. Waiting...
+`
+	if result.StdErr != expected {
+		t.Errorf("Expected status message on standard error, but got: %v", result.StdErr)
+	}
+}
+
+func TestWaitForExpressionTimesOut(t *testing.T) {
+	definition := `
+paths:
+  /ping:
+    get:
+      operationId: ping
+      summary: Simple ping
+`
+
+	context := NewContextBuilder().
+		WithDefinition("myservice", definition).
+		WithResponse(200, `{"version":1}`).
+		Build()
+
+	result := RunCli([]string{"myservice", "ping", "--wait", "version == `2`", "--wait-timeout", "3"}, context)
+
+	if result.Error.Error() != "Timed out waiting for condition" {
+		t.Errorf("Expected timeout error, but got: %v", result.Error)
+	}
+}


### PR DESCRIPTION
Added a new `--wait` flag which allows users to specify a JMESPath expression on the response body. The uipathcli keeps calling the executor and retries the operation until the provided condition evaluates to true.

This feature allows customers of the CLI to write a sync call which waits for some backend operation to be carried out instead of polling manually in a loop.

e.g.

The following command adds the DocumentUnderstanding service to a tenant:
```
uipath oms tenant update-tenant --organization-guid "..." \
                                --tenant-guid "..." \
                                --services "du=true"
```

But the operation to add a service to the tenant is asynchronous and can take some time, but instead of polling, users can now write:

```
uipath oms tenant get-tenant --organization-guid "..." \
                             --tenant-guid "..." \
                             --wait "tenantServiceInstances[?serviceType == 'du'].status == 'Enabled'"
```

The CLI outputs:
Condition is not met yet. Waiting...

Until the operation timed out or the field status for the du serviceType is "Enabled".

The default timeout is 30s but can be adjusted by providing the `--wait-timeout` flag, e.g.

```
uipath oms tenant get-tenant --organization-guid "..." \
                             --tenant-guid "..." \
			     --wait "tenantServiceInstances[?serviceType == 'du'].status == 'Enabled'" \
                             --wait-timeout 300
```