### PR TITLE
Run tests on Windows and MacOS

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,6 +3,7 @@ on: [push]
 
 env:
   UIPATHCLI_BASE_VERSION: "v1.1"
+  GO_VERSION: "1.22.2"
 
 jobs:
   build:
@@ -17,7 +18,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22.2'
+          go-version: ${{ env.GO_VERSION }}
           cache: true
       - name: Version
         id: version
@@ -25,22 +26,12 @@ jobs:
           UIPATHCLI_VERSION=$(./version.sh "$UIPATHCLI_BASE_VERSION")
           echo "UIPATHCLI_VERSION=$(echo $UIPATHCLI_VERSION)" >> $GITHUB_ENV
           echo "UIPATHCLI_VERSION=$(echo $UIPATHCLI_VERSION)" >> $GITHUB_OUTPUT
-      - name: Install dependencies
-        run: go get .
       - name: Build
         run: go build -ldflags="-X github.com/UiPath/uipathcli/commandline.Version=$UIPATHCLI_VERSION" .
       - name: Lint
         run: |
           go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.54.2
           golangci-lint run
-      - name: Test
-        run: go test -coverprofile="coverage.out" -coverpkg "$(go list github.com/UiPath/uipathcli/... | grep -v 'test' | tr '\n' ',')" ./...
-      - name: Coverage
-        env:
-          COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}      
-        run: |
-          go install github.com/mattn/goveralls@latest
-          goveralls -coverprofile="coverage.out" -service="github"
       - name: Package
         run: ./build.sh && ./package.sh
       - name: Upload packages
@@ -50,8 +41,53 @@ jobs:
           path: build/packages/
           if-no-files-found: error
 
+  test_linux:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+      - name: Test
+        run: go test -coverprofile="coverage.out" -coverpkg "$(go list github.com/UiPath/uipathcli/... | grep -v 'test' | tr '\n' ',')" ./...
+      - name: Coverage
+        env:
+          COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}      
+        run: |
+          go install github.com/mattn/goveralls@latest
+          goveralls -coverprofile="coverage.out" -service="github"
+
+  test_windows:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+      - name: Test
+        run: go test ./...
+
+  test_macos:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+      - name: Test
+        run: go test ./...
+
   publish_pages:
-    needs: build
+    needs: [build, test_linux, test_windows, test_macos]
     permissions:
       pages: write
       id-token: write
@@ -79,7 +115,7 @@ jobs:
         uses: actions/deploy-pages@v4
 
   release:
-    needs: build
+    needs: [build, test_linux, test_windows, test_macos]
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     env:

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build/
 coverage.out
 coverage.html
 bin/
+tmp/

--- a/main_test.go
+++ b/main_test.go
@@ -213,7 +213,13 @@ func createFile(t *testing.T, directory string, name string) string {
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() { os.Remove(tempFile.Name()) })
+	defer tempFile.Close()
+	t.Cleanup(func() {
+		err := os.Remove(tempFile.Name())
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
 	return tempFile.Name()
 }
 

--- a/plugin/digitizer/digitizer_plugin_test.go
+++ b/plugin/digitizer/digitizer_plugin_test.go
@@ -381,7 +381,13 @@ func createFile(t *testing.T) string {
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() { os.Remove(tempFile.Name()) })
+	defer tempFile.Close()
+	t.Cleanup(func() {
+		err := os.Remove(tempFile.Name())
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
 	return tempFile.Name()
 }
 

--- a/plugin/orchestrator/orchestrator_plugin_test.go
+++ b/plugin/orchestrator/orchestrator_plugin_test.go
@@ -504,7 +504,13 @@ func createFile(t *testing.T) string {
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() { os.Remove(tempFile.Name()) })
+	defer tempFile.Close()
+	t.Cleanup(func() {
+		err := os.Remove(tempFile.Name())
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
 	return tempFile.Name()
 }
 

--- a/test/execution_test.go
+++ b/test/execution_test.go
@@ -1288,10 +1288,10 @@ paths:
 		WithResponse(200, "").
 		Build()
 
-	path := createFile(t)
+	currentPath, _ := os.Getwd()
+	path := createFileInFolder(t, filepath.Join(currentPath, "tmp"))
 	writeFile(t, path, []byte("hello-world"))
 
-	currentPath, _ := os.Getwd()
 	relativePath, _ := filepath.Rel(currentPath, path)
 	result := RunCli([]string{"myservice", "upload", "--file", relativePath}, context)
 

--- a/test/setup.go
+++ b/test/setup.go
@@ -229,11 +229,27 @@ func RunCli(args []string, context Context) Result {
 }
 
 func createFile(t *testing.T) string {
-	tempFile, err := os.CreateTemp("", "uipath-test")
+	return createFileInFolder(t, "")
+}
+
+func createFileInFolder(t *testing.T, path string) string {
+	if path != "" {
+		err := os.MkdirAll(path, 0700)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	tempFile, err := os.CreateTemp(path, "uipath-test")
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() { os.Remove(tempFile.Name()) })
+	defer tempFile.Close()
+	t.Cleanup(func() {
+		err := os.Remove(tempFile.Name())
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
 	return tempFile.Name()
 }
 

--- a/utils/file_stream_test.go
+++ b/utils/file_stream_test.go
@@ -18,6 +18,7 @@ func TestFileStreamName(t *testing.T) {
 
 func TestFileStreamSize(t *testing.T) {
 	tempFile, _ := os.CreateTemp("", "uipath-test")
+	defer tempFile.Close()
 	t.Cleanup(func() { os.Remove(tempFile.Name()) })
 	err := os.WriteFile(tempFile.Name(), []byte("hello-world"), 0600)
 	if err != nil {
@@ -37,6 +38,7 @@ func TestFileStreamSize(t *testing.T) {
 
 func TestFileStreamData(t *testing.T) {
 	tempFile, _ := os.CreateTemp("", "uipath-test")
+	defer tempFile.Close()
 	t.Cleanup(func() { os.Remove(tempFile.Name()) })
 	err := os.WriteFile(tempFile.Name(), []byte("hello-world"), 0600)
 	if err != nil {


### PR DESCRIPTION
- Extend the CI workflow to test on Windows and MacOS
- Add missing Close() calls when opening the temporary test files
- Fix test with relative paths on different drives. On the Windows GitHub runners the cache directory is on drive C and the current working directory is on drive D which makes the relative path resolution fail.