### PR TITLE
Add global parameter identity-uri

### DIFF
--- a/README.md
+++ b/README.md
@@ -569,6 +569,7 @@ You can either pass global arguments as CLI parameters, set an env variable or s
 | `--uri` | `UIPATH_URI` | `uri` | `https://cloud.uipath.com` | URL override |
 | `--organization` | `UIPATH_ORGANIZATION` | `string` | | Organization name |
 | `--tenant` | `UIPATH_TENANT` | `string` | | Tenant name |
+| `--identity-uri` | `UIPATH_IDENTITY_URI` | `uri` | `https://cloud.uipath.com/identity_` | URL override for identity calls |
 | | `UIPATH_CLIENT_ID` | `string` | | Client Id |
 | | `UIPATH_CLIENT_SECRET` | `string` | | Client Secret |
 | | `UIPATH_PAT` | `string` | | Personal Access Token |

--- a/auth/authenticator_context.go
+++ b/auth/authenticator_context.go
@@ -1,19 +1,23 @@
 package auth
 
+import "net/url"
+
 // AuthenticatorContext provides information required for authenticating requests.
 type AuthenticatorContext struct {
-	Type     string                 `json:"type"`
-	Config   map[string]interface{} `json:"config"`
-	Debug    bool                   `json:"debug"`
-	Insecure bool                   `json:"insecure"`
-	Request  AuthenticatorRequest   `json:"request"`
+	Type        string                 `json:"type"`
+	Config      map[string]interface{} `json:"config"`
+	IdentityUri url.URL                `json:"identityUri"`
+	Debug       bool                   `json:"debug"`
+	Insecure    bool                   `json:"insecure"`
+	Request     AuthenticatorRequest   `json:"request"`
 }
 
 func NewAuthenticatorContext(
 	authType string,
 	config map[string]interface{},
+	identityUri url.URL,
 	debug bool,
 	insecure bool,
 	request AuthenticatorRequest) *AuthenticatorContext {
-	return &AuthenticatorContext{authType, config, debug, insecure, request}
+	return &AuthenticatorContext{authType, config, identityUri, debug, insecure, request}
 }

--- a/auth/bearer_authenticator_config.go
+++ b/auth/bearer_authenticator_config.go
@@ -8,7 +8,7 @@ type bearerAuthenticatorConfig struct {
 	ClientId     string
 	ClientSecret string
 	Properties   map[string]string
-	IdentityUri  *url.URL
+	IdentityUri  url.URL
 }
 
 func newBearerAuthenticatorConfig(
@@ -17,6 +17,6 @@ func newBearerAuthenticatorConfig(
 	clientId string,
 	clientSecret string,
 	properties map[string]string,
-	identityUri *url.URL) *bearerAuthenticatorConfig {
+	identityUri url.URL) *bearerAuthenticatorConfig {
 	return &bearerAuthenticatorConfig{grantType, scopes, clientId, clientSecret, properties, identityUri}
 }

--- a/auth/oauth_authenticator.go
+++ b/auth/oauth_authenticator.go
@@ -35,18 +35,7 @@ func (a OAuthAuthenticator) Auth(ctx AuthenticatorContext) AuthenticatorResult {
 	if err != nil {
 		return *AuthenticatorError(fmt.Errorf("Invalid oauth authenticator configuration: %w", err))
 	}
-	identityBaseUri := config.IdentityUri
-	if identityBaseUri == nil {
-		requestUrl, err := url.Parse(ctx.Request.URL)
-		if err != nil {
-			return *AuthenticatorError(fmt.Errorf("Invalid request url '%s': %w", ctx.Request.URL, err))
-		}
-		identityBaseUri, err = url.Parse(fmt.Sprintf("%s://%s/identity_", requestUrl.Scheme, requestUrl.Host))
-		if err != nil {
-			return *AuthenticatorError(fmt.Errorf("Invalid identity url '%s': %w", ctx.Request.URL, err))
-		}
-	}
-	token, err := a.retrieveToken(*identityBaseUri, *config, ctx.Insecure)
+	token, err := a.retrieveToken(config.IdentityUri, *config, ctx.Insecure)
 	if err != nil {
 		return *AuthenticatorError(fmt.Errorf("Error retrieving access token: %w", err))
 	}
@@ -176,15 +165,7 @@ func (a OAuthAuthenticator) getConfig(ctx AuthenticatorContext) (*oauthAuthentic
 	if err != nil {
 		return nil, err
 	}
-	var uri *url.URL
-	uriString, err := a.parseRequiredString(ctx.Config, "uri")
-	if err == nil {
-		uri, err = url.Parse(uriString)
-		if err != nil {
-			return nil, fmt.Errorf("Error parsing identity uri: %w", err)
-		}
-	}
-	return newOAuthAuthenticatorConfig(clientId, *parsedRedirectUri, scopes, uri), nil
+	return newOAuthAuthenticatorConfig(clientId, *parsedRedirectUri, scopes, ctx.IdentityUri), nil
 }
 
 func (a OAuthAuthenticator) parseRequiredString(config map[string]interface{}, name string) (string, error) {

--- a/auth/oauth_authenticator_config.go
+++ b/auth/oauth_authenticator_config.go
@@ -6,13 +6,13 @@ type oauthAuthenticatorConfig struct {
 	ClientId    string
 	RedirectUrl url.URL
 	Scopes      string
-	IdentityUri *url.URL
+	IdentityUri url.URL
 }
 
 func newOAuthAuthenticatorConfig(
 	clientId string,
 	redirectUrl url.URL,
 	scopes string,
-	identityUri *url.URL) *oauthAuthenticatorConfig {
+	identityUri url.URL) *oauthAuthenticatorConfig {
 	return &oauthAuthenticatorConfig{clientId, redirectUrl, scopes, identityUri}
 }

--- a/commandline/parameter_formatter.go
+++ b/commandline/parameter_formatter.go
@@ -2,7 +2,7 @@ package commandline
 
 import (
 	"fmt"
-	"slices"
+	"sort"
 	"strings"
 
 	"github.com/UiPath/uipathcli/parser"
@@ -68,7 +68,7 @@ func (f parameterFormatter) descriptionFields(parameter parser.Parameter) []inte
 
 func (f parameterFormatter) usageExample(parameter parser.Parameter) string {
 	parameters := f.collectUsageParameters(parameter, "")
-	slices.Sort(parameters)
+	sort.Strings(parameters)
 
 	builder := strings.Builder{}
 	for _, value := range parameters {

--- a/executor/execution_context.go
+++ b/executor/execution_context.go
@@ -22,6 +22,7 @@ type ExecutionContext struct {
 	AuthConfig   config.AuthConfig
 	Insecure     bool
 	Debug        bool
+	IdentityUri  url.URL
 	Plugin       plugin.CommandPlugin
 }
 
@@ -37,6 +38,7 @@ func NewExecutionContext(
 	authConfig config.AuthConfig,
 	insecure bool,
 	debug bool,
+	identityUri url.URL,
 	plugin plugin.CommandPlugin) *ExecutionContext {
-	return &ExecutionContext{organization, tenant, method, uri, route, contentType, input, parameters, authConfig, insecure, debug, plugin}
+	return &ExecutionContext{organization, tenant, method, uri, route, contentType, input, parameters, authConfig, insecure, debug, identityUri, plugin}
 }

--- a/executor/http_executor.go
+++ b/executor/http_executor.go
@@ -144,9 +144,9 @@ func (e HttpExecutor) formatUri(baseUri url.URL, route string, pathParameters []
 	return e.validateUri(formatter.Uri())
 }
 
-func (e HttpExecutor) executeAuthenticators(authConfig config.AuthConfig, debug bool, insecure bool, request *http.Request) (*auth.AuthenticatorResult, error) {
+func (e HttpExecutor) executeAuthenticators(authConfig config.AuthConfig, identityUri url.URL, debug bool, insecure bool, request *http.Request) (*auth.AuthenticatorResult, error) {
 	authRequest := *auth.NewAuthenticatorRequest(request.URL.String(), map[string]string{})
-	ctx := *auth.NewAuthenticatorContext(authConfig.Type, authConfig.Config, debug, insecure, authRequest)
+	ctx := *auth.NewAuthenticatorContext(authConfig.Type, authConfig.Config, identityUri, debug, insecure, authRequest)
 	for _, authProvider := range e.authenticators {
 		result := authProvider.Auth(ctx)
 		if result.Error != "" {
@@ -318,7 +318,7 @@ func (e HttpExecutor) call(context ExecutionContext, writer output.OutputWriter,
 		request.Header.Add("Content-Type", contentType)
 	}
 	e.addHeaders(request, context.Parameters.Header())
-	auth, err := e.executeAuthenticators(context.AuthConfig, context.Debug, context.Insecure, request)
+	auth, err := e.executeAuthenticators(context.AuthConfig, context.IdentityUri, context.Debug, context.Insecure, request)
 	if err != nil {
 		return err
 	}

--- a/executor/plugin_executor.go
+++ b/executor/plugin_executor.go
@@ -19,9 +19,9 @@ type PluginExecutor struct {
 	authenticators []auth.Authenticator
 }
 
-func (e PluginExecutor) executeAuthenticators(baseUri url.URL, authConfig config.AuthConfig, debug bool, insecure bool) (*auth.AuthenticatorResult, error) {
+func (e PluginExecutor) executeAuthenticators(baseUri url.URL, authConfig config.AuthConfig, identityUri url.URL, debug bool, insecure bool) (*auth.AuthenticatorResult, error) {
 	authRequest := *auth.NewAuthenticatorRequest(baseUri.String(), map[string]string{})
-	ctx := *auth.NewAuthenticatorContext(authConfig.Type, authConfig.Config, debug, insecure, authRequest)
+	ctx := *auth.NewAuthenticatorContext(authConfig.Type, authConfig.Config, identityUri, debug, insecure, authRequest)
 	for _, authProvider := range e.authenticators {
 		result := authProvider.Auth(ctx)
 		if result.Error != "" {
@@ -51,7 +51,7 @@ func (e PluginExecutor) pluginAuth(auth *auth.AuthenticatorResult) plugin.AuthRe
 }
 
 func (e PluginExecutor) Call(context ExecutionContext, writer output.OutputWriter, logger log.Logger) error {
-	auth, err := e.executeAuthenticators(context.BaseUri, context.AuthConfig, context.Debug, context.Insecure)
+	auth, err := e.executeAuthenticators(context.BaseUri, context.AuthConfig, context.IdentityUri, context.Debug, context.Insecure)
 	if err != nil {
 		return err
 	}

--- a/test/auth_test.go
+++ b/test/auth_test.go
@@ -122,6 +122,35 @@ paths:
 	}
 }
 
+func TestBearerAuthWithInvalidIdentityUriParameter(t *testing.T) {
+	config := `
+profiles:
+  - name: default
+    auth:
+      clientId: success-client-id
+      clientSecret: success-client-secret
+`
+	definition := `
+paths:
+  /ping:
+    get:
+      operationId: ping
+`
+
+	context := NewContextBuilder().
+		WithDefinition("myservice", definition).
+		WithConfig(config).
+		WithResponse(200, "").
+		WithIdentityResponse(200, `{"access_token": "my-jwt-access-token", "expires_in": 3600, "token_type": "Bearer", "scope": "OR.Ping"}`).
+		Build()
+
+	result := RunCli([]string{"myservice", "ping", "--identity-uri", ":invalid"}, context)
+
+	if !strings.Contains(result.Error.Error(), "Error parsing identity-uri argument") {
+		t.Errorf("Expected identity uri parsing error, but got: %v", result.Error)
+	}
+}
+
 func TestBearerAuthTokenIsCached(t *testing.T) {
 	config := `
 profiles:

--- a/test/show_command_test.go
+++ b/test/show_command_test.go
@@ -141,7 +141,7 @@ paths:
 		names = append(names, parameter["name"].(string))
 	}
 
-	expectedNames := []string{"debug", "profile", "uri", "organization", "tenant", "insecure", "output", "query", "wait", "wait-timeout", "file", "version", "help"}
+	expectedNames := []string{"debug", "profile", "uri", "organization", "tenant", "insecure", "output", "query", "wait", "wait-timeout", "file", "identity-uri", "version", "help"}
 	if !reflect.DeepEqual(names, expectedNames) {
 		t.Errorf("Unexpected global parameters in output, expected: %v but got: %v", expectedNames, names)
 	}


### PR DESCRIPTION
Added a new global parameter to override the identity server uri. This makes it easier to use the UiPath services with an external identity token provider. It was possible before to override the identity server uri by setting the UIPATH_IDENTITY_URI environment variable but not by providing a global CLI parameter.

Refactored the code so that the CLI parameter, config value and environment variable parsing is done in the command_builder like all the other parameters and removed the env variable parsing from the bearer authenticator.