### PR TITLE
Set content-length header when available

### DIFF
--- a/test/execution_test.go
+++ b/test/execution_test.go
@@ -1260,6 +1260,10 @@ paths:
 	if contentType != "application/octet-stream" {
 		t.Errorf("Content-Type is not application/octet-stream, got: %v", contentType)
 	}
+	contentLength := result.RequestHeader["content-length"]
+	if contentLength != "11" {
+		t.Errorf("Content-Length is not 11, got: %v", contentLength)
+	}
 	if result.RequestBody != "hello-world" {
 		t.Errorf("Request body is not as expected, got: %v", result.RequestBody)
 	}


### PR DESCRIPTION
When uploading raw data in the request data a file on disk, the file size is known and can be added as a content length header.

Extended the executor to retrieve the file size and add it as a content-length header when available.