### PR TITLE
Add support for definitions in home directory

### DIFF
--- a/commandline/definition_file_store.go
+++ b/commandline/definition_file_store.go
@@ -95,6 +95,15 @@ func (s DefinitionFileStore) definitionsPath(version string) (string, error) {
 	if s.directory != "" {
 		return s.directory, nil
 	}
+	homeDir, err := os.UserHomeDir()
+	if err == nil {
+		definitionsDirectory := filepath.Join(homeDir, ".uipath", "definitions")
+		_, err := os.Stat(definitionsDirectory)
+		if err == nil {
+			return definitionsDirectory, nil
+		}
+	}
+
 	currentDirectory, err := os.Executable()
 	definitionsDirectory := filepath.Join(filepath.Dir(currentDirectory), DefinitionsDirectory, version)
 	if err != nil {


### PR DESCRIPTION
Check if the definitions folder exists in the home directory and use that one instead of the one in the executable folder.

This allows us to store the uipath executable in the bin folder and use definitions from the home dir.