### PR TITLE
Calculate code coverage and upload to coveralls.io

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,12 +16,18 @@ jobs:
         run: go get .
       - name: Build
         run: go build .
-      - name: Test
-        run: go test -v ./...
       - name: Lint
         run: |
           go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.2
           golangci-lint run
+      - name: Test
+        run: go test -coverprofile="coverage.out" -coverpkg "$(go list github.com/UiPath/uipathcli/... | grep -v 'test' | tr '\n' ',')" ./...
+      - name: Coverage
+        env:
+          COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}      
+        run: |
+          go install github.com/mattn/goveralls@latest
+          goveralls -coverprofile="coverage.out" -service="github"
       - name: Package
         run: ./build.sh && ./package.sh
       - name: Upload packages

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+[![GitHub Release](https://img.shields.io/github/release/UiPath/uipathcli?style=flat-square)](https://github.com/UiPath/uipathcli/releases)
+[![MIT License](https://img.shields.io/badge/license-MIT-blue?style=flat-square)](https://github.com/UiPath/uipathcli/blob/main/LICENSE)
+[![Documentation](https://img.shields.io/badge/Documentation-146e22?style=flat-square&logo=gitbook&logoColor=white)](https://uipath.github.io/uipathcli/)
+
 # UiPath OpenAPI Command-Line-Interface (preview)
 
 The UiPath OpenAPI CLI project is a command line interface to simplify, script and automate API calls for UiPath services. The CLI works on Windows, Linux and MacOS.
@@ -166,7 +170,6 @@ Response:
       "Name": "Administrators",
       "Type": "DirectoryGroup",
       "UserName": "administrators"
-      ...
     }
   ]
 }
@@ -404,8 +407,7 @@ uipath orchestrator users get --query "value[?Name == 'Administrator'] | [0]"
 {
   "Id": 123456,
   "CreationTime": "2023-01-27T10:45:24.763Z",
-  "Name": "Administrator",
-  ...
+  "Name": "Administrator"
 }
 ```
 


### PR DESCRIPTION
- Run tests with code coverage enabled
- Extend CI template to upload code coverage results to coveralls.io
- Add release, license and documentation badges to README.md