### PR TITLE
Add User-Agent header to requests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,7 @@ jobs:
           echo "UIPATHCLI_VERSION=$(echo $UIPATHCLI_VERSION)" >> $GITHUB_ENV
           echo "UIPATHCLI_VERSION=$(echo $UIPATHCLI_VERSION)" >> $GITHUB_OUTPUT
       - name: Build
-        run: go build -ldflags="-X github.com/UiPath/uipathcli/commandline.Version=$UIPATHCLI_VERSION" .
+        run: go build -ldflags="-X github.com/UiPath/uipathcli/utils.Version=$UIPATHCLI_VERSION" .
       - name: Lint
         run: |
           go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.63.4

--- a/build.ps1
+++ b/build.ps1
@@ -3,21 +3,21 @@ New-Item -ItemType Directory -Force -Path build | out-null
 Copy-Item README.md -Destination build/README.md
 
 Write-Host "Building Linux (amd64) executable"
-pwsh -Command { $env:GOOS = "linux"; $env:GOARCH = "amd64"; go build -ldflags="-X github.com/UiPath/uipathcli/commandline.Version=$env:UIPATHCLI_VERSION" -o build/uipath-linux-amd64 }
+pwsh -Command { $env:GOOS = "linux"; $env:GOARCH = "amd64"; go build -ldflags="-X github.com/UiPath/uipathcli/utils.Version=$env:UIPATHCLI_VERSION" -o build/uipath-linux-amd64 }
 
 Write-Host "Building Windows (amd64) executable"
-pwsh -Command { $env:GOOS = "windows"; $env:GOARCH = "amd64"; go build -ldflags="-X github.com/UiPath/uipathcli/commandline.Version=$env:UIPATHCLI_VERSION" -o build/uipath-windows-amd64.exe }
+pwsh -Command { $env:GOOS = "windows"; $env:GOARCH = "amd64"; go build -ldflags="-X github.com/UiPath/uipathcli/utils.Version=$env:UIPATHCLI_VERSION" -o build/uipath-windows-amd64.exe }
 
 Write-Host "Building MacOS (amd64) executable"
-pwsh -Command { $env:GOOS = "darwin"; $env:GOARCH = "amd64"; go build -ldflags="-X github.com/UiPath/uipathcli/commandline.Version=$env:UIPATHCLI_VERSION" -o build/uipath-darwin-amd64 }
+pwsh -Command { $env:GOOS = "darwin"; $env:GOARCH = "amd64"; go build -ldflags="-X github.com/UiPath/uipathcli/utils.Version=$env:UIPATHCLI_VERSION" -o build/uipath-darwin-amd64 }
 
 Write-Host "Building Linux (arm64) executable"
-pwsh -Command { $env:GOOS = "linux"; $env:GOARCH = "arm64"; go build -ldflags="-X github.com/UiPath/uipathcli/commandline.Version=$env:UIPATHCLI_VERSION" -o build/uipath-linux-arm64 }
+pwsh -Command { $env:GOOS = "linux"; $env:GOARCH = "arm64"; go build -ldflags="-X github.com/UiPath/uipathcli/utils.Version=$env:UIPATHCLI_VERSION" -o build/uipath-linux-arm64 }
 
 Write-Host "Building Windows (arm64) executable"
-pwsh -Command { $env:GOOS = "windows"; $env:GOARCH = "arm64"; go build -ldflags="-X github.com/UiPath/uipathcli/commandline.Version=$env:UIPATHCLI_VERSION" -o build/uipath-windows-arm64.exe }
+pwsh -Command { $env:GOOS = "windows"; $env:GOARCH = "arm64"; go build -ldflags="-X github.com/UiPath/uipathcli/utils.Version=$env:UIPATHCLI_VERSION" -o build/uipath-windows-arm64.exe }
 
 Write-Host "Building MacOS (arm64) executable"
-pwsh -Command { $env:GOOS = "darwin"; $env:GOARCH = "arm64"; go build -ldflags="-X github.com/UiPath/uipathcli/commandline.Version=$env:UIPATHCLI_VERSION" -o build//uipath-darwin-arm64 }
+pwsh -Command { $env:GOOS = "darwin"; $env:GOARCH = "arm64"; go build -ldflags="-X github.com/UiPath/uipathcli/utils.Version=$env:UIPATHCLI_VERSION" -o build//uipath-darwin-arm64 }
 
 Write-Host "Successfully completed"

--- a/build.sh
+++ b/build.sh
@@ -6,21 +6,21 @@ mkdir -p build
 cp README.md build/README.md
 
 echo "Building Linux (amd64) executable"
-GOOS=linux GOARCH=amd64 go build -ldflags="-X github.com/UiPath/uipathcli/commandline.Version=$UIPATHCLI_VERSION" -o build/uipath-linux-amd64
+GOOS=linux GOARCH=amd64 go build -ldflags="-X github.com/UiPath/uipathcli/utils.Version=$UIPATHCLI_VERSION" -o build/uipath-linux-amd64
 
 echo "Building Windows (amd64) executable"
-GOOS=windows GOARCH=amd64 go build -ldflags="-X github.com/UiPath/uipathcli/commandline.Version=$UIPATHCLI_VERSION" -o build/uipath-windows-amd64.exe
+GOOS=windows GOARCH=amd64 go build -ldflags="-X github.com/UiPath/uipathcli/utils.Version=$UIPATHCLI_VERSION" -o build/uipath-windows-amd64.exe
 
 echo "Building MacOS (amd64) executable"
-GOOS=darwin GOARCH=amd64 go build -ldflags="-X github.com/UiPath/uipathcli/commandline.Version=$UIPATHCLI_VERSION" -o build/uipath-darwin-amd64
+GOOS=darwin GOARCH=amd64 go build -ldflags="-X github.com/UiPath/uipathcli/utils.Version=$UIPATHCLI_VERSION" -o build/uipath-darwin-amd64
 
 echo "Building Linux (arm64) executable"
-GOOS=linux GOARCH=arm64 go build -ldflags="-X github.com/UiPath/uipathcli/commandline.Version=$UIPATHCLI_VERSION" -o build/uipath-linux-arm64
+GOOS=linux GOARCH=arm64 go build -ldflags="-X github.com/UiPath/uipathcli/utils.Version=$UIPATHCLI_VERSION" -o build/uipath-linux-arm64
 
 echo "Building Windows (arm64) executable"
-GOOS=windows GOARCH=arm64 go build -ldflags="-X github.com/UiPath/uipathcli/commandline.Version=$UIPATHCLI_VERSION" -o build/uipath-windows-arm64.exe
+GOOS=windows GOARCH=arm64 go build -ldflags="-X github.com/UiPath/uipathcli/utils.Version=$UIPATHCLI_VERSION" -o build/uipath-windows-arm64.exe
 
 echo "Building MacOS (arm64) executable"
-GOOS=darwin GOARCH=arm64 go build -ldflags="-X github.com/UiPath/uipathcli/commandline.Version=$UIPATHCLI_VERSION" -o build/uipath-darwin-arm64
+GOOS=darwin GOARCH=arm64 go build -ldflags="-X github.com/UiPath/uipathcli/utils.Version=$UIPATHCLI_VERSION" -o build/uipath-darwin-arm64
 
 echo "Successfully completed"

--- a/commandline/version_command_handler.go
+++ b/commandline/version_command_handler.go
@@ -4,12 +4,9 @@ import (
 	"fmt"
 	"io"
 	"runtime"
-)
 
-// This Version variable is overridden during build time
-// by providing the linker flag:
-// -ldflags="-X github.com/UiPath/uipathcli/commandline.Version=1.2.3"
-var Version = "main"
+	"github.com/UiPath/uipathcli/utils"
+)
 
 // The VersionCommandHandler outputs the build information
 //
@@ -22,7 +19,7 @@ type versionCommandHandler struct {
 }
 
 func (h versionCommandHandler) Execute() {
-	fmt.Fprintf(h.StdOut, "uipathcli %s (%s, %s)\n", Version, runtime.GOOS, runtime.GOARCH)
+	fmt.Fprintf(h.StdOut, "uipathcli %s (%s, %s)\n", utils.Version, runtime.GOOS, runtime.GOARCH)
 }
 
 func newVersionCommandHandler(stdOut io.Writer) *versionCommandHandler {

--- a/executor/http_executor.go
+++ b/executor/http_executor.go
@@ -11,6 +11,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/url"
+	"runtime"
 	"strings"
 	"time"
 
@@ -29,6 +30,8 @@ For more information you can view the help:
 
     uipath config --help
 `
+
+var UserAgent = fmt.Sprintf("uipathcli/%s (%s; %s)", utils.Version, runtime.GOOS, runtime.GOARCH)
 
 // The HttpExecutor implements the Executor interface and constructs HTTP request
 // from the given command line parameters and configurations.
@@ -51,6 +54,7 @@ func (e HttpExecutor) requestId() string {
 func (e HttpExecutor) addHeaders(request *http.Request, headerParameters []ExecutionParameter) {
 	formatter := newParameterFormatter()
 	request.Header.Add("x-request-id", e.requestId())
+	request.Header.Add("User-Agent", UserAgent)
 	for _, parameter := range headerParameters {
 		headerValue := formatter.Format(parameter)
 		request.Header.Add(parameter.Name, headerValue)

--- a/test/execution_test.go
+++ b/test/execution_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -76,29 +77,33 @@ paths:
 	if !strings.HasPrefix(stdErr[0], expected) {
 		t.Errorf("Expected on stderr %v, got: %v", expected, stdErr[0])
 	}
-	expected = "X-Request-Id:"
+	expected = "User-Agent:"
 	if !strings.HasPrefix(stdErr[1], expected) {
 		t.Errorf("Expected on stderr %v, got: %v", expected, stdErr[1])
 	}
-	expected = "HTTP/1.1 200 OK"
-	if stdErr[4] != expected {
-		t.Errorf("Expected on stderr %v, got: %v", expected, stdErr[4])
+	expected = "X-Request-Id:"
+	if !strings.HasPrefix(stdErr[2], expected) {
+		t.Errorf("Expected on stderr %v, got: %v", expected, stdErr[2])
 	}
-	expected = "Content-Length:"
-	if !strings.HasPrefix(stdErr[5], expected) {
+	expected = "HTTP/1.1 200 OK"
+	if stdErr[5] != expected {
 		t.Errorf("Expected on stderr %v, got: %v", expected, stdErr[5])
 	}
-	expected = "Content-Type: text/plain; charset=utf-8"
-	if stdErr[6] != expected {
+	expected = "Content-Length:"
+	if !strings.HasPrefix(stdErr[6], expected) {
 		t.Errorf("Expected on stderr %v, got: %v", expected, stdErr[6])
 	}
-	expected = "Date:"
-	if !strings.HasPrefix(stdErr[7], expected) {
+	expected = "Content-Type: text/plain; charset=utf-8"
+	if stdErr[7] != expected {
 		t.Errorf("Expected on stderr %v, got: %v", expected, stdErr[7])
 	}
+	expected = "Date:"
+	if !strings.HasPrefix(stdErr[8], expected) {
+		t.Errorf("Expected on stderr %v, got: %v", expected, stdErr[8])
+	}
 	expected = `{"hello":"world"}`
-	if stdErr[9] != expected {
-		t.Errorf("Expected on stderr %v, got: %v", expected, stdErr[9])
+	if stdErr[10] != expected {
+		t.Errorf("Expected on stderr %v, got: %v", expected, stdErr[10])
 	}
 }
 
@@ -123,6 +128,28 @@ paths:
 `
 	if result.StdOut != expected {
 		t.Errorf("Expected only response body on stdout %v, got: %v", expected, result.StdOut)
+	}
+}
+
+func TestUserAgent(t *testing.T) {
+	definition := `
+paths:
+  /ping:
+    get:
+      summary: Simple ping
+`
+
+	context := NewContextBuilder().
+		WithDefinition("myservice", definition).
+		WithResponse(200, "").
+		Build()
+
+	result := RunCli([]string{"myservice", "get-ping"}, context)
+
+	userAgent := result.RequestHeader["user-agent"]
+	expected := fmt.Sprintf("uipathcli/main (%s; %s)", runtime.GOOS, runtime.GOARCH)
+	if userAgent != expected {
+		t.Errorf("Could not find user-agent on header, got: %v", userAgent)
 	}
 }
 

--- a/utils/build.go
+++ b/utils/build.go
@@ -1,0 +1,6 @@
+package utils
+
+// This Version variable is overridden during build time
+// by providing the linker flag:
+// -ldflags="-X github.com/UiPath/uipathcli/utils.Version=1.2.3"
+var Version = "main"


### PR DESCRIPTION
Moved the Version constant into the utils package so that the build version can be referenced by all packages.

Adding User-Agent header to all requests in the following format: 
`uipathcli/main (windows; amd64)`