### PR TITLE
Handle file parameter casing for multipart uploads

### DIFF
--- a/commandline/command_builder.go
+++ b/commandline/command_builder.go
@@ -100,7 +100,7 @@ func (b CommandBuilder) fileInput(context *cli.Context, parameters []parser.Para
 		return b.Input
 	}
 	for _, param := range parameters {
-		if param.FieldName == fileFlagName {
+		if strings.EqualFold(param.FieldName, fileFlagName) {
 			return nil
 		}
 	}

--- a/test/execution_test.go
+++ b/test/execution_test.go
@@ -946,6 +946,36 @@ paths:
 	}
 }
 
+func TestPostFormRequestWithUppercaseFile(t *testing.T) {
+	definition := `
+paths:
+  /validate:
+    post:
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              properties:
+                File:
+                  type: string
+                  format: binary
+                  description: The file to upload
+`
+	context := NewContextBuilder().
+		WithResponse(200, "{}").
+		WithDefinition("myservice", definition).
+		Build()
+
+	path := createFile(t)
+	writeFile(t, path, []byte("hello-world"))
+	result := RunCli([]string{"myservice", "post-validate", "--file", path}, context)
+
+	expected := fmt.Sprintf(`Content-Disposition: form-data; name="File"; filename="%s"`, filepath.Base(path))
+	if !strings.Contains(result.RequestBody, expected) {
+		t.Errorf("Did not find Content-Disposition in body, expected: %v, got: %v", expected, result.RequestBody)
+	}
+}
+
 func TestPostFormRequestFromFileReference(t *testing.T) {
 	definition := `
 paths:


### PR DESCRIPTION
Arbitrary parameters for multipart uploads are not supported yet. The uipathcli only parses a well known 'file' parameter. Extended the cli to ignore casing when looking for the file parameter.