### PR TITLE
Upgrade GitHub Action to latest versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,9 +13,9 @@ jobs:
       CGO_ENABLED: "0"
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: '1.22.2'
           cache: true
@@ -44,7 +44,7 @@ jobs:
       - name: Package
         run: ./build.sh && ./package.sh
       - name: Upload packages
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: packages
           path: build/packages/
@@ -59,9 +59,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Download packages
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: packages
           path: build/packages/
@@ -70,13 +70,13 @@ jobs:
           tar -xzvf build/packages/uipathcli-linux-amd64.tar.gz
           ./uipath commands show > documentation/commands.json
       - name: Setup Pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v5
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           path: 'documentation'
       - name: Deploy to GitHub Pages
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4
 
   release:
     needs: build
@@ -86,9 +86,9 @@ jobs:
       UIPATHCLI_VERSION: ${{ needs.build.outputs.UIPATHCLI_VERSION }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Download packages
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: packages
           path: build/packages/


### PR DESCRIPTION
Some versions of the GitHub Actions are deprecated and getting removed. Upgrading all actions to the latest versions.