### PR TITLE
Add support for JSON objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,19 +311,26 @@ uipath product create --name "new-product" --stock "5" --price "1.4" --deleted "
 
 ### Array arguments
 
-Array arguments can be passed as comma-separated strings and are automatically converted to arrays in the JSON body. The CLI supports string, integer, floating point, boolean arrays.
+Array arguments can be passed as comma-separated strings and are automatically converted to arrays in the JSON body. The CLI supports string, integer, floating point and boolean arrays.
 
 ```bash
 uipath product list --name-filter "my-product,new-product"
 ```
 
-You can also provide arrays by repeating parameters:
+You can also provide arrays by specifing the same parameter multiple times:
+
+```bash
+uipath product list --name-filter "my-product" --name-filter "new-product"
+```
+
+This also works for complex objects using the assignment notation or plain JSON:
 
 ```bash
 uipath app create --users "name=Administrator" --users "name=Guest"
+uipath app create --users '{"name": "Administrator"}' --users '{"name": "Guest"}'
 ```
 
-Object arrays are also supported and can be provided using the index operator `[integer]`, e.g.
+Object arrays are also supported and can be provided using the index operator `[0]`,`[1]`, `[2]`, ...
 
 ```bash
 uipath user create --auth "roles[0].name = admin; roles[1].name = user"
@@ -353,6 +360,12 @@ The command creates the following JSON body in the HTTP request:
   }
 }
 ```
+
+You can also specify JSON directly as an argument, e.g.:
+```bash
+uipath product create --product '{ "name": "my-product", "price": { "value": 340, "sale": { "discount": 10, "value": 306 } } }'
+```
+
 ### File Upload arguments
 
 CLI arguments can also refer to files on disk. This command reads the invoice from `/documents/invoice.pdf` and uploads it to the digitize endpoint:
@@ -447,6 +460,9 @@ Authorization: Bearer ...
 HTTP/1.1 200 OK
 Connection: keep-alive
 Content-Type: application/json; charset=utf-8
+
+{"location":"westeurope","serverRegion":"westeurope","clusterId":"du-prod-du-we-g-dns","version":"22.8-63-main.v29c916","timestamp":"2022-08-23T12:23:19.0121688Z"}
+
 
 {
   "location": "westeurope",

--- a/commandline/type_converter.go
+++ b/commandline/type_converter.go
@@ -1,6 +1,7 @@
 package commandline
 
 import (
+	"encoding/json"
 	"fmt"
 	"strconv"
 	"strings"
@@ -163,7 +164,21 @@ func (c typeConverter) initArray(name string, value interface{}, index int) ([]i
 	return c.initArrayItem(array, index)
 }
 
+func (c typeConverter) convertJsonToObject(value string) (interface{}, error) {
+	var data interface{}
+	err := json.Unmarshal([]byte(value), &data)
+	if err != nil {
+		return nil, err
+	}
+	return data, nil
+}
+
 func (c typeConverter) convertToObject(value string, parameter parser.Parameter) (interface{}, error) {
+	data, err := c.convertJsonToObject(value)
+	if err == nil {
+		return data, nil
+	}
+
 	obj := map[string]interface{}{}
 	assigns := c.splitEscaped(value, ';')
 	for _, assign := range assigns {

--- a/test/execution_test.go
+++ b/test/execution_test.go
@@ -1523,3 +1523,57 @@ components:
 		t.Errorf("Object type with custom parameter name not found in request body, expected: %v, but got: %v", expected, result.RequestBody)
 	}
 }
+
+func TestJsonInputForObjectType(t *testing.T) {
+	definition := `
+paths:
+  /validate:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                myparameter:
+                  type: object
+`
+	context := NewContextBuilder().
+		WithResponse(200, "{}").
+		WithDefinition("myservice", definition).
+		Build()
+
+	result := RunCli([]string{"myservice", "post-validate", "--myparameter", `{ "hello": "world" }`}, context)
+
+	expected := `{"myparameter":{"hello":"world"}}`
+	if result.RequestBody != expected {
+		t.Errorf("Did not find json object in request body, expected: %v, got: %v", expected, result.RequestBody)
+	}
+}
+
+func TestMultipleJsonObjectArgumentsForObjectArrayType(t *testing.T) {
+	definition := `
+paths:
+  /validate:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                myparameter:
+                  type: array
+                  items:
+                    type: object
+`
+	context := NewContextBuilder().
+		WithResponse(200, "{}").
+		WithDefinition("myservice", definition).
+		Build()
+
+	result := RunCli([]string{"myservice", "post-validate", "--myparameter", `{ "foo": 1 }`, "--myparameter", `{ "bar": 2 }`}, context)
+
+	expected := `{"myparameter":[{"foo":1},{"bar":2}]}`
+	if result.RequestBody != expected {
+		t.Errorf("Did not find json object in request body, expected: %v, got: %v", expected, result.RequestBody)
+	}
+}


### PR DESCRIPTION
Extend the type converter to handle JSON data for nested object parameters or object arrays.

This allows users to specify plain JSON for input arguments, e.g.

`uipath product create --product '{ "name": "my-product", "price": { "value": 340 } }'`

The command creates the following JSON body in the HTTP request:

```
{
  "product": {
    "name": "my-product",
    "price": {
      "value": 340
    }
  }
}
```