### PR TITLE
Add support for embedded definitions

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -1,6 +1,5 @@
-Write-Host "Copying OpenAPI definitions"
-New-Item -ItemType Directory -Force -Path build/definitions | out-null
-Copy-Item definitions/* -Destination build/definitions/
+Write-Host "Copying README.md"
+New-Item -ItemType Directory -Force -Path build | out-null
 Copy-Item README.md -Destination build/README.md
 
 Write-Host "Building Linux (amd64) executable"

--- a/build.sh
+++ b/build.sh
@@ -1,9 +1,8 @@
 #! /bin/bash
 set -e
 
-echo "Copying OpenAPI definitions"
-mkdir -p build/definitions
-cp definitions/* build/definitions/
+echo "Copying README.md"
+mkdir -p build
 cp README.md build/README.md
 
 echo "Building Linux (amd64) executable"

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"embed"
 	"fmt"
 	"os"
 	"runtime"
@@ -19,6 +20,9 @@ import (
 	plugin_orchestrator "github.com/UiPath/uipathcli/plugin/orchestrator"
 	"github.com/UiPath/uipathcli/utils"
 )
+
+//go:embed definitions/*.yaml
+var embedded embed.FS
 
 func authenticators(pluginsCfg config.PluginConfig) []auth.Authenticator {
 	authenticators := []auth.Authenticator{}
@@ -71,7 +75,7 @@ func main() {
 		os.Stderr,
 		colorsSupported(),
 		*commandline.NewDefinitionProvider(
-			commandline.NewDefinitionFileStore(os.Getenv("UIPATH_DEFINITIONS_PATH")),
+			commandline.NewDefinitionFileStore(os.Getenv("UIPATH_DEFINITIONS_PATH"), embedded),
 			parser.NewOpenApiParser(),
 			[]plugin.CommandPlugin{
 				plugin_digitizer.DigitizeCommand{},

--- a/package.sh
+++ b/package.sh
@@ -7,24 +7,24 @@ rm --force build/packages/*
 pushd build/ > /dev/null
 
 echo "Create Linux (amd64) Package"
-tar --create --gzip --overwrite --file=packages/uipathcli-linux-amd64.tar.gz --transform='flags=r;s|uipath-linux-amd64|uipath|' uipath-linux-amd64 definitions
+tar --create --gzip --overwrite --file=packages/uipathcli-linux-amd64.tar.gz --transform='flags=r;s|uipath-linux-amd64|uipath|' uipath-linux-amd64
 
 echo "Create Windows (amd64) Package"
-zip -q packages/uipathcli-windows-amd64.zip uipath-windows-amd64.exe definitions/*
+zip -q packages/uipathcli-windows-amd64.zip uipath-windows-amd64.exe
 printf "@ uipath-windows-amd64.exe\n@=uipath.exe\n" | zipnote -w packages/uipathcli-windows-amd64.zip
 
 echo "Create MacOS (amd64) Package"
-tar --create --gzip --overwrite --file=packages/uipathcli-darwin-amd64.tar.gz --transform='flags=r;s|uipath-darwin-amd64|uipath|' uipath-darwin-amd64 definitions
+tar --create --gzip --overwrite --file=packages/uipathcli-darwin-amd64.tar.gz --transform='flags=r;s|uipath-darwin-amd64|uipath|' uipath-darwin-amd64
 
 echo "Create Linux (arm64) Package"
-tar --create --gzip --overwrite --file=packages/uipathcli-linux-arm64.tar.gz --transform='flags=r;s|uipath-linux-arm64|uipath|' uipath-linux-arm64 definitions
+tar --create --gzip --overwrite --file=packages/uipathcli-linux-arm64.tar.gz --transform='flags=r;s|uipath-linux-arm64|uipath|' uipath-linux-arm64
 
 echo "Create Windows (arm64) Package"
-zip -q packages/uipathcli-windows-arm64.zip uipath-windows-arm64.exe definitions/*
+zip -q packages/uipathcli-windows-arm64.zip uipath-windows-arm64.exe
 printf "@ uipath-windows-arm64.exe\n@=uipath.exe\n" | zipnote -w packages/uipathcli-windows-arm64.zip
 
 echo "Create MacOS (arm64) Package"
-tar --create --gzip --overwrite --file=packages/uipathcli-darwin-arm64.tar.gz --transform='flags=r;s|uipath-darwin-arm64|uipath|' uipath-darwin-arm64 definitions
+tar --create --gzip --overwrite --file=packages/uipathcli-darwin-arm64.tar.gz --transform='flags=r;s|uipath-darwin-arm64|uipath|' uipath-darwin-arm64
 
 popd > /dev/null
 echo "Successfully created packages"


### PR DESCRIPTION
- Embedding OpenAPI definitions during build time which allows us to distribute a single executable without any additional dependencies
- Extended the definition store to provide embedded OpenAPI documents
- Allowing overriding embedded definitions or adding additional OpenAPI specifications by adding them to the definitions/ folder