### PR TITLE
Use dash to reference standard input

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -128,7 +128,7 @@ go tool cover --html=coverage.out
 The CLI supports a pluggable infrastructure which allows you to implement complex custom commands. The [`DigitizeCommand`](plugin/digitizer/digitize_command.go) is an example for a custom command which abstracts away the complexity of the async digitization API. The digitizer API requires you to upload a file, followed by polling the status API until the digitization finished in order to retrieve the digitization result. The `DigitizeCommand` allows the user to just invoke one command for uploading the file and retrieving the result:
 
 ```bash
-uipath digitizer digitize --file documents/invoice.pdf
+uipath du digitizer digitize --file documents/invoice.pdf
 ```
 
 returns

--- a/README.md
+++ b/README.md
@@ -368,18 +368,18 @@ uipath product create --product '{ "name": "my-product", "price": { "value": 340
 
 ### File Upload arguments
 
-CLI arguments can also refer to files on disk. This command reads the invoice from `/documents/invoice.pdf` and uploads it to the digitize endpoint:
+You can upload a file on disk using the `--file` argument. The following command reads the invoice from `documents/invoice.pdf` and uploads it to the digitize endpoint:
 
 ```bash
-uipath digitizer digitize ---file documents/invoice.pdf
+uipath du digitizer digitize --file documents/invoice.pdf
 ```
 
 ## Standard input (stdin) / Pipes
 
-You can pipe JSON into the CLI as stdin and it will be used as the request body instead of CLI parameters. The following example reads an orchestrator setting, modifies the value using `jq` and pipes the output back into to the CLI to update it:
+You can pipe JSON or any other input into the CLI as stdin and it will be used as the request body when the `--file -` argument was provided:
 
 ```bash
-uipath orchestrator settings-get | jq '.value[] | select(.Id == "Alerts.Email.Enabled") | .Value = "FALSE"' | uipath orchestrator settings-putbyid
+echo '{"hello":"world"}' | uipath du storage upload --object-key "my-data" --file -
 ```
 
 ## Output formats

--- a/executor/http_executor.go
+++ b/executor/http_executor.go
@@ -64,9 +64,8 @@ func (e HttpExecutor) calculateMultipartSize(parameters []ExecutionParameter) in
 		case string:
 			result = result + int64(len(v))
 		case utils.Stream:
-			data, size, err := v.Data()
+			size, err := v.Size()
 			if err == nil {
-				defer data.Close()
 				result = result + size
 			}
 		}
@@ -91,7 +90,7 @@ func (e HttpExecutor) writeMultipartForm(writer *multipart.Writer, parameters []
 			if err != nil {
 				return fmt.Errorf("Error writing form file '%s': %w", parameter.Name, err)
 			}
-			data, _, err := v.Data()
+			data, err := v.Data()
 			if err != nil {
 				return err
 			}
@@ -193,7 +192,7 @@ func (e HttpExecutor) writeMultipartBody(bodyWriter *io.PipeWriter, parameters [
 func (e HttpExecutor) writeInputBody(bodyWriter *io.PipeWriter, input utils.Stream, errorChan chan error) {
 	go func() {
 		defer bodyWriter.Close()
-		data, _, err := input.Data()
+		data, err := input.Data()
 		if err != nil {
 			errorChan <- err
 			return

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.20
 require (
 	github.com/getkin/kin-openapi v0.115.0
 	github.com/jmespath/go-jmespath v0.4.0
-	github.com/mattn/go-isatty v0.0.18
 	github.com/urfave/cli/v2 v2.25.1
 	golang.org/x/sys v0.6.0
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -35,8 +35,6 @@ github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN
 github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
-github.com/mattn/go-isatty v0.0.18 h1:DOKFKCQ7FNG2L1rbrmstDN4QVRdS89Nkh85u68Uwp98=
-github.com/mattn/go-isatty v0.0.18/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 h1:RWengNIwukTxcDr9M+97sNutRR1RKhG96O6jWumTTnw=
 github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826/go.mod h1:TaXosZuwdSHYgviHp1DAtfrULt5eUgsSMsZf+YrPgl8=
 github.com/perimeterx/marshmallow v1.1.4 h1:pZLDH9RjlLGGorbXhcaQLhfuV0pFMNfPO55FuFkxqLw=

--- a/main.go
+++ b/main.go
@@ -8,8 +8,6 @@ import (
 	"os"
 	"runtime"
 
-	"github.com/mattn/go-isatty"
-
 	"github.com/UiPath/uipathcli/auth"
 	"github.com/UiPath/uipathcli/cache"
 	"github.com/UiPath/uipathcli/commandline"
@@ -44,13 +42,6 @@ func colorsSupported() bool {
 }
 
 func stdIn() utils.Stream {
-	f, err := os.Stdin.Stat()
-	if err != nil {
-		return nil
-	}
-	if f.Mode()&os.ModeNamedPipe == 0 || isatty.IsTerminal(os.Stdin.Fd()) || isatty.IsCygwinTerminal(os.Stdin.Fd()) {
-		return nil
-	}
 	return utils.NewReaderStream(parser.RawBodyParameterName, os.Stdin)
 }
 

--- a/parser/openapi_parser.go
+++ b/parser/openapi_parser.go
@@ -9,7 +9,7 @@ import (
 )
 
 const DefaultServerBaseUrl = "https://cloud.uipath.com"
-const RawBodyParameterName = "$input"
+const RawBodyParameterName = "$file"
 const CustomParameterNameExtension = "x-name"
 
 // The OpenApiParser parses OpenAPI (2.x and 3.x) specifications.

--- a/plugin/digitizer/digitize_command.go
+++ b/plugin/digitizer/digitize_command.go
@@ -197,10 +197,7 @@ func (c DigitizeCommand) createDigitizeStatusRequest(operationId string, context
 }
 
 func (c DigitizeCommand) calculateMultipartSize(stream utils.Stream) int64 {
-	data, size, err := stream.Data()
-	if err == nil {
-		defer data.Close()
-	}
+	size, _ := stream.Size()
 	return size
 }
 
@@ -212,7 +209,7 @@ func (c DigitizeCommand) writeMultipartForm(writer *multipart.Writer, stream uti
 	if err != nil {
 		return fmt.Errorf("Error creating form field 'file': %w", err)
 	}
-	data, _, err := stream.Data()
+	data, err := stream.Data()
 	if err != nil {
 		return err
 	}

--- a/plugin/digitizer/digitizer_plugin_test.go
+++ b/plugin/digitizer/digitizer_plugin_test.go
@@ -221,7 +221,7 @@ paths:
 		WithUrlResponse("/my-org/my-tenant/du_/api/digitizer/digitize/result/eb80e441-05de-4a13-9aaa-f65b1babba05?api-version=1", 200, `{"status":"Done"}`).
 		Build()
 
-	result := test.RunCli([]string{"du", "digitization", "digitize", "--content-type", "application/pdf"}, context)
+	result := test.RunCli([]string{"du", "digitization", "digitize", "--content-type", "application/pdf", "--file", "-"}, context)
 
 	expectedResult := `{
   "status": "Done"

--- a/plugin/orchestrator/upload_command.go
+++ b/plugin/orchestrator/upload_command.go
@@ -93,7 +93,7 @@ func (c UploadCommand) createUploadRequest(context plugin.ExecutionContext, url 
 func (c UploadCommand) writeBody(bodyWriter *io.PipeWriter, input utils.Stream, errorChan chan error) (string, int64) {
 	go func() {
 		defer bodyWriter.Close()
-		data, _, err := input.Data()
+		data, err := input.Data()
 		if err != nil {
 			errorChan <- err
 			return
@@ -105,10 +105,7 @@ func (c UploadCommand) writeBody(bodyWriter *io.PipeWriter, input utils.Stream, 
 			return
 		}
 	}()
-	data, size, err := input.Data()
-	if err == nil {
-		defer data.Close()
-	}
+	size, _ := input.Size()
 	return "application/octet-stream", size
 }
 

--- a/test/execution_test.go
+++ b/test/execution_test.go
@@ -1101,7 +1101,7 @@ paths:
 		WithResponse(200, "").
 		Build()
 
-	result := RunCli([]string{"myservice", "create"}, context)
+	result := RunCli([]string{"myservice", "create", "--file", "-"}, context)
 
 	expected := `{"firstName":"foo"}`
 	if result.RequestBody != expected {
@@ -1130,7 +1130,7 @@ paths:
 		WithResponse(200, "").
 		Build()
 
-	result := RunCli([]string{"myservice", "create", "--x-uipath-myvalue", "test-value"}, context)
+	result := RunCli([]string{"myservice", "create", "--x-uipath-myvalue", "test-value", "--file", "-"}, context)
 
 	expectedBody := `{"foo":"bar"}`
 	if result.RequestBody != expectedBody {
@@ -1174,39 +1174,6 @@ paths:
 	}
 }
 
-func TestPostRequestWithStdInAndDisableStdInFlagIgnoresStdIn(t *testing.T) {
-	definition := `
-paths:
-  /create:
-    post:
-      operationId: create
-      requestBody:
-        content:
-          application/json:
-            schema:
-              properties:
-                firstName:
-                  type: string
-                  default: test
-              required:
-                - firstName
-`
-	stdIn := bytes.Buffer{}
-	stdIn.Write([]byte(`{"foo":"bar"}`))
-	context := NewContextBuilder().
-		WithDefinition("myservice", definition).
-		WithStdIn(stdIn).
-		WithResponse(200, "").
-		Build()
-
-	result := RunCli([]string{"myservice", "create", "--disable-stdin"}, context)
-
-	expectedBody := `{"firstName":"test"}`
-	if result.RequestBody != expectedBody {
-		t.Errorf("Invalid json request body, expected: %v, got: %v", expectedBody, result.RequestBody)
-	}
-}
-
 func TestPostWithFileAsRawRequestBody(t *testing.T) {
 	definition := `
 paths:
@@ -1228,7 +1195,7 @@ paths:
 
 	path := createFile(t)
 	writeFile(t, path, []byte("hello-world"))
-	result := RunCli([]string{"myservice", "upload", "--input", path}, context)
+	result := RunCli([]string{"myservice", "upload", "--file", path}, context)
 
 	contentType := result.RequestHeader["content-type"]
 	if contentType != "application/octet-stream" {
@@ -1263,7 +1230,7 @@ paths:
 
 	currentPath, _ := os.Getwd()
 	relativePath, _ := filepath.Rel(currentPath, path)
-	result := RunCli([]string{"myservice", "upload", "--input", relativePath}, context)
+	result := RunCli([]string{"myservice", "upload", "--file", relativePath}, context)
 
 	contentType := result.RequestHeader["content-type"]
 	if contentType != "application/octet-stream" {

--- a/test/parser_test.go
+++ b/test/parser_test.go
@@ -1102,7 +1102,7 @@ paths:
 	}
 }
 
-func TestRawRequestBodyShowsInputParameter(t *testing.T) {
+func TestRawRequestBodyShowsFileParameter(t *testing.T) {
 	definition := `
 paths:
   /upload:
@@ -1127,7 +1127,7 @@ paths:
 		t.Errorf("stdout does not contain raw request body parameter description, expected: %v, got: %v", expected, result.StdOut)
 	}
 
-	expected = "--input"
+	expected = "--file"
 	if !strings.Contains(result.StdOut, expected) {
 		t.Errorf("stdout does not contain input parameter, expected: %v, got: %v", expected, result.StdOut)
 	}

--- a/test/setup.go
+++ b/test/setup.go
@@ -214,7 +214,7 @@ func RunCli(args []string, context Context) Result {
 	args = append([]string{"uipath"}, args...)
 	var input utils.Stream
 	if context.StdIn != nil {
-		input = utils.NewMemoryStream("$input", context.StdIn.Bytes())
+		input = utils.NewMemoryStream(parser.RawBodyParameterName, context.StdIn.Bytes())
 	}
 	err := cli.Run(args, input)
 

--- a/utils/file_stream.go
+++ b/utils/file_stream.go
@@ -21,19 +21,26 @@ func (s FileStream) Name() string {
 	return s.name
 }
 
-func (s FileStream) Data() (io.ReadCloser, int64, error) {
+func (s FileStream) Size() (int64, error) {
+	fileStat, err := os.Stat(s.path)
+	if err != nil && errors.Is(err, os.ErrNotExist) {
+		return -1, fmt.Errorf("File '%s' not found", s.path)
+	}
+	if err != nil {
+		return -1, fmt.Errorf("Error reading file size '%s': %w", s.path, err)
+	}
+	return fileStat.Size(), nil
+}
+
+func (s FileStream) Data() (io.ReadCloser, error) {
 	file, err := os.Open(s.path)
 	if err != nil && errors.Is(err, os.ErrNotExist) {
-		return nil, -1, fmt.Errorf("File '%s' not found", s.path)
+		return nil, fmt.Errorf("File '%s' not found", s.path)
 	}
 	if err != nil {
-		return nil, -1, fmt.Errorf("Error reading file '%s': %w", s.path, err)
+		return nil, fmt.Errorf("Error reading file '%s': %w", s.path, err)
 	}
-	fileStat, err := file.Stat()
-	if err != nil {
-		return nil, -1, fmt.Errorf("Error reading file size '%s': %w", s.path, err)
-	}
-	return file, fileStat.Size(), nil
+	return file, nil
 }
 
 func NewFileStream(path string) *FileStream {

--- a/utils/file_stream_test.go
+++ b/utils/file_stream_test.go
@@ -16,6 +16,25 @@ func TestFileStreamName(t *testing.T) {
 	}
 }
 
+func TestFileStreamSize(t *testing.T) {
+	tempFile, _ := os.CreateTemp("", "uipath-test")
+	t.Cleanup(func() { os.Remove(tempFile.Name()) })
+	err := os.WriteFile(tempFile.Name(), []byte("hello-world"), 0600)
+	if err != nil {
+		t.Fatalf("Error writing file '%s': %v", tempFile.Name(), err)
+	}
+	param := NewFileStream(tempFile.Name())
+
+	size, err := param.Size()
+
+	if size != int64(len("hello-world")) {
+		t.Errorf("Did not return correct file size, but got: %v", size)
+	}
+	if err != nil {
+		t.Errorf("Should not return error, but got: %v", err)
+	}
+}
+
 func TestFileStreamData(t *testing.T) {
 	tempFile, _ := os.CreateTemp("", "uipath-test")
 	t.Cleanup(func() { os.Remove(tempFile.Name()) })
@@ -25,14 +44,11 @@ func TestFileStreamData(t *testing.T) {
 	}
 	param := NewFileStream(tempFile.Name())
 
-	reader, size, err := param.Data()
+	reader, err := param.Data()
 	data, _ := io.ReadAll(reader)
 
 	if string(data) != "hello-world" {
 		t.Errorf("Did not return provided data, but got: %v", string(data))
-	}
-	if size != int64(len("hello-world")) {
-		t.Errorf("Did not return correct file size, but got: %v", size)
 	}
 	if err != nil {
 		t.Errorf("Should not return error, but got: %v", err)
@@ -42,7 +58,7 @@ func TestFileStreamData(t *testing.T) {
 func TestFileStreamFileNotFound(t *testing.T) {
 	param := NewFileStream("unknown-path/my-file.txt")
 
-	_, _, err := param.Data()
+	_, err := param.Data()
 
 	if err.Error() != "File 'unknown-path/my-file.txt' not found" {
 		t.Errorf("Should return file not found error, but got: %v", err)

--- a/utils/memory_stream.go
+++ b/utils/memory_stream.go
@@ -20,8 +20,12 @@ func (s MemoryStream) Name() string {
 	return s.name
 }
 
-func (s MemoryStream) Data() (io.ReadCloser, int64, error) {
-	return io.NopCloser(bytes.NewReader(s.data)), int64(len(s.data)), nil
+func (s MemoryStream) Size() (int64, error) {
+	return int64(len(s.data)), nil
+}
+
+func (s MemoryStream) Data() (io.ReadCloser, error) {
+	return io.NopCloser(bytes.NewReader(s.data)), nil
 }
 
 func NewMemoryStream(name string, data []byte) *MemoryStream {

--- a/utils/memory_stream_test.go
+++ b/utils/memory_stream_test.go
@@ -15,17 +15,27 @@ func TestMemoryStreamName(t *testing.T) {
 	}
 }
 
+func TestMemoryStreamSize(t *testing.T) {
+	param := NewMemoryStream("my-file.txt", []byte("hello-world"))
+
+	size, err := param.Size()
+
+	if size != int64(len("hello-world")) {
+		t.Errorf("Did not return correct file size, but got: %v", size)
+	}
+	if err != nil {
+		t.Errorf("Should not return error, but got: %v", err)
+	}
+}
+
 func TestMemoryStreamData(t *testing.T) {
 	param := NewMemoryStream("my-file.txt", []byte("hello-world"))
 
-	reader, size, err := param.Data()
+	reader, err := param.Data()
 	data, _ := io.ReadAll(reader)
 
 	if string(data) != "hello-world" {
 		t.Errorf("Did not return provided data, but got: %v", string(data))
-	}
-	if size != int64(len("hello-world")) {
-		t.Errorf("Did not return correct file size, but got: %v", size)
 	}
 	if err != nil {
 		t.Errorf("Should not return error, but got: %v", err)

--- a/utils/reader_stream.go
+++ b/utils/reader_stream.go
@@ -20,8 +20,12 @@ func (s ReaderStream) Name() string {
 	return s.name
 }
 
-func (s ReaderStream) Data() (io.ReadCloser, int64, error) {
-	return s.reader, -1, nil
+func (s ReaderStream) Size() (int64, error) {
+	return -1, nil
+}
+
+func (s ReaderStream) Data() (io.ReadCloser, error) {
+	return s.reader, nil
 }
 
 func NewReaderStream(name string, reader io.ReadCloser) *ReaderStream {

--- a/utils/reader_stream_test.go
+++ b/utils/reader_stream_test.go
@@ -16,17 +16,27 @@ func TestReaderStreamName(t *testing.T) {
 	}
 }
 
+func TestReaderStreamSize(t *testing.T) {
+	param := NewReaderStream("my-file.txt", io.NopCloser(strings.NewReader("hello-world")))
+
+	size, err := param.Size()
+
+	if size != -1 {
+		t.Errorf("Did not return correct file size, but got: %v", size)
+	}
+	if err != nil {
+		t.Errorf("Should not return error, but got: %v", err)
+	}
+}
+
 func TestReaderStreamData(t *testing.T) {
 	param := NewReaderStream("my-file.txt", io.NopCloser(strings.NewReader("hello-world")))
 
-	reader, size, err := param.Data()
+	reader, err := param.Data()
 	data, _ := io.ReadAll(reader)
 
 	if string(data) != "hello-world" {
 		t.Errorf("Did not return provided data, but got: %v", string(data))
-	}
-	if size != -1 {
-		t.Errorf("Did not return correct file size, but got: %v", size)
 	}
 	if err != nil {
 		t.Errorf("Should not return error, but got: %v", err)

--- a/utils/stream.go
+++ b/utils/stream.go
@@ -10,5 +10,6 @@ import (
 // loading them in memory first.
 type Stream interface {
 	Name() string
-	Data() (io.ReadCloser, int64, error)
+	Size() (int64, error)
+	Data() (io.ReadCloser, error)
 }


### PR DESCRIPTION
Removed error-prone logic to always check if there is data on standard input which can cause the uipathcli to hang in some cases.

Instead, the user can load the request body data from disk or standard input by using the `--file` parameter.

In order to tell the uipathci to read standard input and pass it as the request body, the user can provide a dash as the file argument `--file -`

Example: Reading file from disk

`uipath du digitizer digitize --file documents/invoice.pdf`

Example: Reading from standard input

`echo "hello world" | uipath du storage upload --object-key "my-data" --file -`