### PR TITLE
Create command abstraction and split up command builder

### DIFF
--- a/commandline/cli.go
+++ b/commandline/cli.go
@@ -40,7 +40,11 @@ func (c Cli) run(args []string, input utils.Stream) error {
 		PluginExecutor:     c.pluginExecutor,
 		DefinitionProvider: c.definitionProvider,
 	}
-	flags := CommandBuilder.CreateDefaultFlags(false)
+
+	flags := NewFlagBuilder().
+		AddDefaultFlags(false).
+		Build()
+
 	commands, err := CommandBuilder.Create(args)
 	if err != nil {
 		return err
@@ -51,8 +55,8 @@ func (c Cli) run(args []string, input utils.Stream) error {
 		Usage:                     "Command-Line Interface for UiPath Services",
 		UsageText:                 "uipath <service> <operation> --parameter",
 		Version:                   "1.0",
-		Flags:                     flags,
-		Commands:                  commands,
+		Flags:                     c.convertFlags(flags...),
+		Commands:                  c.convertCommands(commands...),
 		Writer:                    c.stdOut,
 		ErrWriter:                 c.stdErr,
 		HideVersion:               true,
@@ -88,4 +92,129 @@ func NewCli(
 	pluginExecutor executor.Executor,
 ) *Cli {
 	return &Cli{stdIn, stdOut, stdErr, colors, definitionProvider, configProvider, executor, pluginExecutor}
+}
+
+func (c Cli) convertCommand(command *CommandDefinition) *cli.Command {
+	result := cli.Command{
+		Name:               command.Name,
+		Usage:              command.Summary,
+		Description:        command.Description,
+		Flags:              c.convertFlags(command.Flags...),
+		Subcommands:        c.convertCommands(command.Subcommands...),
+		CustomHelpTemplate: command.HelpTemplate,
+		Hidden:             command.Hidden,
+		HideHelp:           true,
+	}
+	if command.Action != nil {
+		result.Action = func(context *cli.Context) error {
+			return command.Action(&CommandExecContext{context})
+		}
+	}
+	return &result
+}
+
+func (c Cli) convertCommands(commands ...*CommandDefinition) []*cli.Command {
+	result := []*cli.Command{}
+	for _, command := range commands {
+		result = append(result, c.convertCommand(command))
+	}
+	return result
+}
+
+func (c Cli) convertStringSliceFlag(flag *FlagDefinition) *cli.StringSliceFlag {
+	envVars := []string{}
+	if flag.EnvVarName != "" {
+		envVars = append(envVars, flag.EnvVarName)
+	}
+	var value *cli.StringSlice
+	if flag.DefaultValue != nil {
+		value = cli.NewStringSlice(flag.DefaultValue.([]string)...)
+	}
+	return &cli.StringSliceFlag{
+		Name:     flag.Name,
+		Usage:    flag.Summary,
+		EnvVars:  envVars,
+		Required: flag.Required,
+		Hidden:   flag.Hidden,
+		Value:    value,
+	}
+}
+
+func (c Cli) convertIntFlag(flag *FlagDefinition) *cli.IntFlag {
+	envVars := []string{}
+	if flag.EnvVarName != "" {
+		envVars = append(envVars, flag.EnvVarName)
+	}
+	var value int
+	if flag.DefaultValue != nil {
+		value = flag.DefaultValue.(int)
+	}
+	return &cli.IntFlag{
+		Name:     flag.Name,
+		Usage:    flag.Summary,
+		EnvVars:  envVars,
+		Required: flag.Required,
+		Hidden:   flag.Hidden,
+		Value:    value,
+	}
+}
+
+func (c Cli) convertBoolFlag(flag *FlagDefinition) *cli.BoolFlag {
+	envVars := []string{}
+	if flag.EnvVarName != "" {
+		envVars = append(envVars, flag.EnvVarName)
+	}
+	var value bool
+	if flag.DefaultValue != nil {
+		value = flag.DefaultValue.(bool)
+	}
+	return &cli.BoolFlag{
+		Name:     flag.Name,
+		Usage:    flag.Summary,
+		EnvVars:  envVars,
+		Required: flag.Required,
+		Hidden:   flag.Hidden,
+		Value:    value,
+	}
+}
+
+func (c Cli) convertStringFlag(flag *FlagDefinition) *cli.StringFlag {
+	envVars := []string{}
+	if flag.EnvVarName != "" {
+		envVars = append(envVars, flag.EnvVarName)
+	}
+	var value string
+	if flag.DefaultValue != nil {
+		value = flag.DefaultValue.(string)
+	}
+	return &cli.StringFlag{
+		Name:     flag.Name,
+		Usage:    flag.Summary,
+		EnvVars:  envVars,
+		Required: flag.Required,
+		Hidden:   flag.Hidden,
+		Value:    value,
+	}
+}
+
+func (c Cli) convertFlag(flag *FlagDefinition) cli.Flag {
+	switch flag.Type {
+	case FlagTypeStringArray:
+		return c.convertStringSliceFlag(flag)
+	case FlagTypeInteger:
+		return c.convertIntFlag(flag)
+	case FlagTypeBoolean:
+		return c.convertBoolFlag(flag)
+	case FlagTypeString:
+		return c.convertStringFlag(flag)
+	}
+	panic(fmt.Sprintf("Unknown flag type: %s", flag.Type.String()))
+}
+
+func (c Cli) convertFlags(flags ...*FlagDefinition) []cli.Flag {
+	result := []cli.Flag{}
+	for _, flag := range flags {
+		result = append(result, c.convertFlag(flag))
+	}
+	return result
 }

--- a/commandline/command_definition.go
+++ b/commandline/command_definition.go
@@ -1,0 +1,62 @@
+package commandline
+
+import "github.com/urfave/cli/v2"
+
+// The CommandExecContext contains the flag values provided by the user.
+type CommandExecContext struct {
+	*cli.Context
+}
+
+// The CommandExecFunc is the function definition for executing a command action.
+type CommandExecFunc func(*CommandExecContext) error
+
+// The CommandDefinition contains the metadata and builder methods for creating
+// CLI commands.
+type CommandDefinition struct {
+	Name         string
+	Summary      string
+	Description  string
+	Flags        []*FlagDefinition
+	Subcommands  []*CommandDefinition
+	HelpTemplate string
+	Hidden       bool
+	Action       CommandExecFunc
+}
+
+func (c *CommandDefinition) WithFlags(flags []*FlagDefinition) *CommandDefinition {
+	c.Flags = flags
+	return c
+}
+
+func (c *CommandDefinition) WithSubcommands(subcommands []*CommandDefinition) *CommandDefinition {
+	c.Subcommands = subcommands
+	return c
+}
+
+func (c *CommandDefinition) WithHidden(hidden bool) *CommandDefinition {
+	c.Hidden = hidden
+	return c
+}
+
+func (c *CommandDefinition) WithHelpTemplate(helpTemplate string) *CommandDefinition {
+	c.HelpTemplate = helpTemplate
+	return c
+}
+
+func (c *CommandDefinition) WithAction(action CommandExecFunc) *CommandDefinition {
+	c.Action = action
+	return c
+}
+
+func NewCommand(name string, summary string, description string) *CommandDefinition {
+	return &CommandDefinition{
+		name,
+		summary,
+		description,
+		nil,
+		nil,
+		"",
+		false,
+		nil,
+	}
+}

--- a/commandline/flag_builder.go
+++ b/commandline/flag_builder.go
@@ -1,36 +1,152 @@
 package commandline
 
 import (
-	"github.com/urfave/cli/v2"
+	"fmt"
+
+	"github.com/UiPath/uipathcli/config"
 )
 
-type flagBuilder struct {
-	flags map[string]cli.Flag
+const FlagNameDebug = "debug"
+const FlagNameProfile = "profile"
+const FlagNameUri = "uri"
+const FlagNameOrganization = "organization"
+const FlagNameTenant = "tenant"
+const FlagNameInsecure = "insecure"
+const FlagNameOutputFormat = "output"
+const FlagNameQuery = "query"
+const FlagNameWait = "wait"
+const FlagNameWaitTimeout = "wait-timeout"
+const FlagNameFile = "file"
+const FlagNameIdentityUri = "identity-uri"
+const FlagNameVersion = "version"
+const FlagNameHelp = "help"
+
+const FlagValueFromStdIn = "-"
+const FlagValueOutputFormatJson = "json"
+const FlagValueOutputFormatText = "text"
+
+var FlagNamesPredefined = []string{
+	FlagNameDebug,
+	FlagNameProfile,
+	FlagNameUri,
+	FlagNameOrganization,
+	FlagNameTenant,
+	FlagNameInsecure,
+	FlagNameOutputFormat,
+	FlagNameQuery,
+	FlagNameWait,
+	FlagNameWaitTimeout,
+	FlagNameFile,
+	FlagNameIdentityUri,
+	FlagNameVersion,
+	FlagNameHelp,
+}
+
+// The FlagBuilder can be used to prepare a list of flags for a CLI command.
+// The builder takes care that flags with the same name are deduped.
+type FlagBuilder struct {
+	flags map[string]*FlagDefinition
 	order []string
 }
 
-func (b *flagBuilder) AddFlag(flag cli.Flag) {
-	name := flag.Names()[0]
+func (b *FlagBuilder) AddFlag(flag *FlagDefinition) *FlagBuilder {
+	name := flag.Name
 	if _, found := b.flags[name]; !found {
 		b.flags[name] = flag
 		b.order = append(b.order, name)
 	}
+	return b
 }
 
-func (b *flagBuilder) AddFlags(flags []cli.Flag) {
+func (b *FlagBuilder) AddFlags(flags []*FlagDefinition) *FlagBuilder {
 	for _, flag := range flags {
 		b.AddFlag(flag)
 	}
+	return b
 }
 
-func (b flagBuilder) ToList() []cli.Flag {
-	flags := []cli.Flag{}
+func (b *FlagBuilder) AddDefaultFlags(hidden bool) *FlagBuilder {
+	b.AddFlags(b.defaultFlags(hidden))
+	return b
+}
+
+func (b *FlagBuilder) AddHelpFlag() *FlagBuilder {
+	b.AddFlag(b.helpFlag())
+	return b
+}
+
+func (b *FlagBuilder) AddVersionFlag(hidden bool) *FlagBuilder {
+	b.AddFlag(b.versionFlag(hidden))
+	return b
+}
+
+func (b FlagBuilder) Build() []*FlagDefinition {
+	flags := []*FlagDefinition{}
 	for _, name := range b.order {
 		flags = append(flags, b.flags[name])
 	}
 	return flags
 }
 
-func newFlagBuilder() *flagBuilder {
-	return &flagBuilder{map[string]cli.Flag{}, []string{}}
+func (b FlagBuilder) defaultFlags(hidden bool) []*FlagDefinition {
+	return []*FlagDefinition{
+		NewFlag(FlagNameDebug, "Enable debug output", FlagTypeBoolean).
+			WithEnvVarName("UIPATH_DEBUG").
+			WithDefaultValue(false).
+			WithHidden(hidden),
+		NewFlag(FlagNameProfile, "Config profile to use", FlagTypeString).
+			WithEnvVarName("UIPATH_PROFILE").
+			WithDefaultValue(config.DefaultProfile).
+			WithHidden(hidden),
+		NewFlag(FlagNameUri, "Server Base-URI", FlagTypeString).
+			WithEnvVarName("UIPATH_URI").
+			WithHidden(hidden),
+		NewFlag(FlagNameOrganization, "Organization name", FlagTypeString).
+			WithEnvVarName("UIPATH_ORGANIZATION").
+			WithHidden(hidden),
+		NewFlag(FlagNameTenant, "Tenant name", FlagTypeString).
+			WithEnvVarName("UIPATH_TENANT").
+			WithHidden(hidden),
+		NewFlag(FlagNameInsecure, "Disable HTTPS certificate check", FlagTypeBoolean).
+			WithEnvVarName("UIPATH_INSECURE").
+			WithDefaultValue(false).
+			WithHidden(hidden),
+		NewFlag(FlagNameOutputFormat, fmt.Sprintf("Set output format: %s (default), %s", FlagValueOutputFormatJson, FlagValueOutputFormatText), FlagTypeString).
+			WithEnvVarName("UIPATH_OUTPUT").
+			WithDefaultValue("").
+			WithHidden(hidden),
+		NewFlag(FlagNameQuery, "Perform JMESPath query on output", FlagTypeString).
+			WithDefaultValue("").
+			WithHidden(hidden),
+		NewFlag(FlagNameWait, "Waits for the provided condition (JMESPath expression)", FlagTypeString).
+			WithDefaultValue("").
+			WithHidden(hidden),
+		NewFlag(FlagNameWaitTimeout, "Time to wait in seconds for condition", FlagTypeInteger).
+			WithDefaultValue(30).
+			WithHidden(hidden),
+		NewFlag(FlagNameFile, "Provide input from file (use - for stdin)", FlagTypeString).
+			WithDefaultValue("").
+			WithHidden(hidden),
+		NewFlag(FlagNameIdentityUri, "Identity Server URI", FlagTypeString).
+			WithEnvVarName("UIPATH_IDENTITY_URI").
+			WithHidden(hidden),
+		b.versionFlag(hidden),
+	}
+}
+
+func (b FlagBuilder) versionFlag(hidden bool) *FlagDefinition {
+	return NewFlag(FlagNameVersion, "Specific service version", FlagTypeString).
+		WithEnvVarName("UIPATH_VERSION").
+		WithDefaultValue("").
+		WithHidden(hidden)
+}
+
+func (b FlagBuilder) helpFlag() *FlagDefinition {
+	return NewFlag(FlagNameHelp, "Show help", FlagTypeBoolean).
+		WithDefaultValue(false).
+		WithHidden(true)
+}
+
+func NewFlagBuilder() *FlagBuilder {
+	return &FlagBuilder{map[string]*FlagDefinition{}, []string{}}
 }

--- a/commandline/flag_definition.go
+++ b/commandline/flag_definition.go
@@ -1,0 +1,47 @@
+package commandline
+
+type FlagOptionFunc func(*FlagDefinition)
+
+// The FlagDefinition contains the metadata and builder methods for creating
+// command line flags.
+type FlagDefinition struct {
+	Name         string
+	Summary      string
+	Type         FlagType
+	EnvVarName   string
+	DefaultValue interface{}
+	Hidden       bool
+	Required     bool
+}
+
+func (f *FlagDefinition) WithDefaultValue(value interface{}) *FlagDefinition {
+	f.DefaultValue = value
+	return f
+}
+
+func (f *FlagDefinition) WithEnvVarName(envVarName string) *FlagDefinition {
+	f.EnvVarName = envVarName
+	return f
+}
+
+func (f *FlagDefinition) WithHidden(hidden bool) *FlagDefinition {
+	f.Hidden = hidden
+	return f
+}
+
+func (f *FlagDefinition) WithRequired(required bool) *FlagDefinition {
+	f.Required = required
+	return f
+}
+
+func NewFlag(name string, summary string, flagType FlagType) *FlagDefinition {
+	return &FlagDefinition{
+		name,
+		summary,
+		flagType,
+		"",
+		nil,
+		false,
+		false,
+	}
+}

--- a/commandline/flag_type.go
+++ b/commandline/flag_type.go
@@ -1,0 +1,27 @@
+package commandline
+
+import "fmt"
+
+// The FlagType is an enum of the supported flag definition types.
+type FlagType int
+
+const (
+	FlagTypeString FlagType = iota + 1
+	FlagTypeInteger
+	FlagTypeBoolean
+	FlagTypeStringArray
+)
+
+func (t FlagType) String() string {
+	switch t {
+	case FlagTypeString:
+		return "string"
+	case FlagTypeInteger:
+		return "integer"
+	case FlagTypeBoolean:
+		return "boolean"
+	case FlagTypeStringArray:
+		return "stringArray"
+	}
+	panic(fmt.Sprintf("Unknown flag type: %d", int(t)))
+}

--- a/commandline/help_templates.go
+++ b/commandline/help_templates.go
@@ -1,0 +1,19 @@
+package commandline
+
+const OperationCommandHelpTemplate = `NAME:
+   {{template "helpNameTemplate" .}}
+
+USAGE:
+   {{if .UsageText}}{{wrap .UsageText 3}}{{else}}{{.HelpName}}{{if .VisibleFlags}} [command options]{{end}}{{if .ArgsUsage}}{{.ArgsUsage}}{{else}} [arguments...]{{end}}{{end}}{{if .Description}}
+
+DESCRIPTION:
+   {{template "descriptionTemplate" .}}{{end}}{{if .VisibleCommands}}
+
+COMMANDS:{{template "visibleCommandTemplate" .}}{{end}}{{if .VisibleFlagCategories}}
+
+OPTIONS:{{template "visibleFlagCategoryTemplate" .}}{{else if .VisibleFlags}}
+
+OPTIONS:{{range $i, $e := .VisibleFlags}}
+   --{{$e.Name}} {{wrap $e.Usage 6}}
+{{end}}{{end}}
+`

--- a/commandline/show_command_handler.go
+++ b/commandline/show_command_handler.go
@@ -5,7 +5,6 @@ import (
 	"sort"
 
 	"github.com/UiPath/uipathcli/parser"
-	"github.com/urfave/cli/v2"
 )
 
 // showCommandHandler prints all available uipathcli commands
@@ -29,7 +28,7 @@ type commandJson struct {
 	Subcommands []commandJson   `json:"subcommands"`
 }
 
-func (h showCommandHandler) Execute(definitions []parser.Definition, globalFlags []cli.Flag) (string, error) {
+func (h showCommandHandler) Execute(definitions []parser.Definition, globalFlags []*FlagDefinition) (string, error) {
 	result := commandJson{
 		Name:        "uipath",
 		Description: "Command line interface to simplify, script and automate API calls for UiPath services",
@@ -104,7 +103,7 @@ func (h showCommandHandler) convertOperationToCommand(operation parser.Operation
 	}
 }
 
-func (h showCommandHandler) convertFlagsToCommandParameters(flags []cli.Flag) []parameterJson {
+func (h showCommandHandler) convertFlagsToCommandParameters(flags []*FlagDefinition) []parameterJson {
 	result := []parameterJson{}
 	for _, f := range flags {
 		result = append(result, h.convertFlagToCommandParameter(f))
@@ -120,37 +119,14 @@ func (h showCommandHandler) convertParametersToCommandParameters(parameters []pa
 	return result
 }
 
-func (h showCommandHandler) convertFlagToCommandParameter(flag cli.Flag) parameterJson {
-	intFlag, ok := flag.(*cli.IntFlag)
-	if ok {
-		return parameterJson{
-			Name:          intFlag.Name,
-			Description:   intFlag.Usage,
-			Type:          "integer",
-			Required:      false,
-			AllowedValues: []interface{}{},
-			DefaultValue:  intFlag.Value,
-		}
-	}
-	boolFlag, ok := flag.(*cli.BoolFlag)
-	if ok {
-		return parameterJson{
-			Name:          boolFlag.Name,
-			Description:   boolFlag.Usage,
-			Type:          "boolean",
-			Required:      false,
-			AllowedValues: []interface{}{},
-			DefaultValue:  boolFlag.Value,
-		}
-	}
-	stringFlag := flag.(*cli.StringFlag)
+func (h showCommandHandler) convertFlagToCommandParameter(flag *FlagDefinition) parameterJson {
 	return parameterJson{
-		Name:          stringFlag.Name,
-		Description:   stringFlag.Usage,
-		Type:          "string",
+		Name:          flag.Name,
+		Description:   flag.Summary,
+		Type:          flag.Type.String(),
 		Required:      false,
 		AllowedValues: []interface{}{},
-		DefaultValue:  stringFlag.Value,
+		DefaultValue:  flag.DefaultValue,
 	}
 }
 


### PR DESCRIPTION
Added command and flag definition structures to separate building the command metadata and actually rendering the CLI commands.

Moved all the interaction with the cli/v2 module in the `cli.go` source file which simplifies the interactive with the module and abstracts the details away.

The change also moves out some parts from the `command_builder` which grew in complexity.