### PR TITLE
Add argument to disable reading from standard input

### DIFF
--- a/commandline/definition_provider.go
+++ b/commandline/definition_provider.go
@@ -142,7 +142,7 @@ func (p DefinitionProvider) convertToParameters(parameters []plugin.CommandParam
 			p.Name,
 			p.Type,
 			p.Description,
-			parser.ParameterInBody,
+			parser.ParameterInCustom,
 			p.Name,
 			p.Required,
 			nil,

--- a/parser/parameter.go
+++ b/parser/parameter.go
@@ -33,6 +33,7 @@ const (
 	ParameterInHeader = "header"
 	ParameterInBody   = "body"
 	ParameterInForm   = "form"
+	ParameterInCustom = "custom"
 )
 
 func (p Parameter) IsArray() bool {


### PR DESCRIPTION
Added a new argument `--disable-stdin` to instruct the CLI to ignore any data on standard input and use the parameters instead.