### PR TITLE
Add command to publish studio packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,12 +312,12 @@ curl --remote-name "$projectUrl/Main.xaml" \
 # Build and package project
 uipath studio package pack
 
-# Upload package
-uipath orchestrator processes upload-package --file "MyProcess.1.0.0.nupkg"
+# Publish the package
+uipath studio package publish
 
 # Create release
 folderId=$(uipath orchestrator folders get --query "value[0].Id")
-releaseKey=$(uipath orchestrator releases post --folder-id $folderId \
+releaseKey=$(uipath orchestrator releases post --folder-id "$folderId" \
                                                --name "MyProcess" \
                                                --process-key "MyProcess" \
                                                --process-version "1.0.0" \
@@ -325,10 +325,10 @@ releaseKey=$(uipath orchestrator releases post --folder-id $folderId \
                                                --output text)
 
 # Start process
-jobId=$(uipath orchestrator jobs start-jobs --folder-id $folderId \
+jobId=$(uipath orchestrator jobs start-jobs --folder-id "$folderId" \
                                             --start-info "ReleaseKey=$releaseKey" \
                                             --query "value[0].Id")
-uipath orchestrator jobs get-by-id --folder-id $folderId --key $jobId
+uipath orchestrator jobs get-by-id --folder-id "$folderId" --key "$jobId"
 ```
 
 ## Manage Orchestrator Resources
@@ -339,7 +339,7 @@ There are various UiPath Orchestrator resources which you can manage through the
 folderId=$(uipath orchestrator folders get --query "value[0].Id")
 
 # Create new Text asset
-uipath orchestrator assets post --folder-id $folderId \
+uipath orchestrator assets post --folder-id "$folderId" \
                                 --name "MyAsset" \
                                 --value-scope "Global" \
                                 --value-type "Text" \

--- a/main.go
+++ b/main.go
@@ -67,6 +67,7 @@ func main() {
 				plugin_digitizer.NewDigitizeCommand(),
 				plugin_orchestrator.NewUploadCommand(),
 				plugin_orchestrator.NewDownloadCommand(),
+				plugin_studio.NewPackagePublishCommand(),
 				plugin_studio.NewPackagePackCommand(),
 				plugin_studio.NewPackageAnalyzeCommand(),
 			},

--- a/plugin/studio/nupkg_reader.go
+++ b/plugin/studio/nupkg_reader.go
@@ -1,0 +1,71 @@
+package studio
+
+import (
+	"archive/zip"
+	"encoding/xml"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+type nupkgReader struct {
+	Path string
+}
+
+func (r nupkgReader) ReadNuspec() (*nuspec, error) {
+	zip, err := zip.OpenReader(r.Path)
+	if err != nil {
+		return nil, fmt.Errorf("Could not read package '%s': %v", r.Path, err)
+	}
+	defer zip.Close()
+	for _, file := range zip.File {
+		if strings.HasSuffix(file.Name, ".nuspec") {
+			return r.readNuspec(r.Path, file)
+		}
+	}
+	return nil, fmt.Errorf("Could not find nuspec in package '%s'", r.Path)
+}
+
+func (r nupkgReader) readNuspec(source string, file *zip.File) (*nuspec, error) {
+	reader, err := file.Open()
+	if err != nil {
+		return nil, fmt.Errorf("Could not read nuspec in package '%s': %v", source, err)
+	}
+	defer reader.Close()
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		return nil, fmt.Errorf("Could not read nuspec in package '%s': %v", source, err)
+	}
+	var nuspec nuspecXml
+	err = xml.Unmarshal(data, &nuspec)
+	if err != nil {
+		return nil, fmt.Errorf("Could not read nuspec in package '%s': %v", source, err)
+	}
+	return newNuspec(nuspec.Metadata.Title, nuspec.Metadata.Version), nil
+}
+
+func findLatestNupkg(directory string) string {
+	newestFile := ""
+	newestTime := time.Time{}
+
+	files, _ := os.ReadDir(directory)
+	for _, file := range files {
+		extension := filepath.Ext(file.Name())
+		if strings.EqualFold(extension, ".nupkg") {
+			fileInfo, _ := file.Info()
+			time := fileInfo.ModTime()
+			if time.After(newestTime) {
+				newestTime = time
+				newestFile = filepath.Join(directory, file.Name())
+			}
+		}
+	}
+	return newestFile
+}
+
+func newNupkgReader(path string) *nupkgReader {
+	return &nupkgReader{path}
+}

--- a/plugin/studio/nuspec.go
+++ b/plugin/studio/nuspec.go
@@ -1,0 +1,10 @@
+package studio
+
+type nuspec struct {
+	Title   string
+	Version string
+}
+
+func newNuspec(title string, version string) *nuspec {
+	return &nuspec{title, version}
+}

--- a/plugin/studio/nuspec_xml.go
+++ b/plugin/studio/nuspec_xml.go
@@ -1,0 +1,13 @@
+package studio
+
+import "encoding/xml"
+
+type nuspecXml struct {
+	XMLName  xml.Name                 `xml:"package"`
+	Metadata nuspecPackageMetadataXml `xml:"metadata"`
+}
+
+type nuspecPackageMetadataXml struct {
+	Title   string `xml:"title"`
+	Version string `xml:"version"`
+}

--- a/plugin/studio/package_publish_command.go
+++ b/plugin/studio/package_publish_command.go
@@ -1,0 +1,252 @@
+package studio
+
+import (
+	"bytes"
+	"crypto/tls"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/textproto"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/UiPath/uipathcli/log"
+	"github.com/UiPath/uipathcli/output"
+	"github.com/UiPath/uipathcli/plugin"
+	"github.com/UiPath/uipathcli/utils/stream"
+	"github.com/UiPath/uipathcli/utils/visualization"
+)
+
+// The PackagePublishCommand publishes a package
+type PackagePublishCommand struct {
+}
+
+func (c PackagePublishCommand) Command() plugin.Command {
+	return *plugin.NewCommand("studio").
+		WithCategory("package", "Package", "UiPath Studio package-related actions").
+		WithOperation("publish", "Publish Package", "Publishes the package to orchestrator").
+		WithParameter("source", plugin.ParameterTypeString, "Path to package (default: .)", false)
+}
+
+func (c PackagePublishCommand) Execute(context plugin.ExecutionContext, writer output.OutputWriter, logger log.Logger) error {
+	if context.Organization == "" {
+		return errors.New("Organization is not set")
+	}
+	if context.Tenant == "" {
+		return errors.New("Tenant is not set")
+	}
+	source, err := c.getSource(context)
+	if err != nil {
+		return err
+	}
+	nupkgReader := newNupkgReader(source)
+	nuspec, err := nupkgReader.ReadNuspec()
+	if err != nil {
+		return err
+	}
+	baseUri := c.formatUri(context.BaseUri, context.Organization, context.Tenant)
+	params := newPackagePublishParams(source, nuspec.Title, nuspec.Version, baseUri, context.Auth, context.Insecure, context.Debug)
+	result, err := c.publish(*params, logger)
+	if err != nil {
+		return err
+	}
+
+	json, err := json.Marshal(result)
+	if err != nil {
+		return fmt.Errorf("Publish command failed: %v", err)
+	}
+	return writer.WriteResponse(*output.NewResponseInfo(200, "200 OK", "HTTP/1.1", map[string][]string{}, bytes.NewReader(json)))
+}
+
+func (c PackagePublishCommand) publish(params packagePublishParams, logger log.Logger) (*packagePublishResult, error) {
+	file := stream.NewFileStream(params.Source)
+	uploadBar := visualization.NewProgressBar(logger)
+	defer uploadBar.Remove()
+	requestError := make(chan error)
+	request, err := c.createUploadRequest(file, params, uploadBar, requestError)
+	if err != nil {
+		return nil, err
+	}
+	if params.Debug {
+		c.logRequest(logger, request)
+	}
+	response, err := c.send(request, params.Insecure, requestError)
+	if err != nil {
+		return nil, fmt.Errorf("Error sending request: %w", err)
+	}
+	defer response.Body.Close()
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		return nil, fmt.Errorf("Error reading response: %w", err)
+	}
+	c.logResponse(logger, response, body)
+	if response.StatusCode == http.StatusConflict {
+		errorMessage := fmt.Sprintf("Package '%s' already exists", filepath.Base(params.Source))
+		return newFailedPackagePublishResult(errorMessage, params.Source, params.Name, params.Version), nil
+	}
+	if response.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("Orchestrator returned status code '%v' and body '%v'", response.StatusCode, string(body))
+	}
+	return newSucceededPackagePublishResult(params.Source, params.Name, params.Version), nil
+}
+
+func (c PackagePublishCommand) createUploadRequest(file stream.Stream, params packagePublishParams, uploadBar *visualization.ProgressBar, requestError chan error) (*http.Request, error) {
+	bodyReader, bodyWriter := io.Pipe()
+	contentType, contentLength := c.writeMultipartBody(bodyWriter, file, "application/octet-stream", requestError)
+	uploadReader := c.progressReader("uploading...", "completing  ", bodyReader, contentLength, uploadBar)
+
+	uri := params.BaseUri + "/odata/Processes/UiPath.Server.Configuration.OData.UploadPackage"
+	request, err := http.NewRequest("POST", uri, uploadReader)
+	if err != nil {
+		return nil, err
+	}
+	request.Header.Add("Content-Type", contentType)
+	for key, value := range params.Auth.Header {
+		request.Header.Add(key, value)
+	}
+	return request, nil
+}
+
+func (c PackagePublishCommand) progressReader(text string, completedText string, reader io.Reader, length int64, progressBar *visualization.ProgressBar) io.Reader {
+	if length < 10*1024*1024 {
+		return reader
+	}
+	progressReader := visualization.NewProgressReader(reader, func(progress visualization.Progress) {
+		displayText := text
+		if progress.Completed {
+			displayText = completedText
+		}
+		progressBar.UpdateProgress(displayText, progress.BytesRead, length, progress.BytesPerSecond)
+	})
+	return progressReader
+}
+
+func (c PackagePublishCommand) calculateMultipartSize(stream stream.Stream) int64 {
+	size, _ := stream.Size()
+	return size
+}
+
+func (c PackagePublishCommand) writeMultipartForm(writer *multipart.Writer, stream stream.Stream, contentType string) error {
+	filePart := textproto.MIMEHeader{}
+	filePart.Set("Content-Disposition", fmt.Sprintf(`form-data; name="file"; filename="%s"`, stream.Name()))
+	filePart.Set("Content-Type", contentType)
+	w, err := writer.CreatePart(filePart)
+	if err != nil {
+		return fmt.Errorf("Error creating form field 'file': %w", err)
+	}
+	data, err := stream.Data()
+	if err != nil {
+		return err
+	}
+	defer data.Close()
+	_, err = io.Copy(w, data)
+	if err != nil {
+		return fmt.Errorf("Error writing form field 'file': %w", err)
+	}
+	return nil
+}
+
+func (c PackagePublishCommand) writeMultipartBody(bodyWriter *io.PipeWriter, stream stream.Stream, contentType string, errorChan chan error) (string, int64) {
+	contentLength := c.calculateMultipartSize(stream)
+	formWriter := multipart.NewWriter(bodyWriter)
+	go func() {
+		defer bodyWriter.Close()
+		defer formWriter.Close()
+		err := c.writeMultipartForm(formWriter, stream, contentType)
+		if err != nil {
+			errorChan <- err
+			return
+		}
+	}()
+	return formWriter.FormDataContentType(), contentLength
+}
+
+func (c PackagePublishCommand) send(request *http.Request, insecure bool, errorChan chan error) (*http.Response, error) {
+	responseChan := make(chan *http.Response)
+	go func(request *http.Request) {
+		response, err := c.sendRequest(request, insecure)
+		if err != nil {
+			errorChan <- err
+			return
+		}
+		responseChan <- response
+	}(request)
+
+	select {
+	case err := <-errorChan:
+		return nil, err
+	case response := <-responseChan:
+		return response, nil
+	}
+}
+
+func (c PackagePublishCommand) sendRequest(request *http.Request, insecure bool) (*http.Response, error) {
+	transport := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: insecure}, //nolint // This is user configurable and disabled by default
+	}
+	client := &http.Client{Transport: transport}
+	return client.Do(request)
+}
+
+func (c PackagePublishCommand) getSource(context plugin.ExecutionContext) (string, error) {
+	source := c.getParameter("source", ".", context.Parameters)
+	source, _ = filepath.Abs(source)
+	fileInfo, err := os.Stat(source)
+	if err != nil {
+		return "", fmt.Errorf("Package not found.")
+	}
+	if fileInfo.IsDir() {
+		source = findLatestNupkg(source)
+	}
+	if source == "" {
+		return "", errors.New("Could not find package to publish")
+	}
+	return source, nil
+}
+
+func (c PackagePublishCommand) getParameter(name string, defaultValue string, parameters []plugin.ExecutionParameter) string {
+	result := defaultValue
+	for _, p := range parameters {
+		if p.Name == name {
+			if data, ok := p.Value.(string); ok {
+				result = data
+				break
+			}
+		}
+	}
+	return result
+}
+
+func (c PackagePublishCommand) formatUri(baseUri url.URL, org string, tenant string) string {
+	path := baseUri.Path
+	if baseUri.Path == "" {
+		path = "/{organization}/{tenant}/orchestrator_"
+	}
+	path = strings.ReplaceAll(path, "{organization}", org)
+	path = strings.ReplaceAll(path, "{tenant}", tenant)
+	path = strings.TrimSuffix(path, "/")
+	return fmt.Sprintf("%s://%s%s", baseUri.Scheme, baseUri.Host, path)
+}
+
+func (c PackagePublishCommand) logRequest(logger log.Logger, request *http.Request) {
+	buffer := &bytes.Buffer{}
+	_, _ = buffer.ReadFrom(request.Body)
+	body := buffer.Bytes()
+	request.Body = io.NopCloser(bytes.NewReader(body))
+	requestInfo := log.NewRequestInfo(request.Method, request.URL.String(), request.Proto, request.Header, bytes.NewReader(body))
+	logger.LogRequest(*requestInfo)
+}
+
+func (c PackagePublishCommand) logResponse(logger log.Logger, response *http.Response, body []byte) {
+	responseInfo := log.NewResponseInfo(response.StatusCode, response.Status, response.Proto, response.Header, bytes.NewReader(body))
+	logger.LogResponse(*responseInfo)
+}
+
+func NewPackagePublishCommand() *PackagePublishCommand {
+	return &PackagePublishCommand{}
+}

--- a/plugin/studio/package_publish_params.go
+++ b/plugin/studio/package_publish_params.go
@@ -1,0 +1,24 @@
+package studio
+
+import "github.com/UiPath/uipathcli/plugin"
+
+type packagePublishParams struct {
+	Source   string
+	Name     string
+	Version  string
+	BaseUri  string
+	Auth     plugin.AuthResult
+	Insecure bool
+	Debug    bool
+}
+
+func newPackagePublishParams(
+	source string,
+	name string,
+	version string,
+	baseUri string,
+	auth plugin.AuthResult,
+	insecure bool,
+	debug bool) *packagePublishParams {
+	return &packagePublishParams{source, name, version, baseUri, auth, insecure, debug}
+}

--- a/plugin/studio/package_publish_result.go
+++ b/plugin/studio/package_publish_result.go
@@ -1,0 +1,17 @@
+package studio
+
+type packagePublishResult struct {
+	Status  string  `json:"status"`
+	Package string  `json:"package"`
+	Name    string  `json:"name"`
+	Version string  `json:"version"`
+	Error   *string `json:"error"`
+}
+
+func newSucceededPackagePublishResult(packagePath string, name string, version string) *packagePublishResult {
+	return &packagePublishResult{"Succeeded", packagePath, name, version, nil}
+}
+
+func newFailedPackagePublishResult(err string, packagePath string, processKey string, processVersion string) *packagePublishResult {
+	return &packagePublishResult{"Failed", packagePath, processKey, processVersion, &err}
+}

--- a/plugin/studio/setup_test.go
+++ b/plugin/studio/setup_test.go
@@ -1,0 +1,108 @@
+package studio
+
+import (
+	"archive/zip"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+const studioDefinition = `
+openapi: 3.0.1
+info:
+  title: UiPath Studio
+  description: UiPath Studio
+  version: v1
+servers:
+  - url: https://cloud.uipath.com/{organization}/studio_/backend
+    description: The production url
+    variables:
+      organization:
+        description: The organization name (or id)
+        default: my-org
+paths:
+  {}
+`
+
+const nuspecContent = `
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+  <metadata minClientVersion="3.3">
+    <id>MyLibrary</id>
+    <version>1.0.0</version>
+    <title>My Library</title>
+  </metadata>
+</package>`
+
+func writeFile(t *testing.T, data string) string {
+	path := createFile(t)
+	err := os.WriteFile(path, []byte(data), 0600)
+	if err != nil {
+		panic(fmt.Errorf("Error writing file '%s': %w", path, err))
+	}
+	return path
+}
+
+func createFile(t *testing.T) string {
+	tempFile, err := os.CreateTemp("", "uipath-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tempFile.Close()
+	t.Cleanup(func() {
+		err := os.Remove(tempFile.Name())
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+	return tempFile.Name()
+}
+
+func createDirectory(t *testing.T) string {
+	tmp, err := os.MkdirTemp("", "uipath-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.RemoveAll(tmp) })
+	return tmp
+}
+
+func createNupkgArchive(t *testing.T, nuspec string) string {
+	path := createFile(t)
+	writeNupkgArchive(t, path, nuspec)
+	return path
+}
+
+func writeNupkgArchive(t *testing.T, path string, nuspec string) {
+	archive, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer archive.Close()
+	zipWriter := zip.NewWriter(archive)
+	nuspecWriter, err := zipWriter.Create("MyProcess.nuspec")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = io.WriteString(nuspecWriter, nuspec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = zipWriter.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func studioCrossPlatformProjectDirectory() string {
+	_, filename, _, _ := runtime.Caller(0)
+	return filepath.Join(filepath.Dir(filename), "projects", "crossplatform")
+}
+
+func studioWindowsProjectDirectory() string {
+	_, filename, _, _ := runtime.Caller(0)
+	return filepath.Join(filepath.Dir(filename), "projects", "windows")
+}

--- a/plugin/studio/studio_project_reader_test.go
+++ b/plugin/studio/studio_project_reader_test.go
@@ -1,7 +1,6 @@
 package studio
 
 import (
-	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -291,28 +290,4 @@ func TestStudioProjectReaderAddToIgnoredFilesFilePatternExistsNoOp(t *testing.T)
 	if !strings.Contains(json, `["my-file", "*.nupkg"]`) {
 		t.Errorf("Should contain ignored file pattern, but got: %s", json)
 	}
-}
-
-func writeFile(t *testing.T, data string) string {
-	path := createFile(t)
-	err := os.WriteFile(path, []byte(data), 0600)
-	if err != nil {
-		panic(fmt.Errorf("Error writing file '%s': %w", path, err))
-	}
-	return path
-}
-
-func createFile(t *testing.T) string {
-	tempFile, err := os.CreateTemp("", "uipath-test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer tempFile.Close()
-	t.Cleanup(func() {
-		err := os.Remove(tempFile.Name())
-		if err != nil {
-			t.Fatal(err)
-		}
-	})
-	return tempFile.Name()
 }


### PR DESCRIPTION
Implemented new command `uipath studio package publish` which simplifies uploading packages to orchestrator.

Clients can now just pack and publish with two simple commands:

```
uipath studio package pack
uipath studio package publish

```

The publish command supports the optional `--source` argument which allows users to specify the .nupkg which should be uploaded to orchestrator. The source argument can also be a folder and the publish command will automatically find the latest package based on the last modified timestamp. If the argument is not provided, it defaults to the current execution directory.