### PR TITLE
Add version flag to output build information

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,6 +7,8 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    outputs:
+      UIPATHCLI_VERSION: ${{ steps.version.outputs.UIPATHCLI_VERSION }}
     env:
       CGO_ENABLED: "0"
     steps:
@@ -17,10 +19,16 @@ jobs:
         with:
           go-version: '1.22.2'
           cache: true
+      - name: Version
+        id: version
+        run: |
+          UIPATHCLI_VERSION=$(./version.sh "$UIPATHCLI_BASE_VERSION")
+          echo "UIPATHCLI_VERSION=$(echo $UIPATHCLI_VERSION)" >> $GITHUB_ENV
+          echo "UIPATHCLI_VERSION=$(echo $UIPATHCLI_VERSION)" >> $GITHUB_OUTPUT
       - name: Install dependencies
         run: go get .
       - name: Build
-        run: go build .
+        run: go build -ldflags="-X github.com/UiPath/uipathcli/commandline.Version=$UIPATHCLI_VERSION" .
       - name: Lint
         run: |
           go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.54.2
@@ -74,6 +82,8 @@ jobs:
     needs: build
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    env:
+      UIPATHCLI_VERSION: ${{ needs.build.outputs.UIPATHCLI_VERSION }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -83,6 +93,6 @@ jobs:
           name: packages
           path: build/packages/
       - name: Publish
-        run: ./publish.sh "$UIPATHCLI_BASE_VERSION"
+        run: ./publish.sh "$UIPATHCLI_VERSION"
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/build.ps1
+++ b/build.ps1
@@ -3,21 +3,21 @@ New-Item -ItemType Directory -Force -Path build | out-null
 Copy-Item README.md -Destination build/README.md
 
 Write-Host "Building Linux (amd64) executable"
-pwsh -Command { $env:GOOS = "linux"; $env:GOARCH = "amd64"; go build -o build/uipath-linux-amd64 }
+pwsh -Command { $env:GOOS = "linux"; $env:GOARCH = "amd64"; go build -ldflags="-X github.com/UiPath/uipathcli/commandline.Version=$env:UIPATHCLI_VERSION" -o build/uipath-linux-amd64 }
 
 Write-Host "Building Windows (amd64) executable"
-pwsh -Command { $env:GOOS = "windows"; $env:GOARCH = "amd64"; go build -o build/uipath-windows-amd64.exe }
+pwsh -Command { $env:GOOS = "windows"; $env:GOARCH = "amd64"; go build -ldflags="-X github.com/UiPath/uipathcli/commandline.Version=$env:UIPATHCLI_VERSION" -o build/uipath-windows-amd64.exe }
 
 Write-Host "Building MacOS (amd64) executable"
-pwsh -Command { $env:GOOS = "darwin"; $env:GOARCH = "amd64"; go build -o build/uipath-darwin-amd64 }
+pwsh -Command { $env:GOOS = "darwin"; $env:GOARCH = "amd64"; go build -ldflags="-X github.com/UiPath/uipathcli/commandline.Version=$env:UIPATHCLI_VERSION" -o build/uipath-darwin-amd64 }
 
 Write-Host "Building Linux (arm64) executable"
-pwsh -Command { $env:GOOS = "linux"; $env:GOARCH = "arm64"; go build -o build/uipath-linux-arm64 }
+pwsh -Command { $env:GOOS = "linux"; $env:GOARCH = "arm64"; go build -ldflags="-X github.com/UiPath/uipathcli/commandline.Version=$env:UIPATHCLI_VERSION" -o build/uipath-linux-arm64 }
 
 Write-Host "Building Windows (arm64) executable"
-pwsh -Command { $env:GOOS = "windows"; $env:GOARCH = "arm64"; go build -o build/uipath-windows-arm64.exe }
+pwsh -Command { $env:GOOS = "windows"; $env:GOARCH = "arm64"; go build -ldflags="-X github.com/UiPath/uipathcli/commandline.Version=$env:UIPATHCLI_VERSION" -o build/uipath-windows-arm64.exe }
 
 Write-Host "Building MacOS (arm64) executable"
-pwsh -Command { $env:GOOS = "darwin"; $env:GOARCH = "arm64"; go build -o build//uipath-darwin-arm64 }
+pwsh -Command { $env:GOOS = "darwin"; $env:GOARCH = "arm64"; go build -ldflags="-X github.com/UiPath/uipathcli/commandline.Version=$env:UIPATHCLI_VERSION" -o build//uipath-darwin-arm64 }
 
 Write-Host "Successfully completed"

--- a/build.sh
+++ b/build.sh
@@ -6,21 +6,21 @@ mkdir -p build
 cp README.md build/README.md
 
 echo "Building Linux (amd64) executable"
-GOOS=linux GOARCH=amd64 go build -o build/uipath-linux-amd64
+GOOS=linux GOARCH=amd64 go build -ldflags="-X github.com/UiPath/uipathcli/commandline.Version=$UIPATHCLI_VERSION" -o build/uipath-linux-amd64
 
 echo "Building Windows (amd64) executable"
-GOOS=windows GOARCH=amd64 go build -o build/uipath-windows-amd64.exe
+GOOS=windows GOARCH=amd64 go build -ldflags="-X github.com/UiPath/uipathcli/commandline.Version=$UIPATHCLI_VERSION" -o build/uipath-windows-amd64.exe
 
 echo "Building MacOS (amd64) executable"
-GOOS=darwin GOARCH=amd64 go build -o build/uipath-darwin-amd64
+GOOS=darwin GOARCH=amd64 go build -ldflags="-X github.com/UiPath/uipathcli/commandline.Version=$UIPATHCLI_VERSION" -o build/uipath-darwin-amd64
 
 echo "Building Linux (arm64) executable"
-GOOS=linux GOARCH=arm64 go build -o build/uipath-linux-arm64
+GOOS=linux GOARCH=arm64 go build -ldflags="-X github.com/UiPath/uipathcli/commandline.Version=$UIPATHCLI_VERSION" -o build/uipath-linux-arm64
 
 echo "Building Windows (arm64) executable"
-GOOS=windows GOARCH=arm64 go build -o build/uipath-windows-arm64.exe
+GOOS=windows GOARCH=arm64 go build -ldflags="-X github.com/UiPath/uipathcli/commandline.Version=$UIPATHCLI_VERSION" -o build/uipath-windows-arm64.exe
 
 echo "Building MacOS (arm64) executable"
-GOOS=darwin GOARCH=arm64 go build -o build/uipath-darwin-arm64
+GOOS=darwin GOARCH=arm64 go build -ldflags="-X github.com/UiPath/uipathcli/commandline.Version=$UIPATHCLI_VERSION" -o build/uipath-darwin-arm64
 
 echo "Successfully completed"

--- a/commandline/cli.go
+++ b/commandline/cli.go
@@ -43,6 +43,7 @@ func (c Cli) run(args []string, input utils.Stream) error {
 
 	flags := NewFlagBuilder().
 		AddDefaultFlags(false).
+		AddVersionFlag().
 		Build()
 
 	commands, err := CommandBuilder.Create(args)
@@ -62,6 +63,14 @@ func (c Cli) run(args []string, input utils.Stream) error {
 		HideVersion:               true,
 		HideHelpCommand:           true,
 		DisableSliceFlagSeparator: true,
+		Action: func(context *cli.Context) error {
+			if context.IsSet(FlagNameVersion) {
+				handler := newVersionCommandHandler(c.stdOut)
+				handler.Execute()
+				return nil
+			}
+			return cli.ShowAppHelp(context)
+		},
 	}
 	return app.Run(args)
 }

--- a/commandline/flag_builder.go
+++ b/commandline/flag_builder.go
@@ -20,6 +20,7 @@ const FlagNameFile = "file"
 const FlagNameIdentityUri = "identity-uri"
 const FlagNameServiceVersion = "service-version"
 const FlagNameHelp = "help"
+const FlagNameVersion = "version"
 
 const FlagValueFromStdIn = "-"
 const FlagValueOutputFormatJson = "json"
@@ -40,6 +41,7 @@ var FlagNamesPredefined = []string{
 	FlagNameIdentityUri,
 	FlagNameServiceVersion,
 	FlagNameHelp,
+	FlagNameVersion,
 }
 
 // The FlagBuilder can be used to prepare a list of flags for a CLI command.
@@ -72,6 +74,11 @@ func (b *FlagBuilder) AddDefaultFlags(hidden bool) *FlagBuilder {
 
 func (b *FlagBuilder) AddHelpFlag() *FlagBuilder {
 	b.AddFlag(b.helpFlag())
+	return b
+}
+
+func (b *FlagBuilder) AddVersionFlag() *FlagBuilder {
+	b.AddFlag(b.versionFlag())
 	return b
 }
 
@@ -132,6 +139,11 @@ func (b FlagBuilder) defaultFlags(hidden bool) []*FlagDefinition {
 			WithHidden(hidden),
 		b.serviceVersionFlag(hidden),
 	}
+}
+
+func (b FlagBuilder) versionFlag() *FlagDefinition {
+	return NewFlag(FlagNameVersion, "Display the build version", FlagTypeBoolean).
+		WithHidden(true)
 }
 
 func (b FlagBuilder) serviceVersionFlag(hidden bool) *FlagDefinition {

--- a/commandline/version_command_handler.go
+++ b/commandline/version_command_handler.go
@@ -1,0 +1,30 @@
+package commandline
+
+import (
+	"fmt"
+	"io"
+	"runtime"
+)
+
+// This Version variable is overridden during build time
+// by providing the linker flag:
+// -ldflags="-X github.com/UiPath/uipathcli/commandline.Version=1.2.3"
+var Version = "main"
+
+// The VersionCommandHandler outputs the build information
+//
+// Example:
+// uipath --version
+//
+// uipathcli v1.0.0 (windows, amd64)
+type versionCommandHandler struct {
+	StdOut io.Writer
+}
+
+func (h versionCommandHandler) Execute() {
+	fmt.Fprintf(h.StdOut, "uipathcli %s (%s, %s)\n", Version, runtime.GOOS, runtime.GOARCH)
+}
+
+func newVersionCommandHandler(stdOut io.Writer) *versionCommandHandler {
+	return &versionCommandHandler{stdOut}
+}

--- a/test/version_test.go
+++ b/test/version_test.go
@@ -1,0 +1,17 @@
+package test
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestVersionOutput(t *testing.T) {
+	context := NewContextBuilder().
+		Build()
+
+	result := RunCli([]string{"--version"}, context)
+
+	if !strings.HasPrefix(result.StdOut, "uipathcli main") {
+		t.Errorf("Did not return version information, got: %v", result.StdOut)
+	}
+}

--- a/version.sh
+++ b/version.sh
@@ -1,0 +1,76 @@
+#! /bin/bash
+############################################################
+# Generates the next version to publish
+#
+# DESCRIPTION:
+# This scripts retrieves the latest tag, increments the
+# version and creates a new release on GitHub.
+############################################################
+
+set -o pipefail
+set -e
+
+############################################################
+# Retrieves the latest version by sorting the git tags
+#
+# Returns:
+#   The latest git tag
+############################################################
+function get_latest_version()
+{
+    local version_filter="$1"
+
+    git fetch --all --tags --quiet
+    git tag | sort -V | grep "^$version_filter.*" | tail -1 || echo "$version_filter"
+}
+
+############################################################
+# Increment patch version on the provided semver string
+#
+# Arguments:
+#   - The version (semver format, e.g. 1.0.0)
+#
+# Returns:
+#   Incremented patch version (e.g. 1.0.1)
+############################################################
+function increment_patch_version()
+{
+    local version="$1"
+
+    local array
+    local IFS='.'; read -r -a array <<< "$version"
+    if [ -z "${array[2]}" ]; then
+        array[2]="0"
+    else
+        array[2]=$((array[2]+1))
+    fi
+    echo "$(local IFS='.'; echo "${array[*]}")"
+}
+
+############################################################
+# Create new tag
+#
+# Arguments:
+#   - The tag name
+############################################################
+function create_tag()
+{
+    local tag_name="$1"
+
+    git tag "$tag_name"
+}
+
+############################################################
+# Main
+############################################################
+function main()
+{
+    local base_version="$1"
+    local latest_version
+    local new_version
+
+    latest_version=$(get_latest_version "$base_version")
+    new_version=$(increment_patch_version "$latest_version")
+    echo "$new_version"
+}
+main "$1"


### PR DESCRIPTION
Generating the version number before building and embedding it into the executable so that it can be outputted by the following command:

`uipath --version`

`uipathcli v1.0.0 (windows, amd64)`