### PR TITLE
Rename version flag to service-version

### DIFF
--- a/commandline/config_command_handler.go
+++ b/commandline/config_command_handler.go
@@ -47,8 +47,8 @@ func (h configCommandHandler) Set(key string, value string, profileName string) 
 
 func (h configCommandHandler) setConfigValue(config *config.Config, key string, value string) error {
 	keyParts := strings.Split(key, ".")
-	if key == "version" {
-		config.SetVersion(value)
+	if key == "serviceVersion" {
+		config.SetServiceVersion(value)
 		return nil
 	} else if key == "organization" {
 		config.ConfigureOrgTenant(value, "")

--- a/commandline/definition_data.go
+++ b/commandline/definition_data.go
@@ -2,11 +2,11 @@ package commandline
 
 // DefinitionData contains the name of the definition file and its data.
 type DefinitionData struct {
-	Name    string
-	Version string
-	Data    []byte
+	Name           string
+	ServiceVersion string
+	Data           []byte
 }
 
-func NewDefinitionData(name string, version string, data []byte) *DefinitionData {
-	return &DefinitionData{name, version, data}
+func NewDefinitionData(name string, serviceVersion string, data []byte) *DefinitionData {
+	return &DefinitionData{name, serviceVersion, data}
 }

--- a/commandline/definition_file_store.go
+++ b/commandline/definition_file_store.go
@@ -21,52 +21,52 @@ type DefinitionFileStore struct {
 
 const DefinitionsDirectory = "definitions"
 
-func (s *DefinitionFileStore) Names(version string) ([]string, error) {
+func (s *DefinitionFileStore) Names(serviceVersion string) ([]string, error) {
 	if s.definitions != nil {
 		names := []string{}
 		for _, definition := range s.definitions {
-			if version == definition.Version {
+			if serviceVersion == definition.ServiceVersion {
 				names = append(names, definition.Name)
 			}
 		}
 		return names, nil
 	}
 
-	definitionFiles, err := s.discoverDefinitions(version)
+	definitionFiles, err := s.discoverDefinitions(serviceVersion)
 	if err != nil {
 		return nil, err
 	}
 	return s.definitionNames(definitionFiles), nil
 }
 
-func (s *DefinitionFileStore) Read(name string, version string) (*DefinitionData, error) {
+func (s *DefinitionFileStore) Read(name string, serviceVersion string) (*DefinitionData, error) {
 	if s.definitions != nil {
 		for _, definition := range s.definitions {
-			if name == definition.Name && version == definition.Version {
+			if name == definition.Name && serviceVersion == definition.ServiceVersion {
 				return &definition, nil
 			}
 		}
 	}
 
-	definitionFiles, err := s.discoverDefinitions(version)
+	definitionFiles, err := s.discoverDefinitions(serviceVersion)
 	if err != nil {
 		return nil, err
 	}
 
 	for _, fileName := range definitionFiles {
 		if name == s.definitionName(fileName) {
-			data, err := s.readDefinitionData(version, fileName)
+			data, err := s.readDefinitionData(serviceVersion, fileName)
 			if err != nil {
 				return nil, err
 			}
-			definition := NewDefinitionData(name, version, data)
+			definition := NewDefinitionData(name, serviceVersion, data)
 			return definition, err
 		}
 	}
 	return nil, nil
 }
 
-func (s *DefinitionFileStore) discoverDefinitions(version string) ([]string, error) {
+func (s *DefinitionFileStore) discoverDefinitions(serviceVersion string) ([]string, error) {
 	if s.files != nil {
 		return s.files, nil
 	}
@@ -77,13 +77,13 @@ func (s *DefinitionFileStore) discoverDefinitions(version string) ([]string, err
 	for _, fileName := range embeddedFiles {
 		definitionFiles[fileName] = fileName
 	}
-	directoryFiles := s.discoverDefinitionsDirectory(version)
+	directoryFiles := s.discoverDefinitionsDirectory(serviceVersion)
 	for _, fileName := range directoryFiles {
 		definitionFiles[fileName] = fileName
 	}
 
 	if len(definitionFiles) == 0 {
-		return nil, fmt.Errorf("Could not find definition files in folder '%s'", s.definitionsPath(version))
+		return nil, fmt.Errorf("Could not find definition files in folder '%s'", s.definitionsPath(serviceVersion))
 	}
 
 	result := []string{}
@@ -106,9 +106,9 @@ func (s DefinitionFileStore) discoverDefinitionsEmbedded() []string {
 	return definitionFiles
 }
 
-func (s DefinitionFileStore) discoverDefinitionsDirectory(version string) []string {
+func (s DefinitionFileStore) discoverDefinitionsDirectory(serviceVersion string) []string {
 	definitionFiles := []string{}
-	definitionsDirectory := s.definitionsPath(version)
+	definitionsDirectory := s.definitionsPath(serviceVersion)
 	files, err := os.ReadDir(definitionsDirectory)
 	if err == nil {
 		for _, file := range files {
@@ -121,15 +121,15 @@ func (s DefinitionFileStore) discoverDefinitionsDirectory(version string) []stri
 	return definitionFiles
 }
 
-func (s DefinitionFileStore) definitionsPath(version string) string {
+func (s DefinitionFileStore) definitionsPath(serviceVersion string) string {
 	if s.directory != "" {
 		return s.directory
 	}
 	currentDirectory, err := os.Executable()
 	if err != nil {
-		return filepath.Join(DefinitionsDirectory, version)
+		return filepath.Join(DefinitionsDirectory, serviceVersion)
 	}
-	return filepath.Join(filepath.Dir(currentDirectory), DefinitionsDirectory, version)
+	return filepath.Join(filepath.Dir(currentDirectory), DefinitionsDirectory, serviceVersion)
 }
 
 func (s DefinitionFileStore) definitionName(path string) string {
@@ -144,8 +144,8 @@ func (s DefinitionFileStore) definitionNames(paths []string) []string {
 	return names
 }
 
-func (s DefinitionFileStore) readDefinitionData(version string, fileName string) ([]byte, error) {
-	definitionsFilePath := filepath.Join(s.definitionsPath(version), fileName)
+func (s DefinitionFileStore) readDefinitionData(serviceVersion string, fileName string) ([]byte, error) {
+	definitionsFilePath := filepath.Join(s.definitionsPath(serviceVersion), fileName)
 	data, err := os.ReadFile(definitionsFilePath)
 	if err != nil {
 		embeddedFilePath := path.Join(DefinitionsDirectory, fileName)

--- a/commandline/definition_provider.go
+++ b/commandline/definition_provider.go
@@ -28,8 +28,8 @@ type DefinitionProvider struct {
 	commandPlugins []plugin.CommandPlugin
 }
 
-func (p DefinitionProvider) Index(version string) ([]parser.Definition, error) {
-	emptyDefinitions, err := p.loadEmptyDefinitions(version)
+func (p DefinitionProvider) Index(serviceVersion string) ([]parser.Definition, error) {
+	emptyDefinitions, err := p.loadEmptyDefinitions(serviceVersion)
 	if err != nil {
 		return nil, err
 	}
@@ -44,15 +44,15 @@ func (p DefinitionProvider) Index(version string) ([]parser.Definition, error) {
 	return result, nil
 }
 
-func (p DefinitionProvider) Load(name string, version string) (*parser.Definition, error) {
-	names, err := p.store.Names(version)
+func (p DefinitionProvider) Load(name string, serviceVersion string) (*parser.Definition, error) {
+	names, err := p.store.Names(serviceVersion)
 	if err != nil {
 		return nil, err
 	}
 	definitions := []*parser.Definition{}
 	for _, n := range names {
 		if p.getServiceName(n) == name {
-			data, err := p.store.Read(n, version)
+			data, err := p.store.Read(n, serviceVersion)
 			if err != nil {
 				return nil, err
 			}
@@ -86,8 +86,8 @@ func (p DefinitionProvider) getServiceName(name string) string {
 	return name
 }
 
-func (p DefinitionProvider) loadEmptyDefinitions(version string) ([]DefinitionData, error) {
-	names, err := p.store.Names(version)
+func (p DefinitionProvider) loadEmptyDefinitions(serviceVersion string) ([]DefinitionData, error) {
+	names, err := p.store.Names(serviceVersion)
 	if err != nil {
 		return nil, err
 	}
@@ -95,7 +95,7 @@ func (p DefinitionProvider) loadEmptyDefinitions(version string) ([]DefinitionDa
 	for _, name := range names {
 		serviceName := p.getServiceName(name)
 		if len(result) == 0 || result[len(result)-1].Name != serviceName {
-			result = append(result, *NewDefinitionData(serviceName, version, []byte{}))
+			result = append(result, *NewDefinitionData(serviceName, serviceVersion, []byte{}))
 		}
 	}
 	return result, nil

--- a/commandline/definition_store.go
+++ b/commandline/definition_store.go
@@ -2,6 +2,6 @@ package commandline
 
 // DefinitionStore is used to provide the names and content of definition files.
 type DefinitionStore interface {
-	Names(version string) ([]string, error)
-	Read(name string, version string) (*DefinitionData, error)
+	Names(serviceVersion string) ([]string, error)
+	Read(name string, serviceVersion string) (*DefinitionData, error)
 }

--- a/commandline/flag_builder.go
+++ b/commandline/flag_builder.go
@@ -18,7 +18,7 @@ const FlagNameWait = "wait"
 const FlagNameWaitTimeout = "wait-timeout"
 const FlagNameFile = "file"
 const FlagNameIdentityUri = "identity-uri"
-const FlagNameVersion = "version"
+const FlagNameServiceVersion = "service-version"
 const FlagNameHelp = "help"
 
 const FlagValueFromStdIn = "-"
@@ -38,7 +38,7 @@ var FlagNamesPredefined = []string{
 	FlagNameWaitTimeout,
 	FlagNameFile,
 	FlagNameIdentityUri,
-	FlagNameVersion,
+	FlagNameServiceVersion,
 	FlagNameHelp,
 }
 
@@ -75,8 +75,8 @@ func (b *FlagBuilder) AddHelpFlag() *FlagBuilder {
 	return b
 }
 
-func (b *FlagBuilder) AddVersionFlag(hidden bool) *FlagBuilder {
-	b.AddFlag(b.versionFlag(hidden))
+func (b *FlagBuilder) AddServiceVersionFlag(hidden bool) *FlagBuilder {
+	b.AddFlag(b.serviceVersionFlag(hidden))
 	return b
 }
 
@@ -130,13 +130,13 @@ func (b FlagBuilder) defaultFlags(hidden bool) []*FlagDefinition {
 		NewFlag(FlagNameIdentityUri, "Identity Server URI", FlagTypeString).
 			WithEnvVarName("UIPATH_IDENTITY_URI").
 			WithHidden(hidden),
-		b.versionFlag(hidden),
+		b.serviceVersionFlag(hidden),
 	}
 }
 
-func (b FlagBuilder) versionFlag(hidden bool) *FlagDefinition {
-	return NewFlag(FlagNameVersion, "Specific service version", FlagTypeString).
-		WithEnvVarName("UIPATH_VERSION").
+func (b FlagBuilder) serviceVersionFlag(hidden bool) *FlagDefinition {
+	return NewFlag(FlagNameServiceVersion, "Specific service version", FlagTypeString).
+		WithEnvVarName("UIPATH_SERVICE_VERSION").
 		WithDefaultValue("").
 		WithHidden(hidden)
 }

--- a/config/config.go
+++ b/config/config.go
@@ -9,16 +9,16 @@ import (
 
 // The Config structure holds the config data from the selected profile.
 type Config struct {
-	Uri          *url.URL
-	Organization string
-	Tenant       string
-	Parameter    map[string]string
-	Header       map[string]string
-	Auth         AuthConfig
-	Insecure     bool
-	Debug        bool
-	Output       string
-	Version      string
+	Uri            *url.URL
+	Organization   string
+	Tenant         string
+	Parameter      map[string]string
+	Header         map[string]string
+	Auth           AuthConfig
+	Insecure       bool
+	Debug          bool
+	Output         string
+	ServiceVersion string
 }
 
 // AuthConfig with metadata used for authenticating the caller.
@@ -169,6 +169,6 @@ func (c Config) SetAuthProperty(key string, value string) {
 	c.Auth.Config["properties"] = properties
 }
 
-func (c *Config) SetVersion(version string) {
-	c.Version = version
+func (c *Config) SetServiceVersion(serviceVersion string) {
+	c.ServiceVersion = serviceVersion
 }

--- a/config/config_provider.go
+++ b/config/config_provider.go
@@ -47,7 +47,7 @@ func (p *ConfigProvider) Update(profileName string, config Config) error {
 	profile.Auth = config.Auth.Config
 	profile.Header = config.Header
 	profile.Parameter = config.Parameter
-	profile.Version = config.Version
+	profile.ServiceVersion = config.ServiceVersion
 
 	if index == -1 {
 		p.profiles = append(p.profiles, profile)
@@ -82,10 +82,10 @@ func (p ConfigProvider) convertToConfig(profile profileYaml) Config {
 			Type:   fmt.Sprintf("%v", profile.Auth["type"]),
 			Config: profile.Auth,
 		},
-		Insecure: profile.Insecure,
-		Debug:    profile.Debug,
-		Output:   profile.Output,
-		Version:  profile.Version,
+		Insecure:       profile.Insecure,
+		Debug:          profile.Debug,
+		Output:         profile.Output,
+		ServiceVersion: profile.ServiceVersion,
 	}
 }
 

--- a/config/profile_yaml.go
+++ b/config/profile_yaml.go
@@ -1,15 +1,15 @@
 package config
 
 type profileYaml struct {
-	Name         string                 `yaml:"name"`
-	Organization string                 `yaml:"organization,omitempty"`
-	Tenant       string                 `yaml:"tenant,omitempty"`
-	Uri          urlYaml                `yaml:"uri,omitempty"`
-	Parameter    map[string]string      `yaml:"parameter,omitempty"`
-	Header       map[string]string      `yaml:"header,omitempty"`
-	Auth         map[string]interface{} `yaml:"auth,omitempty"`
-	Insecure     bool                   `yaml:"insecure,omitempty"`
-	Debug        bool                   `yaml:"debug,omitempty"`
-	Output       string                 `yaml:"output,omitempty"`
-	Version      string                 `yaml:"version,omitempty"`
+	Name           string                 `yaml:"name"`
+	Organization   string                 `yaml:"organization,omitempty"`
+	Tenant         string                 `yaml:"tenant,omitempty"`
+	Uri            urlYaml                `yaml:"uri,omitempty"`
+	Parameter      map[string]string      `yaml:"parameter,omitempty"`
+	Header         map[string]string      `yaml:"header,omitempty"`
+	Auth           map[string]interface{} `yaml:"auth,omitempty"`
+	Insecure       bool                   `yaml:"insecure,omitempty"`
+	Debug          bool                   `yaml:"debug,omitempty"`
+	Output         string                 `yaml:"output,omitempty"`
+	ServiceVersion string                 `yaml:"serviceVersion,omitempty"`
 }

--- a/test/config_set_test.go
+++ b/test/config_set_test.go
@@ -320,13 +320,13 @@ func TestConfigSetAuthProperties(t *testing.T) {
 	}
 }
 
-func TestConfigSetVersion(t *testing.T) {
+func TestConfigSetServiceVersion(t *testing.T) {
 	configFile := createFile(t)
 	context := NewContextBuilder().
 		WithConfigFile(configFile).
 		Build()
 
-	RunCli([]string{"config", "set", "--key", "version", "--value", "22.10"}, context)
+	RunCli([]string{"config", "set", "--key", "serviceVersion", "--value", "22.10"}, context)
 
 	config, err := os.ReadFile(configFile)
 	if err != nil {
@@ -334,7 +334,7 @@ func TestConfigSetVersion(t *testing.T) {
 	}
 	expectedConfig := `profiles:
 - name: default
-  version: "22.10"
+  serviceVersion: "22.10"
 `
 	if string(config) != expectedConfig {
 		t.Errorf("Expected generated config %v, but got %v", expectedConfig, string(config))

--- a/test/parser_test.go
+++ b/test/parser_test.go
@@ -1379,7 +1379,7 @@ paths:
 		WithDefinitionVersion("myversionedservice", "2.0", definition2_0).
 		Build()
 
-	result := RunCli([]string{"--version", "2.0", "--help"}, context)
+	result := RunCli([]string{"--service-version", "2.0", "--help"}, context)
 
 	if !strings.Contains(result.StdOut, "myversionedservice") {
 		t.Errorf("Could not find versioned service definition, but got: %v", result.StdOut)
@@ -1435,7 +1435,7 @@ paths:
 		WithDefinitionVersion("myversionedservice", "2.0", definition2_0).
 		Build()
 
-	result := RunCli([]string{"myversionedservice", "--version", "2.0", "--help"}, context)
+	result := RunCli([]string{"myversionedservice", "--service-version", "2.0", "--help"}, context)
 
 	if !strings.Contains(result.StdOut, "ping-v2") {
 		t.Errorf("Could not find versioned service operation, but got: %v", result.StdOut)

--- a/test/setup.go
+++ b/test/setup.go
@@ -41,8 +41,8 @@ func (b *ContextBuilder) WithDefinition(name string, data string) *ContextBuilde
 	return b
 }
 
-func (b *ContextBuilder) WithDefinitionVersion(name string, version string, data string) *ContextBuilder {
-	definitionData := commandline.NewDefinitionData(name, version, []byte(data))
+func (b *ContextBuilder) WithDefinitionVersion(name string, serviceVersion string, data string) *ContextBuilder {
+	definitionData := commandline.NewDefinitionData(name, serviceVersion, []byte(data))
 	b.context.Definitions = append(b.context.Definitions, *definitionData)
 	return b
 }

--- a/test/show_command_test.go
+++ b/test/show_command_test.go
@@ -141,7 +141,7 @@ paths:
 		names = append(names, parameter["name"].(string))
 	}
 
-	expectedNames := []string{"debug", "profile", "uri", "organization", "tenant", "insecure", "output", "query", "wait", "wait-timeout", "file", "identity-uri", "version", "help"}
+	expectedNames := []string{"debug", "profile", "uri", "organization", "tenant", "insecure", "output", "query", "wait", "wait-timeout", "file", "identity-uri", "service-version", "help"}
 	if !reflect.DeepEqual(names, expectedNames) {
 		t.Errorf("Unexpected global parameters in output, expected: %v but got: %v", expectedNames, names)
 	}


### PR DESCRIPTION
The `--version` flag is a very common and basically a reserved flag. 
Renaming the UiPath specific version flag to `--service-version` 
which avoids name conflicts and makes the intent of the flag clear.