### PR TITLE
Add support for multiple service definition versions

### DIFF
--- a/commandline/config_command_handler.go
+++ b/commandline/config_command_handler.go
@@ -47,7 +47,10 @@ func (h ConfigCommandHandler) Set(key string, value string, profileName string) 
 
 func (h ConfigCommandHandler) setConfigValue(config *config.Config, key string, value string) error {
 	keyParts := strings.Split(key, ".")
-	if key == "organization" {
+	if key == "version" {
+		config.SetVersion(value)
+		return nil
+	} else if key == "organization" {
 		config.ConfigureOrgTenant(value, "")
 		return nil
 	} else if key == "tenant" {

--- a/commandline/definition_data.go
+++ b/commandline/definition_data.go
@@ -2,10 +2,11 @@ package commandline
 
 // DefinitionData contains the name of the definition file and its data.
 type DefinitionData struct {
-	Name string
-	Data []byte
+	Name    string
+	Version string
+	Data    []byte
 }
 
-func NewDefinitionData(name string, data []byte) *DefinitionData {
-	return &DefinitionData{name, data}
+func NewDefinitionData(name string, version string, data []byte) *DefinitionData {
+	return &DefinitionData{name, version, data}
 }

--- a/commandline/definition_provider.go
+++ b/commandline/definition_provider.go
@@ -28,8 +28,8 @@ type DefinitionProvider struct {
 	commandPlugins []plugin.CommandPlugin
 }
 
-func (p DefinitionProvider) Index() ([]parser.Definition, error) {
-	emptyDefinitions, err := p.loadEmptyDefinitions()
+func (p DefinitionProvider) Index(version string) ([]parser.Definition, error) {
+	emptyDefinitions, err := p.loadEmptyDefinitions(version)
 	if err != nil {
 		return nil, err
 	}
@@ -44,15 +44,15 @@ func (p DefinitionProvider) Index() ([]parser.Definition, error) {
 	return result, nil
 }
 
-func (p DefinitionProvider) Load(name string) (*parser.Definition, error) {
-	names, err := p.store.Names()
+func (p DefinitionProvider) Load(name string, version string) (*parser.Definition, error) {
+	names, err := p.store.Names(version)
 	if err != nil {
 		return nil, err
 	}
 	definitions := []*parser.Definition{}
 	for _, n := range names {
 		if p.getServiceName(n) == name {
-			data, err := p.store.Read(n)
+			data, err := p.store.Read(n, version)
 			if err != nil {
 				return nil, err
 			}
@@ -86,8 +86,8 @@ func (p DefinitionProvider) getServiceName(name string) string {
 	return name
 }
 
-func (p DefinitionProvider) loadEmptyDefinitions() ([]DefinitionData, error) {
-	names, err := p.store.Names()
+func (p DefinitionProvider) loadEmptyDefinitions(version string) ([]DefinitionData, error) {
+	names, err := p.store.Names(version)
 	if err != nil {
 		return nil, err
 	}
@@ -95,7 +95,7 @@ func (p DefinitionProvider) loadEmptyDefinitions() ([]DefinitionData, error) {
 	for _, name := range names {
 		serviceName := p.getServiceName(name)
 		if len(result) == 0 || result[len(result)-1].Name != serviceName {
-			result = append(result, *NewDefinitionData(serviceName, []byte{}))
+			result = append(result, *NewDefinitionData(serviceName, version, []byte{}))
 		}
 	}
 	return result, nil

--- a/commandline/definition_store.go
+++ b/commandline/definition_store.go
@@ -2,6 +2,6 @@ package commandline
 
 // DefinitionStore is used to provide the names and content of definition files.
 type DefinitionStore interface {
-	Names() ([]string, error)
-	Read(name string) (*DefinitionData, error)
+	Names(version string) ([]string, error)
+	Read(name string, version string) (*DefinitionData, error)
 }

--- a/config/config.go
+++ b/config/config.go
@@ -19,6 +19,7 @@ type Config struct {
 	Insecure     bool
 	Debug        bool
 	Output       string
+	Version      string
 }
 
 // AuthConfig with metadata used for authenticating the caller.
@@ -171,4 +172,8 @@ func (c Config) SetAuthProperty(key string, value string) {
 	}
 	properties[key] = value
 	c.Auth.Config["properties"] = properties
+}
+
+func (c *Config) SetVersion(version string) {
+	c.Version = version
 }

--- a/config/config_provider.go
+++ b/config/config_provider.go
@@ -48,6 +48,7 @@ func (p *ConfigProvider) Update(profileName string, config Config) error {
 	profile.Header = config.Header
 	profile.Path = config.Path
 	profile.Query = config.Query
+	profile.Version = config.Version
 
 	if index == -1 {
 		p.profiles = append(p.profiles, profile)
@@ -89,6 +90,7 @@ func (p ConfigProvider) convertToConfig(profile profileYaml) Config {
 		Insecure: profile.Insecure,
 		Debug:    profile.Debug,
 		Output:   profile.Output,
+		Version:  profile.Version,
 	}
 }
 

--- a/config/profile_yaml.go
+++ b/config/profile_yaml.go
@@ -12,4 +12,5 @@ type profileYaml struct {
 	Insecure     bool                   `yaml:"insecure,omitempty"`
 	Debug        bool                   `yaml:"debug,omitempty"`
 	Output       string                 `yaml:"output,omitempty"`
+	Version      string                 `yaml:"version,omitempty"`
 }

--- a/test/config_set_test.go
+++ b/test/config_set_test.go
@@ -341,3 +341,24 @@ func TestConfigSetAuthProperties(t *testing.T) {
 		t.Errorf("Expected generated config %v, but got %v", expectedConfig, string(config))
 	}
 }
+
+func TestConfigSetVersion(t *testing.T) {
+	configFile := createFile(t)
+	context := NewContextBuilder().
+		WithConfigFile(configFile).
+		Build()
+
+	RunCli([]string{"config", "set", "--key", "version", "--value", "22.10"}, context)
+
+	config, err := os.ReadFile(configFile)
+	if err != nil {
+		t.Errorf("Config file does not exist: %v", err)
+	}
+	expectedConfig := `profiles:
+- name: default
+  version: "22.10"
+`
+	if string(config) != expectedConfig {
+		t.Errorf("Expected generated config %v, but got %v", expectedConfig, string(config))
+	}
+}

--- a/test/parser_test.go
+++ b/test/parser_test.go
@@ -1296,3 +1296,115 @@ paths:
 		t.Errorf("stdout does not contain form parameter description, expected: %v, got: %v", expected, result.StdOut)
 	}
 }
+
+func TestShowsSpecifiedVersionServiceDefinition(t *testing.T) {
+	definition := `
+paths:
+  /ping:
+    get:
+      operationId: ping-v1
+`
+	definition2_0 := `
+paths:
+  /ping:
+    get:
+      operationId: ping-v2
+`
+	context := NewContextBuilder().
+		WithDefinition("myservice", definition).
+		WithDefinitionVersion("myversionedservice", "2.0", definition2_0).
+		Build()
+
+	result := RunCli([]string{"--version", "2.0", "--help"}, context)
+
+	if !strings.Contains(result.StdOut, "myversionedservice") {
+		t.Errorf("Could not find versioned service definition, but got: %v", result.StdOut)
+	}
+	if strings.Contains(result.StdOut, "myservice") {
+		t.Errorf("Should not parse default service definitions, but got: %v", result.StdOut)
+	}
+}
+
+func TestShowsDefaultVersionServiceDefinitions(t *testing.T) {
+	definition := `
+paths:
+  /ping:
+    get:
+      operationId: ping-v1
+`
+	definition2_0 := `
+paths:
+  /ping:
+    get:
+      operationId: ping-v2
+`
+	context := NewContextBuilder().
+		WithDefinition("myservice", definition).
+		WithDefinitionVersion("myversionedservice", "2.0", definition2_0).
+		Build()
+
+	result := RunCli([]string{"--help"}, context)
+
+	if !strings.Contains(result.StdOut, "myservice") {
+		t.Errorf("Could not find default service definition, but got: %v", result.StdOut)
+	}
+	if strings.Contains(result.StdOut, "myversionedservice") {
+		t.Errorf("Should not parse versioned service definitions, but got: %v", result.StdOut)
+	}
+}
+
+func TestShowsSpecifiedVersionServiceOperations(t *testing.T) {
+	definition := `
+paths:
+  /ping:
+    get:
+      operationId: ping-v1
+`
+	definition2_0 := `
+paths:
+  /ping:
+    get:
+      operationId: ping-v2
+`
+	context := NewContextBuilder().
+		WithDefinition("myservice", definition).
+		WithDefinitionVersion("myversionedservice", "2.0", definition2_0).
+		Build()
+
+	result := RunCli([]string{"myversionedservice", "--version", "2.0", "--help"}, context)
+
+	if !strings.Contains(result.StdOut, "ping-v2") {
+		t.Errorf("Could not find versioned service operation, but got: %v", result.StdOut)
+	}
+	if strings.Contains(result.StdOut, "ping-v1") {
+		t.Errorf("Should not parse default service operation, but got: %v", result.StdOut)
+	}
+}
+
+func TestShowsDefaultVersionServiceOperations(t *testing.T) {
+	definition := `
+paths:
+  /ping:
+    get:
+      operationId: ping-v1
+`
+	definition2_0 := `
+paths:
+  /ping:
+    get:
+      operationId: ping-v2
+`
+	context := NewContextBuilder().
+		WithDefinition("myservice", definition).
+		WithDefinitionVersion("myversionedservice", "2.0", definition2_0).
+		Build()
+
+	result := RunCli([]string{"myservice", "--help"}, context)
+
+	if !strings.Contains(result.StdOut, "ping-v1") {
+		t.Errorf("Could not find default service operation, but got: %v", result.StdOut)
+	}
+	if strings.Contains(result.StdOut, "ping-v2") {
+		t.Errorf("Should not parse versioned service operation, but got: %v", result.StdOut)
+	}
+}

--- a/test/setup.go
+++ b/test/setup.go
@@ -36,7 +36,13 @@ func NewContextBuilder() *ContextBuilder {
 }
 
 func (b *ContextBuilder) WithDefinition(name string, data string) *ContextBuilder {
-	definitionData := commandline.NewDefinitionData(name, []byte(data))
+	definitionData := commandline.NewDefinitionData(name, "", []byte(data))
+	b.context.Definitions = append(b.context.Definitions, *definitionData)
+	return b
+}
+
+func (b *ContextBuilder) WithDefinitionVersion(name string, version string, data string) *ContextBuilder {
+	definitionData := commandline.NewDefinitionData(name, version, []byte(data))
 	b.context.Definitions = append(b.context.Definitions, *definitionData)
 	return b
 }
@@ -189,17 +195,13 @@ func RunCli(args []string, context Context) Result {
 		commandPlugins = append(commandPlugins, context.CommandPlugin)
 	}
 
-	definitionFiles := []string{}
-	for _, data := range context.Definitions {
-		definitionFiles = append(definitionFiles, data.Name+".yaml")
-	}
 	cli := commandline.NewCli(
 		context.StdIn,
 		stdout,
 		stderr,
 		false,
 		*commandline.NewDefinitionProvider(
-			commandline.NewDefinitionFileStoreWithData(definitionFiles, context.Definitions),
+			commandline.NewDefinitionFileStoreWithData(context.Definitions),
 			parser.NewOpenApiParser(),
 			commandPlugins,
 		),


### PR DESCRIPTION
Added `--version` parameter to uipathcli which allows targeting specific version of the service definitions. When specified the cli will read the service definitions from a sub folder inside of the definitions/ folder.

Also extended the `uipath config set` command to allow pinning the profile to a specific version of service definitions. This allows configuring a dedicated automation suite profile, e.g.

```
profiles:
- name: as-2022.10
   uri: ...
   version: 2022.10
```