### PR TITLE
Update digitize command to use DocumentUnderstanding Framework API

### DIFF
--- a/plugin/digitizer/digitize_response.go
+++ b/plugin/digitizer/digitize_response.go
@@ -1,5 +1,5 @@
 package digitzer
 
 type digitizeResponse struct {
-	OperationId string `json:"operationId"`
+	DocumentId string `json:"documentId"`
 }


### PR DESCRIPTION
The digitize command used the digitization service directly. Updated the sync over async CLI command to use the DocumentUnderstanding Framework API directly.