### PR TITLE
Compile statically-linked binary

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,9 +1,14 @@
 name: CI
 on: [push]
 
+env:
+  UIPATHCLI_BASE_VERSION: "v1.1"
+
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      CGO_ENABLED: "0"
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -78,6 +83,6 @@ jobs:
           name: packages
           path: build/packages/
       - name: Publish
-        run: ./publish.sh
+        run: ./publish.sh "$UIPATHCLI_BASE_VERSION"
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/publish.sh
+++ b/publish.sh
@@ -30,8 +30,10 @@ declare -a RELEASE_FILES=(
 ############################################################
 function get_latest_version()
 {
+    local version_filter="$1"
+
     git fetch --all --tags --quiet
-    git tag | sort -V | tail -1
+    git tag | sort -V | grep "^$version_filter.*" | tail -1 || echo "$version_filter"
 }
 
 ############################################################
@@ -49,7 +51,11 @@ function increment_patch_version()
 
     local array
     local IFS='.'; read -r -a array <<< "$version"
-    array[2]=$((array[2]+1))
+    if [ -z "${array[2]}" ]; then
+        array[2]="0"
+    else
+        array[2]=$((array[2]+1))
+    fi
     echo "$(local IFS='.'; echo "${array[*]}")"
 }
 
@@ -121,10 +127,11 @@ function upload_release_file()
 ############################################################
 function main()
 {
+    local base_version="$1"
     local latest_version
     local new_version
 
-    latest_version=$(get_latest_version)
+    latest_version=$(get_latest_version "$base_version")
     new_version=$(increment_patch_version "$latest_version")
     echo "=================================="
     echo "Releasing new version of uipathcli"
@@ -146,4 +153,4 @@ function main()
 
     echo "Successfully created release '$new_version'"
 }
-main
+main "$1"


### PR DESCRIPTION
- Bundle all required libraries and create a statically-linked binary would should improve cross-platform support and avoids errors when libc is missing or and older version

- Updated the publish.sh script to support upgrading the major/minor version and increased it to v1.1