### PR TITLE
Download .NET runtime for cross-platform Studio Projects

### DIFF
--- a/plugin/archive.go
+++ b/plugin/archive.go
@@ -1,0 +1,14 @@
+package plugin
+
+import "os"
+
+type Archive interface {
+	Extract(filePath string, destinationFolder string, permissions os.FileMode) error
+}
+
+func newArchive(archiveType ArchiveType) Archive {
+	if archiveType == ArchiveTypeZip {
+		return newZipArchive()
+	}
+	return newTarGzArchive()
+}

--- a/plugin/archive_type.go
+++ b/plugin/archive_type.go
@@ -1,0 +1,8 @@
+package plugin
+
+type ArchiveType int
+
+const (
+	ArchiveTypeZip ArchiveType = iota + 1
+	ArchiveTypeTarGz
+)

--- a/plugin/external_plugin.go
+++ b/plugin/external_plugin.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/UiPath/uipathcli/log"
 	"github.com/UiPath/uipathcli/utils/directories"
+	"github.com/UiPath/uipathcli/utils/resiliency"
 	"github.com/UiPath/uipathcli/utils/visualization"
 )
 
@@ -22,7 +23,20 @@ type ExternalPlugin struct {
 	Logger log.Logger
 }
 
-func (p ExternalPlugin) GetTool(name string, url string, executable string) (string, error) {
+func (p ExternalPlugin) GetTool(name string, url string, archiveType ArchiveType, executable string) (string, error) {
+	path := ""
+	err := resiliency.Retry(func() error {
+		var err error
+		path, err = p.getTool(name, url, archiveType, executable)
+		if err != nil {
+			return resiliency.Retryable(err)
+		}
+		return nil
+	})
+	return path, err
+}
+
+func (p ExternalPlugin) getTool(name string, url string, archiveType ArchiveType, executable string) (string, error) {
 	pluginDirectory, err := p.pluginDirectory(name, url)
 	if err != nil {
 		return "", fmt.Errorf("Could not download %s: %v", name, err)
@@ -38,21 +52,35 @@ func (p ExternalPlugin) GetTool(name string, url string, executable string) (str
 	progressBar := visualization.NewProgressBar(p.Logger)
 	defer progressBar.Remove()
 	progressBar.UpdatePercentage("downloading...", 0)
-	zipArchivePath := filepath.Join(tmpPluginDirectory, name)
-	err = p.download(name, url, zipArchivePath, progressBar)
+	archivePath := filepath.Join(tmpPluginDirectory, name)
+	err = p.download(name, url, archivePath, progressBar)
 	if err != nil {
 		return "", err
 	}
-	err = newZipArchive().Extract(zipArchivePath, tmpPluginDirectory, pluginDirectoryPermissions)
+	archive := newArchive(archiveType)
+	err = archive.Extract(archivePath, tmpPluginDirectory, pluginDirectoryPermissions)
 	if err != nil {
 		return "", fmt.Errorf("Could not extract %s archive: %v", name, err)
 	}
-	os.Remove(zipArchivePath)
-	err = os.Rename(tmpPluginDirectory, pluginDirectory)
+	err = os.Remove(archivePath)
+	if err != nil {
+		return "", fmt.Errorf("Could not remove %s archive: %v", name, err)
+	}
+	err = p.rename(tmpPluginDirectory, pluginDirectory)
 	if err != nil {
 		return "", fmt.Errorf("Could not install %s: %v", name, err)
 	}
 	return path, nil
+}
+
+func (p ExternalPlugin) rename(source string, target string) error {
+	return resiliency.RetryN(10, func() error {
+		err := os.Rename(source, target)
+		if err != nil {
+			return resiliency.Retryable(err)
+		}
+		return nil
+	})
 }
 
 func (p ExternalPlugin) download(name string, url string, destination string, progressBar *visualization.ProgressBar) error {

--- a/plugin/studio/studio_plugin_windows_test.go
+++ b/plugin/studio/studio_plugin_windows_test.go
@@ -55,7 +55,7 @@ func TestPackWindowsSuccessfully(t *testing.T) {
 	}
 }
 
-func TestPackOnWindowsWithCorrectArguments(t *testing.T) {
+func TestPackCrossPlatformProjectOnWindowsWithCorrectArguments(t *testing.T) {
 	commandName := ""
 	commandArgs := []string{}
 	exec := process.NewExecCustomProcess(0, "", "", func(name string, args []string) {
@@ -68,6 +68,45 @@ func TestPackOnWindowsWithCorrectArguments(t *testing.T) {
 		Build()
 
 	source := studioCrossPlatformProjectDirectory()
+	destination := createDirectory(t)
+	test.RunCli([]string{"studio", "package", "pack", "--source", source, "--destination", destination}, context)
+
+	if !strings.HasSuffix(commandName, "dotnet.exe") {
+		t.Errorf("Expected command name to be dotnet.exe, but got: %v", commandName)
+	}
+	if !strings.HasSuffix(commandArgs[0], "uipcli.dll") {
+		t.Errorf("Expected 1st argument to be the uipcli.dll, but got: %v", commandArgs[0])
+	}
+	if commandArgs[1] != "package" {
+		t.Errorf("Expected 2nd argument to be package, but got: %v", commandArgs[1])
+	}
+	if commandArgs[2] != "pack" {
+		t.Errorf("Expected 3rd argument to be pack, but got: %v", commandArgs[2])
+	}
+	if commandArgs[3] != filepath.Join(source, "project.json") {
+		t.Errorf("Expected 4th argument to be the project.json, but got: %v", commandArgs[3])
+	}
+	if commandArgs[4] != "--output" {
+		t.Errorf("Expected 5th argument to be output, but got: %v", commandArgs[4])
+	}
+	if commandArgs[5] != destination {
+		t.Errorf("Expected 6th argument to be the output path, but got: %v", commandArgs[5])
+	}
+}
+
+func TestPackWindowsOnlyProjectOnWindowsWithCorrectArguments(t *testing.T) {
+	commandName := ""
+	commandArgs := []string{}
+	exec := process.NewExecCustomProcess(0, "", "", func(name string, args []string) {
+		commandName = name
+		commandArgs = args
+	})
+	context := test.NewContextBuilder().
+		WithDefinition("studio", studioDefinition).
+		WithCommandPlugin(PackagePackCommand{exec}).
+		Build()
+
+	source := studioWindowsProjectDirectory()
 	destination := createDirectory(t)
 	test.RunCli([]string{"studio", "package", "pack", "--source", source, "--destination", destination}, context)
 
@@ -117,7 +156,36 @@ func TestAnalyzeWindowsSuccessfully(t *testing.T) {
 	}
 }
 
-func TestAnalyzeOnWindowsWithCorrectArguments(t *testing.T) {
+func TestAnalyzeWindowsOnlyProjectOnWindowsWithCorrectArguments(t *testing.T) {
+	commandName := ""
+	commandArgs := []string{}
+	exec := process.NewExecCustomProcess(0, "", "", func(name string, args []string) {
+		commandName = name
+		commandArgs = args
+	})
+	context := test.NewContextBuilder().
+		WithDefinition("studio", studioDefinition).
+		WithCommandPlugin(PackageAnalyzeCommand{exec}).
+		Build()
+
+	source := studioWindowsProjectDirectory()
+	test.RunCli([]string{"studio", "package", "analyze", "--source", source}, context)
+
+	if !strings.HasSuffix(commandName, "uipcli.exe") {
+		t.Errorf("Expected command name to be uipcli.exe, but got: %v", commandName)
+	}
+	if commandArgs[0] != "package" {
+		t.Errorf("Expected 1st argument to be package, but got: %v", commandArgs[0])
+	}
+	if commandArgs[1] != "analyze" {
+		t.Errorf("Expected 2nd argument to be analyze, but got: %v", commandArgs[1])
+	}
+	if commandArgs[2] != filepath.Join(source, "project.json") {
+		t.Errorf("Expected 3rd argument to be the project.json, but got: %v", commandArgs[2])
+	}
+}
+
+func TestAnalyzeCrossPlatformProjectOnWindowsWithCorrectArguments(t *testing.T) {
 	commandName := ""
 	commandArgs := []string{}
 	exec := process.NewExecCustomProcess(0, "", "", func(name string, args []string) {
@@ -132,16 +200,19 @@ func TestAnalyzeOnWindowsWithCorrectArguments(t *testing.T) {
 	source := studioCrossPlatformProjectDirectory()
 	test.RunCli([]string{"studio", "package", "analyze", "--source", source}, context)
 
-	if !strings.HasSuffix(commandName, "uipcli.exe") {
-		t.Errorf("Expected command name to be uipcli.exe, but got: %v", commandName)
+	if !strings.HasSuffix(commandName, "dotnet.exe") {
+		t.Errorf("Expected command name to be dotnet.exe, but got: %v", commandName)
 	}
-	if commandArgs[0] != "package" {
-		t.Errorf("Expected 2nd argument to be package, but got: %v", commandArgs[0])
+	if !strings.HasSuffix(commandArgs[0], "uipcli.dll") {
+		t.Errorf("Expected 1st argument to be the uipcli.dll, but got: %v", commandArgs[0])
 	}
-	if commandArgs[1] != "analyze" {
-		t.Errorf("Expected 3rd argument to be analyze, but got: %v", commandArgs[1])
+	if commandArgs[1] != "package" {
+		t.Errorf("Expected 2nd argument to be package, but got: %v", commandArgs[1])
 	}
-	if commandArgs[2] != filepath.Join(source, "project.json") {
-		t.Errorf("Expected 4th argument to be the project.json, but got: %v", commandArgs[2])
+	if commandArgs[2] != "analyze" {
+		t.Errorf("Expected 3rd argument to be analyze, but got: %v", commandArgs[2])
+	}
+	if commandArgs[3] != filepath.Join(source, "project.json") {
+		t.Errorf("Expected 4th argument to be the project.json, but got: %v", commandArgs[3])
 	}
 }

--- a/plugin/studio/uipcli.go
+++ b/plugin/studio/uipcli.go
@@ -2,70 +2,105 @@ package studio
 
 import (
 	"fmt"
-	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 
 	"github.com/UiPath/uipathcli/log"
 	"github.com/UiPath/uipathcli/plugin"
 	"github.com/UiPath/uipathcli/utils/process"
 )
 
-const uipcliVersion = "24.12.9111.31003"
-const uipcliUrl = "https://uipath.pkgs.visualstudio.com/Public.Feeds/_apis/packaging/feeds/1c781268-d43d-45ab-9dfc-0151a1c740b7/nuget/packages/UiPath.CLI/versions/" + uipcliVersion + "/content"
+const uipcliCrossPlatformVersion = "24.12.9111.31003"
+const uipcliCrossPlatformUrl = "https://uipath.pkgs.visualstudio.com/Public.Feeds/_apis/packaging/feeds/1c781268-d43d-45ab-9dfc-0151a1c740b7/nuget/packages/UiPath.CLI/versions/" + uipcliCrossPlatformVersion + "/content"
 
 const uipcliWindowsVersion = "24.12.9111.31003"
 const uipcliWindowsUrl = "https://uipath.pkgs.visualstudio.com/Public.Feeds/_apis/packaging/feeds/1c781268-d43d-45ab-9dfc-0151a1c740b7/nuget/packages/UiPath.CLI.Windows/versions/" + uipcliWindowsVersion + "/content"
+
+const dotnetLinuxX64Url = "https://aka.ms/dotnet/8.0/dotnet-runtime-linux-x64.tar.gz"
+const dotnetMacOsX64Url = "https://aka.ms/dotnet/8.0/dotnet-runtime-osx-x64.tar.gz"
+const dotnetWindowsX64Url = "https://aka.ms/dotnet/8.0/dotnet-runtime-win-x64.zip"
+
+const dotnetLinuxArm64Url = "https://aka.ms/dotnet/8.0/dotnet-runtime-linux-arm64.tar.gz"
+const dotnetMacOsArm64Url = "https://aka.ms/dotnet/8.0/dotnet-runtime-osx-arm64.tar.gz"
+const dotnetWindowsArm64Url = "https://aka.ms/dotnet/8.0/dotnet-runtime-win-arm64.zip"
 
 type uipcli struct {
 	Exec   process.ExecProcess
 	Logger log.Logger
 	path   string
+	args   []string
 }
 
 func (c *uipcli) Initialize(targetFramework TargetFramework) error {
-	name := "uipcli"
-	url := uipcliUrl
-	if targetFramework.IsWindowsOnly() {
-		name = "uipcli-win"
-		url = uipcliWindowsUrl
-	}
-	uipcliPath, err := c.getPath(name, url)
+	uipcliPath, err := c.getUipcliPath(targetFramework)
 	if err != nil {
 		return err
 	}
 	c.path = uipcliPath
+
+	if filepath.Ext(c.path) == ".dll" {
+		dotnetPath, err := c.getDotnetPath()
+		if err != nil {
+			return err
+		}
+		c.path = dotnetPath
+		c.args = []string{uipcliPath}
+	}
 	return nil
 }
 
 func (c uipcli) Execute(args ...string) (process.ExecCmd, error) {
-	path := c.path
-	if filepath.Ext(path) == ".dll" {
-		dotnetPath, err := exec.LookPath("dotnet")
-		if err != nil {
-			return nil, fmt.Errorf("Could not find dotnet runtime to run command: %v", err)
-		}
-		path = dotnetPath
-		args = append([]string{c.path}, args...)
-	}
-
-	cmd := c.Exec.Command(path, args...)
+	args = append(c.args, args...)
+	cmd := c.Exec.Command(c.path, args...)
 	return cmd, nil
 }
 
-func (c uipcli) getPath(name string, url string) (string, error) {
+func (c uipcli) getUipcliPath(targetFramework TargetFramework) (string, error) {
 	externalPlugin := plugin.NewExternalPlugin(c.Logger)
+	name := "uipcli"
+	url := uipcliCrossPlatformUrl
 	executable := "tools/uipcli.dll"
-	if c.isWindows() {
+	if targetFramework.IsWindowsOnly() {
+		name = "uipcli-win"
+		url = uipcliWindowsUrl
 		executable = "tools/uipcli.exe"
 	}
-	return externalPlugin.GetTool(name, url, executable)
+	return externalPlugin.GetTool(name, url, plugin.ArchiveTypeZip, executable)
 }
 
-func (c uipcli) isWindows() bool {
-	return runtime.GOOS == "windows"
+func (c uipcli) getDotnetPath() (string, error) {
+	externalPlugin := plugin.NewExternalPlugin(c.Logger)
+	name := fmt.Sprintf("dotnet8-%s-%s", runtime.GOOS, runtime.GOARCH)
+	url, archiveType, executable := c.dotnetUrl()
+	return externalPlugin.GetTool(name, url, archiveType, executable)
+}
+
+func (c uipcli) dotnetUrl() (string, plugin.ArchiveType, string) {
+	if c.isArm() {
+		switch runtime.GOOS {
+		case "windows":
+			return dotnetWindowsArm64Url, plugin.ArchiveTypeZip, "dotnet.exe"
+		case "darwin":
+			return dotnetMacOsArm64Url, plugin.ArchiveTypeTarGz, "dotnet"
+		default:
+			return dotnetLinuxArm64Url, plugin.ArchiveTypeTarGz, "dotnet"
+		}
+	}
+	switch runtime.GOOS {
+	case "windows":
+		return dotnetWindowsX64Url, plugin.ArchiveTypeZip, "dotnet.exe"
+	case "darwin":
+		return dotnetMacOsX64Url, plugin.ArchiveTypeTarGz, "dotnet"
+	default:
+		return dotnetLinuxX64Url, plugin.ArchiveTypeTarGz, "dotnet"
+	}
+}
+
+func (c uipcli) isArm() bool {
+	return strings.HasPrefix(strings.ToLower(runtime.GOARCH), "arm")
 }
 
 func newUipcli(exec process.ExecProcess, logger log.Logger) *uipcli {
-	return &uipcli{exec, logger, ""}
+	return &uipcli{exec, logger, "", []string{}}
 }

--- a/plugin/tar_gz_archive.go
+++ b/plugin/tar_gz_archive.go
@@ -1,0 +1,84 @@
+package plugin
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type tarGzArchive struct{}
+
+func (t tarGzArchive) Extract(filePath string, destinationFolder string, permissions os.FileMode) error {
+	file, err := os.Open(filePath)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	gzipReader, err := gzip.NewReader(file)
+	if err != nil {
+		return err
+	}
+	defer gzipReader.Close()
+
+	tarReader := tar.NewReader(gzipReader)
+	for {
+		header, err := tarReader.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return err
+		}
+
+		err = t.extractFile(header, tarReader, destinationFolder, permissions)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (t tarGzArchive) extractFile(header *tar.Header, reader *tar.Reader, destinationFolder string, permissions os.FileMode) error {
+	path, err := t.sanitizeArchivePath(destinationFolder, header.Name)
+	if err != nil {
+		return err
+	}
+
+	if header.FileInfo().IsDir() {
+		return os.MkdirAll(path, permissions)
+	}
+
+	err = os.MkdirAll(filepath.Dir(path), permissions)
+	if err != nil {
+		return err
+	}
+
+	destinationFile, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, permissions)
+	if err != nil {
+		return err
+	}
+	defer destinationFile.Close()
+
+	_, err = io.CopyN(destinationFile, reader, MaxArchiveSize)
+	if err != nil && err != io.EOF {
+		return err
+	}
+	return nil
+}
+
+func (t tarGzArchive) sanitizeArchivePath(directory string, name string) (string, error) {
+	result := filepath.Join(directory, name)
+	if strings.HasPrefix(result, filepath.Clean(directory)) {
+		return result, nil
+	}
+	return "", fmt.Errorf("File path '%s' is not allowed", directory)
+}
+
+func newTarGzArchive() *tarGzArchive {
+	return &tarGzArchive{}
+}

--- a/plugin/zip_archive.go
+++ b/plugin/zip_archive.go
@@ -13,8 +13,8 @@ const MaxArchiveSize = 1 * 1024 * 1024 * 1024
 
 type zipArchive struct{}
 
-func (z zipArchive) Extract(zipArchive string, destinationFolder string, permissions os.FileMode) error {
-	archive, err := zip.OpenReader(zipArchive)
+func (z zipArchive) Extract(filePath string, destinationFolder string, permissions os.FileMode) error {
+	archive, err := zip.OpenReader(filePath)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
- Downloading the required .NET runtime when the user builds cross-platform Studio projects which allows the uipathcli to work without any additional dependencies

- Implemented support to for tar.gz archives which is needed to extract dotnet runtime archives on Linux and MacOS

- Added retry mechanism for downloading the plugins to make the operation more robust