### PR TITLE
Improve compatibility error message when building UiPath Studio projects

### DIFF
--- a/plugin/studio/package_analyze_command.go
+++ b/plugin/studio/package_analyze_command.go
@@ -80,9 +80,14 @@ func (c PackageAnalyzeCommand) execute(source string, treatWarningsAsErrors bool
 	}
 
 	projectReader := newStudioProjectReader(source)
+	targetFramework := projectReader.GetTargetFramework()
+	supported, err := targetFramework.IsSupported()
+	if !supported {
+		return 1, nil, err
+	}
 
 	uipcli := newUipcli(c.Exec, logger)
-	err = uipcli.Initialize(projectReader.GetTargetFramework())
+	err = uipcli.Initialize(targetFramework)
 	if err != nil {
 		return 1, nil, err
 	}

--- a/plugin/studio/package_pack_command.go
+++ b/plugin/studio/package_pack_command.go
@@ -97,9 +97,14 @@ func (c PackagePackCommand) execute(params packagePackParams, debug bool, logger
 	}
 
 	projectReader := newStudioProjectReader(params.Source)
+	targetFramework := projectReader.GetTargetFramework()
+	supported, err := targetFramework.IsSupported()
+	if !supported {
+		return nil, err
+	}
 
 	uipcli := newUipcli(c.Exec, logger)
-	err := uipcli.Initialize(projectReader.GetTargetFramework())
+	err = uipcli.Initialize(targetFramework)
 	if err != nil {
 		return nil, err
 	}

--- a/plugin/studio/studio_plugin_notwin_test.go
+++ b/plugin/studio/studio_plugin_notwin_test.go
@@ -81,3 +81,46 @@ func TestAnalyzeOnLinuxWithCorrectArguments(t *testing.T) {
 		t.Errorf("Expected 4th argument to be the project.json, but got: %v", commandArgs[3])
 	}
 }
+
+func TestAnalyzeWindowsProjectOnLinuxReturnsCompatibilityError(t *testing.T) {
+	called := false
+	exec := process.NewExecCustomProcess(0, "", "", func(name string, args []string) {
+		called = true
+	})
+	context := test.NewContextBuilder().
+		WithDefinition("studio", studioDefinition).
+		WithCommandPlugin(PackageAnalyzeCommand{exec}).
+		Build()
+
+	source := studioWindowsProjectDirectory()
+	result := test.RunCli([]string{"studio", "package", "analyze", "--source", source}, context)
+
+	if called {
+		t.Error("Expected uipcli not to be called but it was.")
+	}
+	if result.Error == nil || result.Error.Error() != "UiPath Studio Projects which target windows-only are not support on linux devices. Build the project on windows or change the target framework to cross-platform." {
+		t.Errorf("Expected compatibility error, but got: %v", result.Error)
+	}
+}
+
+func TestPackWindowsProjectOnLinuxReturnsCompatibilityError(t *testing.T) {
+	called := false
+	exec := process.NewExecCustomProcess(0, "", "", func(name string, args []string) {
+		called = true
+	})
+	context := test.NewContextBuilder().
+		WithDefinition("studio", studioDefinition).
+		WithCommandPlugin(PackagePackCommand{exec}).
+		Build()
+
+	source := studioWindowsProjectDirectory()
+	destination := createDirectory(t)
+	result := test.RunCli([]string{"studio", "package", "pack", "--source", source, "--destination", destination}, context)
+
+	if called {
+		t.Error("Expected uipcli not to be called but it was.")
+	}
+	if result.Error == nil || result.Error.Error() != "UiPath Studio Projects which target windows-only are not support on linux devices. Build the project on windows or change the target framework to cross-platform." {
+		t.Errorf("Expected compatibility error, but got: %v", result.Error)
+	}
+}

--- a/plugin/studio/studio_plugin_test.go
+++ b/plugin/studio/studio_plugin_test.go
@@ -372,6 +372,11 @@ func studioCrossPlatformProjectDirectory() string {
 	return filepath.Join(filepath.Dir(filename), "projects", "crossplatform")
 }
 
+func studioWindowsProjectDirectory() string {
+	_, filename, _, _ := runtime.Caller(0)
+	return filepath.Join(filepath.Dir(filename), "projects", "windows")
+}
+
 func createDirectory(t *testing.T) string {
 	tmp, err := os.MkdirTemp("", "uipath-test")
 	if err != nil {

--- a/plugin/studio/studio_plugin_windows_test.go
+++ b/plugin/studio/studio_plugin_windows_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
 
@@ -145,9 +144,4 @@ func TestAnalyzeOnWindowsWithCorrectArguments(t *testing.T) {
 	if commandArgs[2] != filepath.Join(source, "project.json") {
 		t.Errorf("Expected 4th argument to be the project.json, but got: %v", commandArgs[2])
 	}
-}
-
-func studioWindowsProjectDirectory() string {
-	_, filename, _, _ := runtime.Caller(0)
-	return filepath.Join(filepath.Dir(filename), "projects", "windows")
 }

--- a/plugin/studio/studio_project_reader.go
+++ b/plugin/studio/studio_project_reader.go
@@ -14,6 +14,9 @@ type studioProjectReader struct {
 
 func (p studioProjectReader) GetTargetFramework() TargetFramework {
 	project, _ := p.ReadMetadata()
+	if strings.EqualFold(project.TargetFramework, "legacy") {
+		return TargetFrameworkLegacy
+	}
 	if strings.EqualFold(project.TargetFramework, "windows") {
 		return TargetFrameworkWindows
 	}

--- a/plugin/studio/target_framework.go
+++ b/plugin/studio/target_framework.go
@@ -1,8 +1,25 @@
 package studio
 
+import (
+	"errors"
+	"runtime"
+)
+
 type TargetFramework int
 
 const (
 	TargetFrameworkCrossPlatform TargetFramework = iota + 1
 	TargetFrameworkWindows
+	TargetFrameworkLegacy
 )
+
+func (t TargetFramework) IsWindowsOnly() bool {
+	return t == TargetFrameworkWindows || t == TargetFrameworkLegacy
+}
+
+func (t TargetFramework) IsSupported() (bool, error) {
+	if t.IsWindowsOnly() && runtime.GOOS != "windows" {
+		return false, errors.New("UiPath Studio Projects which target windows-only are not support on linux devices. Build the project on windows or change the target framework to cross-platform.")
+	}
+	return true, nil
+}

--- a/plugin/studio/uipcli.go
+++ b/plugin/studio/uipcli.go
@@ -26,7 +26,7 @@ type uipcli struct {
 func (c *uipcli) Initialize(targetFramework TargetFramework) error {
 	name := "uipcli"
 	url := uipcliUrl
-	if targetFramework == TargetFrameworkWindows {
+	if targetFramework.IsWindowsOnly() {
 		name = "uipcli-win"
 		url = uipcliWindowsUrl
 	}


### PR DESCRIPTION
Added validation which checks if the target framework of the UiPath Studio project is support on the current operation system. Returning a detailed error message when users try to build Windows-only projects on linux.

Issue: https://github.com/UiPath/uipathcli/issues/145