### PR TITLE
Add validation for output-type values

### DIFF
--- a/plugin/studio/studio_plugin_test.go
+++ b/plugin/studio/studio_plugin_test.go
@@ -70,6 +70,20 @@ func TestPackNonExistentProjectShowsProjectJsonNotFound(t *testing.T) {
 	}
 }
 
+func TestInvalidOutputTypeShowsValidationError(t *testing.T) {
+	context := test.NewContextBuilder().
+		WithDefinition("studio", studioDefinition).
+		WithCommandPlugin(NewPackagePackCommand()).
+		Build()
+	source := studioCrossPlatformProjectDirectory()
+	destination := createDirectory(t)
+	result := test.RunCli([]string{"studio", "package", "pack", "--source", source, "--destination", destination, "--output-type", "unknown"}, context)
+
+	if !strings.Contains(result.StdErr, "Invalid output type 'unknown', allowed values: Process, Library, Tests, Objects") {
+		t.Errorf("Expected stderr to show output type is invalid, but got: %v", result.StdErr)
+	}
+}
+
 func TestFailedPackagingReturnsFailureStatus(t *testing.T) {
 	exec := utils.NewExecCustomProcess(1, "Build output", "There was an error", func(name string, args []string) {})
 	context := test.NewContextBuilder().


### PR DESCRIPTION
- Extending the studio pack command to check the allowed values for the output-type argument. Returning proper error message when the value is not one of the following strings: "Process", "Library", "Tests", "Objects"

- Improving help output to show allowed values:
```
--output-type string
  Force the output to a specific type.

  Allowed Values:
  - Process
  - Library
  - Tests
  - Objects
```