### PR TITLE
Avoid escaping string values with equal sign in complex parameters

### DIFF
--- a/commandline/type_converter.go
+++ b/commandline/type_converter.go
@@ -182,7 +182,7 @@ func (c typeConverter) convertToObject(value string, parameter parser.Parameter)
 	obj := map[string]interface{}{}
 	assigns := c.splitEscaped(value, ';')
 	for _, assign := range assigns {
-		keyValue := c.splitEscaped(assign, '=')
+		keyValue := c.splitEscapedMaxCount(assign, '=', 2)
 		if len(keyValue) < 2 {
 			keyValue = append(keyValue, "")
 		}
@@ -243,6 +243,10 @@ func (c typeConverter) convertValueToBooleanArray(value string, parameter parser
 }
 
 func (c typeConverter) splitEscaped(str string, separator byte) []string {
+	return c.splitEscapedMaxCount(str, separator, -1)
+}
+
+func (c typeConverter) splitEscapedMaxCount(str string, separator byte, maxCount int) []string {
 	result := []string{}
 	item := []byte{}
 	escaping := false
@@ -256,6 +260,14 @@ func (c typeConverter) splitEscaped(str string, separator byte) []string {
 		} else if char == separator && !escaping {
 			result = append(result, string(item))
 			item = []byte{}
+			if len(result) == maxCount-1 {
+				if i+1 < len(str) {
+					item = []byte(str[i+1:])
+					result = append(result, string(item))
+				}
+				break
+			}
+
 		} else {
 			escaping = false
 			item = append(item, char)

--- a/commandline/type_converter_test.go
+++ b/commandline/type_converter_test.go
@@ -183,6 +183,21 @@ func TestNegativeIndexIsIgnored(t *testing.T) {
 	}
 }
 
+func TestConvertStringAvoidEscapeEqualSign(t *testing.T) {
+	converter := newTypeConverter()
+
+	parameter := newParameter("tag", parser.ParameterTypeObject,
+		[]parser.Parameter{
+			newParameter("name", parser.ParameterTypeString, []parser.Parameter{}),
+		})
+	result, _ := converter.Convert("name=hello=", parameter)
+
+	name := getValue(result, "name")
+	if name != "hello=" {
+		t.Errorf("Result should contain equal sign, but got: %v", name)
+	}
+}
+
 func getValue(result interface{}, key string) interface{} {
 	return result.(map[string]interface{})[key]
 }


### PR DESCRIPTION
All equal signs of an string assignment in complex parameters were required to be escaped, e.g.

`--parts "id=hello\\=world"`

Extended the type converter so that the part after an equal sign will always be treated as a simple value without splitting it in multiple parts. Assignments are always a key-value pair.

This allows the user to use values with equals signs, like base64 encoded strings without the need to escape, e.g.

`--parts "id=hello=world"`

This will set the id value to 'hello=world'.