### PR TITLE
Fix commands section in short help command (-h)

### DIFF
--- a/commandline/command_builder.go
+++ b/commandline/command_builder.go
@@ -716,7 +716,7 @@ func (b CommandBuilder) createConfigSetCommand() *cli.Command {
 }
 
 func (b CommandBuilder) loadDefinitions(args []string, version string) ([]parser.Definition, error) {
-	if len(args) <= 1 || strings.HasPrefix(args[1], "--") {
+	if len(args) <= 1 || strings.HasPrefix(args[1], "-") {
 		return b.DefinitionProvider.Index(version)
 	}
 	if len(args) > 1 && args[1] == "commands" {

--- a/main_test.go
+++ b/main_test.go
@@ -31,6 +31,24 @@ func TestMainReadsDefinitions(t *testing.T) {
 	}
 }
 
+func TestHelpReadsDefinitions(t *testing.T) {
+	config := createFile(t, ".uipath", "config")
+	definition := createFile(t, "definitions", "service-a.yaml")
+
+	t.Setenv("UIPATH_CONFIGURATION_PATH", config)
+	t.Setenv("UIPATH_DEFINITIONS_PATH", filepath.Dir(definition))
+
+	os.Args = []string{"uipath", "-h"}
+	output := captureOutput(t, func() {
+		main()
+	})
+
+	expected := `service-a`
+	if !strings.Contains(output, expected) {
+		t.Errorf("Expected %s in output, but got: %v", expected, output)
+	}
+}
+
 func TestMainParsesDefinition(t *testing.T) {
 	config := createFile(t, ".uipath", "config")
 	definition := createFile(t, "definitions", "service-a.yaml")


### PR DESCRIPTION
The OpenAPI specification definitions are parsed lazily for performance reasons. The detection for the -h argument did not work properly. Therefore, the specfications have not been loaded at all and the commands section in the output contained only the built-in commands.

Fixes: https://github.com/UiPath/uipathcli/issues/117