### PR TITLE
Optional source and destination parameters for studio commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ curl --remote-name "$projectUrl/Main.xaml" \
      --remote-name "$projectUrl/project.json"
 
 # Build and package project
-uipath studio package pack --source . --destination . --package-version 1.0.0
+uipath studio package pack
 
 # Upload package
 uipath orchestrator processes upload-package --file "MyProcess.1.0.0.nupkg"

--- a/plugin/studio/projects/crossplatform/project.json
+++ b/plugin/studio/projects/crossplatform/project.json
@@ -13,7 +13,7 @@
   "entitiesStores": [],
   "schemaVersion": "4.0",
   "studioVersion": "24.10.1.0",
-  "projectVersion": "1.0.2",
+  "projectVersion": "1.0.0",
   "runtimeOptions": {
     "autoDispose": false,
     "netFrameworkLazyLoading": false,
@@ -40,7 +40,9 @@
       "privateWorkflows": []
     },
     "processOptions": {
-      "ignoredFiles": []
+      "ignoredFiles": [
+        "MyProcess.*.nupkg"
+      ]
     },
     "fileInfoCollection": [],
     "saveToCloud": false

--- a/plugin/studio/projects/windows/project.json
+++ b/plugin/studio/projects/windows/project.json
@@ -41,7 +41,9 @@
       "privateWorkflows": []
     },
     "processOptions": {
-      "ignoredFiles": []
+      "ignoredFiles": [
+        "MyWindowsProcess.*.nupkg"
+      ]
     },
     "fileInfoCollection": [],
     "saveToCloud": false

--- a/plugin/studio/studio_plugin_test.go
+++ b/plugin/studio/studio_plugin_test.go
@@ -30,33 +30,6 @@ paths:
   {}
 `
 
-func TestPackWithoutSourceParameterShowsValidationError(t *testing.T) {
-	context := test.NewContextBuilder().
-		WithDefinition("studio", studioDefinition).
-		WithCommandPlugin(NewPackagePackCommand()).
-		Build()
-
-	result := test.RunCli([]string{"studio", "package", "pack", "--destination", "test.nupkg"}, context)
-
-	if !strings.Contains(result.StdErr, "Argument --source is missing") {
-		t.Errorf("Expected stderr to show that source parameter is missing, but got: %v", result.StdErr)
-	}
-}
-
-func TestPackWithoutDestinationParameterShowsValidationError(t *testing.T) {
-	context := test.NewContextBuilder().
-		WithDefinition("studio", studioDefinition).
-		WithCommandPlugin(NewPackagePackCommand()).
-		Build()
-
-	source := studioCrossPlatformProjectDirectory()
-	result := test.RunCli([]string{"studio", "package", "pack", "--source", source}, context)
-
-	if !strings.Contains(result.StdErr, "Argument --destination is missing") {
-		t.Errorf("Expected stderr to show that destination parameter is missing, but got: %v", result.StdErr)
-	}
-}
-
 func TestPackNonExistentProjectShowsProjectJsonNotFound(t *testing.T) {
 	context := test.NewContextBuilder().
 		WithDefinition("studio", studioDefinition).
@@ -138,11 +111,11 @@ func TestPackCrossPlatformSuccessfully(t *testing.T) {
 	if stdout["projectId"] != "9011ee47-8dd4-4726-8850-299bd6ef057c" {
 		t.Errorf("Expected projectId to be set, but got: %v", result.StdOut)
 	}
-	if stdout["version"] != "1.0.2" {
+	if stdout["version"] != "1.0.0" {
 		t.Errorf("Expected version to be set, but got: %v", result.StdOut)
 	}
 	outputFile := stdout["output"].(string)
-	if outputFile != filepath.Join(destination, "MyProcess.1.0.2.nupkg") {
+	if outputFile != filepath.Join(destination, "MyProcess.1.0.0.nupkg") {
 		t.Errorf("Expected output path to be set, but got: %v", result.StdOut)
 	}
 	if _, err := os.Stat(outputFile); err != nil {
@@ -227,19 +200,6 @@ func TestPackWithReleaseNotesArgument(t *testing.T) {
 	}
 	if commandArgs[index+1] != "These are release notes." {
 		t.Errorf("Expected release notes argument, but got: %v", strings.Join(commandArgs, " "))
-	}
-}
-
-func TestAnalyzeWithoutSourceParameterShowsValidationError(t *testing.T) {
-	context := test.NewContextBuilder().
-		WithDefinition("studio", studioDefinition).
-		WithCommandPlugin(NewPackageAnalyzeCommand()).
-		Build()
-
-	result := test.RunCli([]string{"studio", "package", "analyze"}, context)
-
-	if !strings.Contains(result.StdErr, "Argument --source is missing") {
-		t.Errorf("Expected stderr to show that source parameter is missing, but got: %v", result.StdErr)
 	}
 }
 

--- a/plugin/studio/studio_project.go
+++ b/plugin/studio/studio_project.go
@@ -1,0 +1,22 @@
+package studio
+
+import (
+	"fmt"
+	"strings"
+)
+
+type studioProject struct {
+	Name            string
+	Description     string
+	ProjectId       string
+	TargetFramework TargetFramework
+}
+
+func (p studioProject) NupkgIgnoreFilePattern() string {
+	id := strings.ReplaceAll(p.Name, " ", ".")
+	return fmt.Sprintf("%s.*.nupkg", id)
+}
+
+func newStudioProject(name string, description string, projectId string, targetFramework TargetFramework) *studioProject {
+	return &studioProject{name, description, projectId, targetFramework}
+}

--- a/plugin/studio/studio_project_reader.go
+++ b/plugin/studio/studio_project_reader.go
@@ -12,34 +12,133 @@ type studioProjectReader struct {
 	Path string
 }
 
-func (p studioProjectReader) GetTargetFramework() TargetFramework {
-	project, _ := p.ReadMetadata()
-	if strings.EqualFold(project.TargetFramework, "legacy") {
+func (r studioProjectReader) ReadMetadata() (studioProject, error) {
+	data, err := r.readProjectJson()
+	if err != nil {
+		return studioProject{}, err
+	}
+	var projectJson studioProjectJson
+	err = json.Unmarshal(data, &projectJson)
+	if err != nil {
+		return studioProject{}, fmt.Errorf("Error parsing %s file: %v", defaultProjectJson, err)
+	}
+	project := newStudioProject(
+		projectJson.Name,
+		projectJson.Description,
+		projectJson.ProjectId,
+		r.convertToTargetFramework(projectJson.TargetFramework))
+	return *project, nil
+}
+
+func (r studioProjectReader) convertToTargetFramework(targetFramework string) TargetFramework {
+	if strings.EqualFold(targetFramework, "legacy") {
 		return TargetFrameworkLegacy
 	}
-	if strings.EqualFold(project.TargetFramework, "windows") {
+	if strings.EqualFold(targetFramework, "windows") {
 		return TargetFrameworkWindows
 	}
 	return TargetFrameworkCrossPlatform
 }
 
-func (p studioProjectReader) ReadMetadata() (studioProjectJson, error) {
-	file, err := os.Open(p.Path)
+func (r studioProjectReader) AddToIgnoredFiles(fileName string) error {
+	data, err := r.readProjectJson()
 	if err != nil {
-		return studioProjectJson{}, fmt.Errorf("Error reading %s file: %v", defaultProjectJson, err)
+		return err
 	}
-	defer file.Close()
-	byteValue, err := io.ReadAll(file)
+	var result interface{}
+	err = json.Unmarshal(data, &result)
 	if err != nil {
-		return studioProjectJson{}, fmt.Errorf("Error reading %s file: %v", defaultProjectJson, err)
+		return fmt.Errorf("Error parsing %s file: %v", defaultProjectJson, err)
 	}
 
-	var project studioProjectJson
-	err = json.Unmarshal(byteValue, &project)
+	changed, err := r.addToIgnoredFiles(result.(map[string]interface{}), fileName)
 	if err != nil {
-		return studioProjectJson{}, fmt.Errorf("Error parsing %s file: %v", defaultProjectJson, err)
+		return fmt.Errorf("Error updating %s file: %v", defaultProjectJson, err)
 	}
-	return project, nil
+	if !changed {
+		return nil
+	}
+	return r.updateProjectJson(result)
+}
+
+func (r studioProjectReader) readProjectJson() ([]byte, error) {
+	file, err := os.Open(r.Path)
+	if err != nil {
+		return nil, fmt.Errorf("Error reading %s file: %v", defaultProjectJson, err)
+	}
+	defer file.Close()
+	data, err := io.ReadAll(file)
+	if err != nil {
+		return nil, fmt.Errorf("Error reading %s file: %v", defaultProjectJson, err)
+	}
+	return data, err
+}
+
+func (r studioProjectReader) updateProjectJson(result interface{}) error {
+	updated, err := json.Marshal(result)
+	if err != nil {
+		return fmt.Errorf("Error updating %s file: %v", defaultProjectJson, err)
+	}
+	fileInfo, err := os.Stat(r.Path)
+	if err != nil {
+		return fmt.Errorf("Error updating %s file: %v", defaultProjectJson, err)
+	}
+	err = os.WriteFile(r.Path, updated, fileInfo.Mode())
+	if err != nil {
+		return fmt.Errorf("Error updating %s file: %v", defaultProjectJson, err)
+	}
+	return nil
+}
+
+func (r studioProjectReader) addToIgnoredFiles(result map[string]interface{}, fileName string) (bool, error) {
+	designOptions, err := r.createObjectField(result, "designOptions")
+	if err != nil {
+		return false, err
+	}
+	processOptions, err := r.createObjectField(designOptions, "processOptions")
+	if err != nil {
+		return false, err
+	}
+	ignoredFiles, err := r.createArrayField(processOptions, "ignoredFiles")
+	if err != nil {
+		return false, err
+	}
+	if r.isFileNameIgnored(ignoredFiles, fileName) {
+		return false, nil
+	}
+	processOptions["ignoredFiles"] = append(ignoredFiles, fileName)
+	return true, nil
+}
+
+func (r studioProjectReader) createObjectField(result map[string]interface{}, fieldName string) (map[string]interface{}, error) {
+	if _, ok := result[fieldName]; !ok {
+		result[fieldName] = map[string]interface{}{}
+	}
+	field, ok := result[fieldName].(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("Unexpected type for field '%s'", fieldName)
+	}
+	return field, nil
+}
+
+func (r studioProjectReader) createArrayField(result map[string]interface{}, fieldName string) ([]interface{}, error) {
+	if _, ok := result[fieldName]; !ok {
+		result[fieldName] = []interface{}{}
+	}
+	field, ok := result[fieldName].([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("Unexpected type for field '%s'", fieldName)
+	}
+	return field, nil
+}
+
+func (r studioProjectReader) isFileNameIgnored(ignoredFiles []interface{}, fileName string) bool {
+	for _, ignoredFile := range ignoredFiles {
+		if ignoredFile == fileName {
+			return true
+		}
+	}
+	return false
 }
 
 func newStudioProjectReader(path string) *studioProjectReader {

--- a/plugin/studio/studio_project_reader_test.go
+++ b/plugin/studio/studio_project_reader_test.go
@@ -1,0 +1,318 @@
+package studio
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestStudioProjectReader_FileNotFound_ReturnsError(t *testing.T) {
+	studioProjectReader := newStudioProjectReader("not-found")
+	_, err := studioProjectReader.ReadMetadata()
+	if !strings.HasPrefix(err.Error(), "Error reading project.json file") {
+		t.Errorf("Should return reading error, but got: %v", err)
+	}
+}
+
+func TestStudioProjectReaderInvalidJsonReturnsError(t *testing.T) {
+	path := writeFile(t, "INVALID")
+
+	studioProjectReader := newStudioProjectReader(path)
+	_, err := studioProjectReader.ReadMetadata()
+	if !strings.HasPrefix(err.Error(), "Error parsing project.json file") {
+		t.Errorf("Should return parsing error, but got: %v", err)
+	}
+}
+
+func TestStudioProjectReaderReturnsMetadata(t *testing.T) {
+	path := writeFile(t, `
+{
+  "name": "My Process",
+  "projectId": "5fe987d1-7495-4dc7-bc4c-feaf08600b95",
+  "description": "This is my process",
+  "targetFramework": "Portable"
+}
+`)
+
+	studioProjectReader := newStudioProjectReader(path)
+	project, err := studioProjectReader.ReadMetadata()
+	if err != nil {
+		t.Errorf("Should not return error, but got: %v", err)
+	}
+	if project.Name != "My Process" {
+		t.Errorf("Should return project name 'My Process', but got: %s", project.Name)
+	}
+	if project.Description != "This is my process" {
+		t.Errorf("Should return project description 'This is my process', but got: %s", project.Description)
+	}
+	if project.ProjectId != "5fe987d1-7495-4dc7-bc4c-feaf08600b95" {
+		t.Errorf("Should return project id '5fe987d1-7495-4dc7-bc4c-feaf08600b95', but got: %s", project.ProjectId)
+	}
+	if project.TargetFramework != TargetFrameworkCrossPlatform {
+		t.Errorf("Should return cross platform target framework, but got: %d", project.TargetFramework)
+	}
+}
+
+func TestStudioProjectReaderReturnsTargetFrameworkWindows(t *testing.T) {
+	path := writeFile(t, `
+{
+  "targetFramework": "windows"
+}
+`)
+
+	studioProjectReader := newStudioProjectReader(path)
+	project, err := studioProjectReader.ReadMetadata()
+	if err != nil {
+		t.Errorf("Should not return error, but got: %v", err)
+	}
+	if project.TargetFramework != TargetFrameworkWindows {
+		t.Errorf("Should return windows target framework, but got: %d", project.TargetFramework)
+	}
+}
+
+func TestStudioProjectReaderReturnsTargetFrameworkLegacy(t *testing.T) {
+	path := writeFile(t, `
+{
+  "targetFramework": "Legacy"
+}
+`)
+
+	studioProjectReader := newStudioProjectReader(path)
+	project, err := studioProjectReader.ReadMetadata()
+	if err != nil {
+		t.Errorf("Should not return error, but got: %v", err)
+	}
+	if project.TargetFramework != TargetFrameworkLegacy {
+		t.Errorf("Should return legacy target framework, but got: %d", project.TargetFramework)
+	}
+}
+
+func TestStudioProjectReaderUnknownTargetFrameworkDefaultsToCrossPlatform(t *testing.T) {
+	path := writeFile(t, `
+{
+  "targetFramework": "Unknown"
+}
+`)
+
+	studioProjectReader := newStudioProjectReader(path)
+	project, err := studioProjectReader.ReadMetadata()
+	if err != nil {
+		t.Errorf("Should not return error, but got: %v", err)
+	}
+	if project.TargetFramework != TargetFrameworkCrossPlatform {
+		t.Errorf("Should return cross platform target framework, but got: %d", project.TargetFramework)
+	}
+}
+
+func TestStudioProjectReaderAddToIgnoredFilesCreatesNewSection(t *testing.T) {
+	path := writeFile(t, `
+{
+  "name": "My Process",
+  "projectId": "5fe987d1-7495-4dc7-bc4c-feaf08600b95",
+  "description": "This is my process",
+  "targetFramework": "Portable"
+}
+`)
+
+	studioProjectReader := newStudioProjectReader(path)
+	err := studioProjectReader.AddToIgnoredFiles("*.nupkg")
+	if err != nil {
+		t.Errorf("Should not return error, but got: %v", err)
+	}
+	_, err = studioProjectReader.ReadMetadata()
+	if err != nil {
+		t.Errorf("Should not return error, but got: %v", err)
+	}
+	data, _ := os.ReadFile(path)
+	json := string(data)
+	if !strings.Contains(json, `"designOptions":{"processOptions":{"ignoredFiles":["*.nupkg"]}}`) {
+		t.Errorf("Should contain ignored file pattern, but got: %s", json)
+	}
+}
+
+func TestStudioProjectReaderAddToIgnoredFilesAddsToExistingDesignOptions(t *testing.T) {
+	path := writeFile(t, `
+{
+  "name": "My Process",
+  "projectId": "5fe987d1-7495-4dc7-bc4c-feaf08600b95",
+  "description": "This is my process",
+  "targetFramework": "Portable",
+  "designOptions": {
+    "otherOptions": {}
+  }
+}
+`)
+
+	studioProjectReader := newStudioProjectReader(path)
+	err := studioProjectReader.AddToIgnoredFiles("*.nupkg")
+	if err != nil {
+		t.Errorf("Should not return error, but got: %v", err)
+	}
+	_, err = studioProjectReader.ReadMetadata()
+	if err != nil {
+		t.Errorf("Should not return error, but got: %v", err)
+	}
+	data, _ := os.ReadFile(path)
+	json := string(data)
+	if !strings.Contains(json, `"designOptions":{"otherOptions":{},"processOptions":{"ignoredFiles":["*.nupkg"]}}`) {
+		t.Errorf("Should contain ignored file pattern, but got: %s", json)
+	}
+}
+
+func TestStudioProjectReaderAddToIgnoredFilesAddsToExistingProcessOptions(t *testing.T) {
+	path := writeFile(t, `
+{
+  "name": "My Process",
+  "projectId": "5fe987d1-7495-4dc7-bc4c-feaf08600b95",
+  "description": "This is my process",
+  "targetFramework": "Portable",
+  "designOptions": {
+    "processOptions": {
+	  "otherOptions": {}
+    }
+  }
+}
+`)
+
+	studioProjectReader := newStudioProjectReader(path)
+	err := studioProjectReader.AddToIgnoredFiles("*.nupkg")
+	if err != nil {
+		t.Errorf("Should not return error, but got: %v", err)
+	}
+	_, err = studioProjectReader.ReadMetadata()
+	if err != nil {
+		t.Errorf("Should not return error, but got: %v", err)
+	}
+	data, _ := os.ReadFile(path)
+	json := string(data)
+	if !strings.Contains(json, `"designOptions":{"processOptions":{"ignoredFiles":["*.nupkg"],"otherOptions":{}}}`) {
+		t.Errorf("Should contain ignored file pattern, but got: %s", json)
+	}
+}
+
+func TestStudioProjectReaderAddToIgnoredFilesAddsToExistingIgnoredFiles(t *testing.T) {
+	path := writeFile(t, `
+{
+  "name": "My Process",
+  "projectId": "5fe987d1-7495-4dc7-bc4c-feaf08600b95",
+  "description": "This is my process",
+  "targetFramework": "Portable",
+  "designOptions": {
+    "processOptions": {
+	  "ignoredFiles": ["my-file"]
+	}
+  }
+}
+`)
+
+	studioProjectReader := newStudioProjectReader(path)
+	err := studioProjectReader.AddToIgnoredFiles("*.nupkg")
+	if err != nil {
+		t.Errorf("Should not return error, but got: %v", err)
+	}
+	_, err = studioProjectReader.ReadMetadata()
+	if err != nil {
+		t.Errorf("Should not return error, but got: %v", err)
+	}
+	data, _ := os.ReadFile(path)
+	json := string(data)
+	if !strings.Contains(json, `"designOptions":{"processOptions":{"ignoredFiles":["my-file","*.nupkg"]}}`) {
+		t.Errorf("Should contain ignored file pattern, but got: %s", json)
+	}
+}
+
+func TestStudioProjectReaderAddToIgnoredFilesFileNotFoundReturnsError(t *testing.T) {
+	studioProjectReader := newStudioProjectReader("not-found")
+	err := studioProjectReader.AddToIgnoredFiles("*.nupkg")
+	if !strings.HasPrefix(err.Error(), "Error reading project.json file") {
+		t.Errorf("Should return reading error, but got: %v", err)
+	}
+}
+
+func TestStudioProjectReaderAddToIgnoredFilesInvalidJsonReturnsError(t *testing.T) {
+	path := writeFile(t, "INVALID")
+
+	studioProjectReader := newStudioProjectReader(path)
+	err := studioProjectReader.AddToIgnoredFiles("*.nupkg")
+	if !strings.HasPrefix(err.Error(), "Error parsing project.json file") {
+		t.Errorf("Should return parsing error, but got: %v", err)
+	}
+}
+
+func TestStudioProjectReaderAddToIgnoredFilesInvalidIgnoredFilesReturnsError(t *testing.T) {
+	path := writeFile(t, `
+{
+  "name": "My Process",
+  "projectId": "5fe987d1-7495-4dc7-bc4c-feaf08600b95",
+  "description": "This is my process",
+  "targetFramework": "Portable",
+  "designOptions": {
+    "processOptions": {
+	  "ignoredFiles": {}
+	}
+  }
+}
+`)
+
+	studioProjectReader := newStudioProjectReader(path)
+	err := studioProjectReader.AddToIgnoredFiles("*.nupkg")
+	if err.Error() != "Error updating project.json file: Unexpected type for field 'ignoredFiles'" {
+		t.Errorf("Should return updating error, but got: %v", err)
+	}
+}
+
+func TestStudioProjectReaderAddToIgnoredFilesFilePatternExistsNoOp(t *testing.T) {
+	path := writeFile(t, `
+{
+  "name": "My Process",
+  "projectId": "5fe987d1-7495-4dc7-bc4c-feaf08600b95",
+  "description": "This is my process",
+  "targetFramework": "Portable",
+  "designOptions": {
+    "processOptions": {
+	  "ignoredFiles": ["my-file", "*.nupkg"]
+	}
+  }
+}
+`)
+
+	studioProjectReader := newStudioProjectReader(path)
+	err := studioProjectReader.AddToIgnoredFiles("*.nupkg")
+	if err != nil {
+		t.Errorf("Should not return error, but got: %v", err)
+	}
+	_, err = studioProjectReader.ReadMetadata()
+	if err != nil {
+		t.Errorf("Should not return error, but got: %v", err)
+	}
+	data, _ := os.ReadFile(path)
+	json := string(data)
+	if !strings.Contains(json, `["my-file", "*.nupkg"]`) {
+		t.Errorf("Should contain ignored file pattern, but got: %s", json)
+	}
+}
+
+func writeFile(t *testing.T, data string) string {
+	path := createFile(t)
+	err := os.WriteFile(path, []byte(data), 0600)
+	if err != nil {
+		panic(fmt.Errorf("Error writing file '%s': %w", path, err))
+	}
+	return path
+}
+
+func createFile(t *testing.T) string {
+	tempFile, err := os.CreateTemp("", "uipath-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tempFile.Close()
+	t.Cleanup(func() {
+		err := os.Remove(tempFile.Name())
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+	return tempFile.Name()
+}


### PR DESCRIPTION
Improving the Studio commands for packaging and analyzing to use the current directory when --source and --destination parameters have been omitted.

This makes the `uipath studio package pack` and `uipath studio package analyze` commands much easier to use when working in the current Studio project directory.

Also extended the pack command to add nupkg files to the ignored files section of the project so that subsequent `uipath studio package pack` commands do not include previously created nupkg files.