### PR TITLE
Add network package with common http client

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -161,7 +161,7 @@ func (c CreateCommand) Command() plugin.Command {
   // Provides the definition of the command like name, description and parameters
 }
 
-func (c CreateCommand) Execute(context plugin.ExecutionContext, writer output.OutputWriter, logger log.Logger) error {
+func (c CreateCommand) Execute(ctx plugin.ExecutionContext, writer output.OutputWriter, logger log.Logger) error {
   // Invoked when the CLI command is executed
 }
 ```
@@ -213,7 +213,7 @@ func (c StatusCommand) Command() plugin.Command {
       IsHidden()
 }
 
-func (c StatusCommand) Execute(context plugin.ExecutionContext, writer output.OutputWriter, logger log.Logger) error {
+func (c StatusCommand) Execute(ctx plugin.ExecutionContext, writer output.OutputWriter, logger log.Logger) error {
   return fmt.Errorf("Status command not supported")
 }
 ```

--- a/auth/authenticator_context.go
+++ b/auth/authenticator_context.go
@@ -4,20 +4,20 @@ import "net/url"
 
 // AuthenticatorContext provides information required for authenticating requests.
 type AuthenticatorContext struct {
-	Type        string                 `json:"type"`
-	Config      map[string]interface{} `json:"config"`
-	IdentityUri url.URL                `json:"identityUri"`
-	Debug       bool                   `json:"debug"`
-	Insecure    bool                   `json:"insecure"`
-	Request     AuthenticatorRequest   `json:"request"`
+	Type        string
+	Config      map[string]interface{}
+	IdentityUri url.URL
+	OperationId string
+	Insecure    bool
+	Request     AuthenticatorRequest
 }
 
 func NewAuthenticatorContext(
 	authType string,
 	config map[string]interface{},
 	identityUri url.URL,
-	debug bool,
+	operationId string,
 	insecure bool,
 	request AuthenticatorRequest) *AuthenticatorContext {
-	return &AuthenticatorContext{authType, config, identityUri, debug, insecure, request}
+	return &AuthenticatorContext{authType, config, identityUri, operationId, insecure, request}
 }

--- a/auth/authenticator_request.go
+++ b/auth/authenticator_request.go
@@ -2,8 +2,8 @@ package auth
 
 // AuthenticatorRequest describes the request which needs to be authenticated.
 type AuthenticatorRequest struct {
-	URL    string            `json:"url"`
-	Header map[string]string `json:"header"`
+	URL    string
+	Header map[string]string
 }
 
 func NewAuthenticatorRequest(

--- a/auth/bearer_authenticator.go
+++ b/auth/bearer_authenticator.go
@@ -32,6 +32,7 @@ func (a BearerAuthenticator) Auth(ctx AuthenticatorContext) AuthenticatorResult 
 		config.ClientId,
 		config.ClientSecret,
 		config.Properties,
+		ctx.OperationId,
 		ctx.Insecure)
 	tokenResponse, err := identityClient.GetToken(*tokenRequest)
 	if err != nil {

--- a/auth/oauth_authenticator.go
+++ b/auth/oauth_authenticator.go
@@ -35,7 +35,7 @@ func (a OAuthAuthenticator) Auth(ctx AuthenticatorContext) AuthenticatorResult {
 	if err != nil {
 		return *AuthenticatorError(fmt.Errorf("Invalid oauth authenticator configuration: %w", err))
 	}
-	token, err := a.retrieveToken(config.IdentityUri, *config, ctx.Insecure)
+	token, err := a.retrieveToken(config.IdentityUri, *config, ctx.OperationId, ctx.Insecure)
 	if err != nil {
 		return *AuthenticatorError(fmt.Errorf("Error retrieving access token: %w", err))
 	}
@@ -43,7 +43,7 @@ func (a OAuthAuthenticator) Auth(ctx AuthenticatorContext) AuthenticatorResult {
 	return *AuthenticatorSuccess(ctx.Request.Header, ctx.Config)
 }
 
-func (a OAuthAuthenticator) retrieveToken(identityBaseUri url.URL, config oauthAuthenticatorConfig, insecure bool) (string, error) {
+func (a OAuthAuthenticator) retrieveToken(identityBaseUri url.URL, config oauthAuthenticatorConfig, operationId string, insecure bool) (string, error) {
 	cacheKey := fmt.Sprintf("oauthtoken|%s|%s|%s|%s", identityBaseUri.Scheme, identityBaseUri.Hostname(), config.ClientId, config.Scopes)
 	token, _ := a.cache.Get(cacheKey)
 	if token != "" {
@@ -65,6 +65,7 @@ func (a OAuthAuthenticator) retrieveToken(identityBaseUri url.URL, config oauthA
 		code,
 		codeVerifier,
 		config.RedirectUrl.String(),
+		operationId,
 		insecure)
 	tokenResponse, err := identityClient.GetToken(*tokenRequest)
 	if err != nil {

--- a/auth/oauth_authenticator_test.go
+++ b/auth/oauth_authenticator_test.go
@@ -25,7 +25,7 @@ func TestOAuthAuthenticatorNotEnabled(t *testing.T) {
 		"scopes":   "OR.Users",
 	}
 	request := NewAuthenticatorRequest("http:/localhost", map[string]string{})
-	context := NewAuthenticatorContext("login", config, createIdentityUrl(""), false, false, *request)
+	context := NewAuthenticatorContext("login", config, createIdentityUrl(""), "72b54f995dc5df454d2c1d984cea9c59", false, *request)
 
 	authenticator := NewOAuthAuthenticator(cache.NewFileCache(), *NewBrowserLauncher())
 	result := authenticator.Auth(*context)
@@ -46,12 +46,12 @@ func TestOAuthAuthenticatorPreservesExistingHeaders(t *testing.T) {
 		"my-header": "my-value",
 	}
 	request := NewAuthenticatorRequest("http:/localhost", headers)
-	context := NewAuthenticatorContext("login", config, createIdentityUrl(""), false, false, *request)
+	context := NewAuthenticatorContext("login", config, createIdentityUrl(""), "77a4d29d6c01dd5f146974cabdef3524", false, *request)
 
 	authenticator := NewOAuthAuthenticator(cache.NewFileCache(), *NewBrowserLauncher())
 	result := authenticator.Auth(*context)
 	if result.Error != "" {
-		t.Errorf("Expected no error when oauth flow is skipped, but got: %v", result.Error)
+		t.Errorf("Expected no error when performing oauth flow, but got: %v", result.Error)
 	}
 	if result.RequestHeader["my-header"] != "my-value" {
 		t.Errorf("Request header should not be changed, but got: %v", result.RequestHeader)
@@ -65,7 +65,7 @@ func TestOAuthAuthenticatorInvalidConfig(t *testing.T) {
 		"scopes":      "OR.Users",
 	}
 	request := NewAuthenticatorRequest("http:/localhost", map[string]string{})
-	context := NewAuthenticatorContext("login", config, createIdentityUrl(""), false, false, *request)
+	context := NewAuthenticatorContext("login", config, createIdentityUrl(""), "02ce225755f20f839fb03b38557b8341", false, *request)
 
 	authenticator := NewOAuthAuthenticator(cache.NewFileCache(), *NewBrowserLauncher())
 	result := authenticator.Auth(*context)
@@ -240,7 +240,7 @@ func createAuthContext(baseUrl url.URL) AuthenticatorContext {
 	}
 	identityUrl := createIdentityUrl(baseUrl.Host)
 	request := NewAuthenticatorRequest(fmt.Sprintf("%s://%s", baseUrl.Scheme, baseUrl.Host), map[string]string{})
-	context := NewAuthenticatorContext("login", config, identityUrl, false, false, *request)
+	context := NewAuthenticatorContext("login", config, identityUrl, "d7b087788be2154da3ad9d6bc14588f4", false, *request)
 	return *context
 }
 

--- a/auth/token_request.go
+++ b/auth/token_request.go
@@ -12,13 +12,14 @@ type tokenRequest struct {
 	CodeVerifier string
 	RedirectUri  string
 	Properties   map[string]string
+	OperationId  string
 	Insecure     bool
 }
 
-func newTokenRequest(baseUri url.URL, grantType string, scopes string, clientId string, clientSecret string, properties map[string]string, insecure bool) *tokenRequest {
-	return &tokenRequest{baseUri, grantType, scopes, clientId, clientSecret, "", "", "", properties, insecure}
+func newTokenRequest(baseUri url.URL, grantType string, scopes string, clientId string, clientSecret string, properties map[string]string, operationId string, insecure bool) *tokenRequest {
+	return &tokenRequest{baseUri, grantType, scopes, clientId, clientSecret, "", "", "", properties, operationId, insecure}
 }
 
-func newAuthorizationCodeTokenRequest(baseUri url.URL, clientId string, code string, codeVerifier string, redirectUrl string, insecure bool) *tokenRequest {
-	return &tokenRequest{baseUri, "authorization_code", "", clientId, "", code, codeVerifier, redirectUrl, map[string]string{}, insecure}
+func newAuthorizationCodeTokenRequest(baseUri url.URL, clientId string, code string, codeVerifier string, redirectUrl string, operationId string, insecure bool) *tokenRequest {
+	return &tokenRequest{baseUri, "authorization_code", "", clientId, "", code, codeVerifier, redirectUrl, map[string]string{}, operationId, insecure}
 }

--- a/executor/execution_context.go
+++ b/executor/execution_context.go
@@ -2,7 +2,6 @@ package executor
 
 import (
 	"net/url"
-	"time"
 
 	"github.com/UiPath/uipathcli/config"
 	"github.com/UiPath/uipathcli/plugin"
@@ -21,12 +20,10 @@ type ExecutionContext struct {
 	Input        stream.Stream
 	Parameters   ExecutionParameters
 	AuthConfig   config.AuthConfig
-	Insecure     bool
-	Timeout      time.Duration
-	MaxAttempts  int
-	Debug        bool
 	IdentityUri  url.URL
 	Plugin       plugin.CommandPlugin
+	Debug        bool
+	Settings     ExecutionSettings
 }
 
 func NewExecutionContext(
@@ -39,12 +36,10 @@ func NewExecutionContext(
 	input stream.Stream,
 	parameters []ExecutionParameter,
 	authConfig config.AuthConfig,
-	insecure bool,
-	timeout time.Duration,
-	maxAttempts int,
-	debug bool,
 	identityUri url.URL,
-	plugin plugin.CommandPlugin) *ExecutionContext {
+	plugin plugin.CommandPlugin,
+	debug bool,
+	settings ExecutionSettings) *ExecutionContext {
 	return &ExecutionContext{
 		organization,
 		tenant,
@@ -55,11 +50,9 @@ func NewExecutionContext(
 		input,
 		parameters,
 		authConfig,
-		insecure,
-		timeout,
-		maxAttempts,
-		debug,
 		identityUri,
 		plugin,
+		debug,
+		settings,
 	}
 }

--- a/executor/execution_settings.go
+++ b/executor/execution_settings.go
@@ -1,0 +1,26 @@
+package executor
+
+import (
+	"time"
+)
+
+// The ExecutionSettings provides global settings for executing commands.
+type ExecutionSettings struct {
+	OperationId string
+	Timeout     time.Duration
+	MaxAttempts int
+	Insecure    bool
+}
+
+func NewExecutionSettings(
+	operationId string,
+	timeout time.Duration,
+	maxAttempts int,
+	insecure bool) *ExecutionSettings {
+	return &ExecutionSettings{
+		operationId,
+		timeout,
+		maxAttempts,
+		insecure,
+	}
+}

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -12,5 +12,5 @@ import (
 // The OutputWriter should be used to output the result of the command.
 // The Logger should be used for providing additional information when running a command.
 type Executor interface {
-	Call(context ExecutionContext, writer output.OutputWriter, logger log.Logger) error
+	Call(ctx ExecutionContext, writer output.OutputWriter, logger log.Logger) error
 }

--- a/executor/http_executor.go
+++ b/executor/http_executor.go
@@ -2,8 +2,7 @@ package executor
 
 import (
 	"bytes"
-	"crypto/rand"
-	"crypto/tls"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -11,16 +10,13 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/url"
-	"runtime"
 	"strings"
 
 	"github.com/UiPath/uipathcli/auth"
-	"github.com/UiPath/uipathcli/config"
 	"github.com/UiPath/uipathcli/log"
 	"github.com/UiPath/uipathcli/output"
-	"github.com/UiPath/uipathcli/utils"
 	"github.com/UiPath/uipathcli/utils/converter"
-	"github.com/UiPath/uipathcli/utils/resiliency"
+	"github.com/UiPath/uipathcli/utils/network"
 	"github.com/UiPath/uipathcli/utils/stream"
 	"github.com/UiPath/uipathcli/utils/visualization"
 )
@@ -34,33 +30,17 @@ For more information you can view the help:
     uipath config --help
 `
 
-var UserAgent = fmt.Sprintf("uipathcli/%s (%s; %s)", utils.Version, runtime.GOOS, runtime.GOARCH)
-
 // The HttpExecutor implements the Executor interface and constructs HTTP request
 // from the given command line parameters and configurations.
 type HttpExecutor struct {
 	authenticators []auth.Authenticator
 }
 
-func (e HttpExecutor) Call(context ExecutionContext, writer output.OutputWriter, logger log.Logger) error {
-	return resiliency.RetryN(context.MaxAttempts, func() error {
-		return e.call(context, writer, logger)
-	})
-}
-
-func (e HttpExecutor) requestId() string {
-	bytes := make([]byte, 16)
-	_, _ = rand.Read(bytes)
-	return fmt.Sprintf("%x%x%x%x%x", bytes[0:4], bytes[4:6], bytes[6:8], bytes[8:10], bytes[10:])
-}
-
-func (e HttpExecutor) addHeaders(request *http.Request, headerParameters []ExecutionParameter) {
+func (e HttpExecutor) addHeaders(header http.Header, headerParameters []ExecutionParameter) {
 	converter := converter.NewStringConverter()
-	request.Header.Add("x-request-id", e.requestId())
-	request.Header.Add("User-Agent", UserAgent)
 	for _, parameter := range headerParameters {
 		headerValue := converter.ToString(parameter.Value)
-		request.Header.Add(parameter.Name, headerValue)
+		header.Set(parameter.Name, headerValue)
 	}
 }
 
@@ -153,37 +133,46 @@ func (e HttpExecutor) formatUri(baseUri url.URL, route string, pathParameters []
 	return e.validateUri(uriBuilder.Build())
 }
 
-func (e HttpExecutor) executeAuthenticators(authConfig config.AuthConfig, identityUri url.URL, debug bool, insecure bool, request *http.Request) (*auth.AuthenticatorResult, error) {
-	authRequest := *auth.NewAuthenticatorRequest(request.URL.String(), map[string]string{})
-	ctx := *auth.NewAuthenticatorContext(authConfig.Type, authConfig.Config, identityUri, debug, insecure, authRequest)
+func (e HttpExecutor) authenticatorContext(ctx ExecutionContext, url string) auth.AuthenticatorContext {
+	authRequest := *auth.NewAuthenticatorRequest(url, map[string]string{})
+	return *auth.NewAuthenticatorContext(
+		ctx.AuthConfig.Type,
+		ctx.AuthConfig.Config,
+		ctx.IdentityUri,
+		ctx.Settings.OperationId,
+		ctx.Settings.Insecure,
+		authRequest)
+}
+
+func (e HttpExecutor) executeAuthenticators(ctx ExecutionContext, url string) (*auth.AuthenticatorResult, error) {
+	authContext := e.authenticatorContext(ctx, url)
 	for _, authProvider := range e.authenticators {
-		result := authProvider.Auth(ctx)
+		result := authProvider.Auth(authContext)
 		if result.Error != "" {
 			return nil, errors.New(result.Error)
 		}
-		ctx.Config = result.Config
+		authContext.Config = result.Config
 		for k, v := range result.RequestHeader {
-			ctx.Request.Header[k] = v
+			authContext.Request.Header[k] = v
 		}
 	}
-	return auth.AuthenticatorSuccess(ctx.Request.Header, ctx.Config), nil
+	return auth.AuthenticatorSuccess(authContext.Request.Header, authContext.Config), nil
 }
 
 func (e HttpExecutor) progressReader(text string, completedText string, reader io.Reader, length int64, progressBar *visualization.ProgressBar) io.Reader {
 	if length < 10*1024*1024 {
 		return reader
 	}
-	progressReader := visualization.NewProgressReader(reader, func(progress visualization.Progress) {
+	return visualization.NewProgressReader(reader, func(progress visualization.Progress) {
 		displayText := text
 		if progress.Completed {
 			displayText = completedText
 		}
 		progressBar.UpdateProgress(displayText, progress.BytesRead, length, progress.BytesPerSecond)
 	})
-	return progressReader
 }
 
-func (e HttpExecutor) writeMultipartBody(bodyWriter *io.PipeWriter, parameters []ExecutionParameter, errorChan chan error) (string, int64) {
+func (e HttpExecutor) writeMultipartBody(bodyWriter *io.PipeWriter, parameters []ExecutionParameter, cancel context.CancelCauseFunc) (string, int64) {
 	multipartSize := e.calculateMultipartSize(parameters)
 	formWriter := multipart.NewWriter(bodyWriter)
 	go func() {
@@ -191,31 +180,31 @@ func (e HttpExecutor) writeMultipartBody(bodyWriter *io.PipeWriter, parameters [
 		defer formWriter.Close()
 		err := e.writeMultipartForm(formWriter, parameters)
 		if err != nil {
-			errorChan <- err
+			cancel(err)
 			return
 		}
 	}()
 	return formWriter.FormDataContentType(), multipartSize
 }
 
-func (e HttpExecutor) writeInputBody(bodyWriter *io.PipeWriter, input stream.Stream, errorChan chan error) {
+func (e HttpExecutor) writeInputBody(bodyWriter *io.PipeWriter, input stream.Stream, cancel context.CancelCauseFunc) {
 	go func() {
 		defer bodyWriter.Close()
 		data, err := input.Data()
 		if err != nil {
-			errorChan <- err
+			cancel(err)
 			return
 		}
 		defer data.Close()
 		_, err = io.Copy(bodyWriter, data)
 		if err != nil {
-			errorChan <- err
+			cancel(err)
 			return
 		}
 	}()
 }
 
-func (e HttpExecutor) writeUrlEncodedBody(bodyWriter *io.PipeWriter, parameters []ExecutionParameter, errorChan chan error) {
+func (e HttpExecutor) writeUrlEncodedBody(bodyWriter *io.PipeWriter, parameters []ExecutionParameter, cancel context.CancelCauseFunc) {
 	go func() {
 		defer bodyWriter.Close()
 		queryStringBuilder := converter.NewQueryStringBuilder()
@@ -225,134 +214,100 @@ func (e HttpExecutor) writeUrlEncodedBody(bodyWriter *io.PipeWriter, parameters 
 		queryString := queryStringBuilder.Build()
 		_, err := bodyWriter.Write([]byte(queryString))
 		if err != nil {
-			errorChan <- err
+			cancel(err)
 			return
 		}
 	}()
 }
 
-func (e HttpExecutor) writeJsonBody(bodyWriter *io.PipeWriter, parameters []ExecutionParameter, errorChan chan error) {
+func (e HttpExecutor) writeJsonBody(bodyWriter *io.PipeWriter, parameters []ExecutionParameter, cancel context.CancelCauseFunc) {
 	go func() {
 		defer bodyWriter.Close()
 		err := e.serializeJson(bodyWriter, parameters)
 		if err != nil {
-			errorChan <- err
+			cancel(err)
 			return
 		}
 	}()
 }
 
-func (e HttpExecutor) writeBody(context ExecutionContext, errorChan chan error) (io.Reader, string, int64, int64) {
-	if context.Input != nil {
+func (e HttpExecutor) writeBody(ctx ExecutionContext, cancel context.CancelCauseFunc) (io.ReadCloser, string, int64, int64) {
+	if ctx.Input != nil {
 		reader, writer := io.Pipe()
-		e.writeInputBody(writer, context.Input, errorChan)
-		contentLength, _ := context.Input.Size()
-		return reader, context.ContentType, contentLength, contentLength
+		e.writeInputBody(writer, ctx.Input, cancel)
+		contentLength, _ := ctx.Input.Size()
+		return reader, ctx.ContentType, contentLength, contentLength
 	}
-	formParameters := context.Parameters.Form()
+	formParameters := ctx.Parameters.Form()
 	if len(formParameters) > 0 {
 		reader, writer := io.Pipe()
-		contentType, multipartSize := e.writeMultipartBody(writer, formParameters, errorChan)
+		contentType, multipartSize := e.writeMultipartBody(writer, formParameters, cancel)
 		return reader, contentType, -1, multipartSize
 	}
-	bodyParameters := context.Parameters.Body()
-	if len(bodyParameters) > 0 && context.ContentType == "application/x-www-form-urlencoded" {
+	bodyParameters := ctx.Parameters.Body()
+	if len(bodyParameters) > 0 && ctx.ContentType == "application/x-www-form-urlencoded" {
 		reader, writer := io.Pipe()
-		e.writeUrlEncodedBody(writer, bodyParameters, errorChan)
-		return reader, context.ContentType, -1, -1
+		e.writeUrlEncodedBody(writer, bodyParameters, cancel)
+		return reader, ctx.ContentType, -1, -1
 	}
 	if len(bodyParameters) > 0 {
 		reader, writer := io.Pipe()
-		e.writeJsonBody(writer, bodyParameters, errorChan)
-		return reader, context.ContentType, -1, -1
+		e.writeJsonBody(writer, bodyParameters, cancel)
+		return reader, ctx.ContentType, -1, -1
 	}
-	return bytes.NewReader([]byte{}), context.ContentType, -1, -1
+	return io.NopCloser(bytes.NewReader([]byte{})), ctx.ContentType, -1, -1
 }
 
-func (e HttpExecutor) send(client *http.Client, request *http.Request, errorChan chan error) (*http.Response, error) {
-	responseChan := make(chan *http.Response)
-	go func(client *http.Client, request *http.Request) {
-		response, err := client.Do(request)
-		if err != nil {
-			errorChan <- err
-			return
-		}
-		responseChan <- response
-	}(client, request)
-
-	select {
-	case err := <-errorChan:
-		return nil, err
-	case response := <-responseChan:
-		return response, nil
+func (e HttpExecutor) pathParameters(ctx ExecutionContext) []ExecutionParameter {
+	pathParameters := ctx.Parameters.Path()
+	if ctx.Organization != "" {
+		pathParameters = append(pathParameters, *NewExecutionParameter("organization", ctx.Organization, "path"))
 	}
-}
-
-func (e HttpExecutor) logRequest(logger log.Logger, request *http.Request) {
-	buffer := &bytes.Buffer{}
-	_, _ = buffer.ReadFrom(request.Body)
-	body := buffer.Bytes()
-	request.Body = io.NopCloser(bytes.NewReader(body))
-	requestInfo := log.NewRequestInfo(request.Method, request.URL.String(), request.Proto, request.Header, bytes.NewReader(body))
-	logger.LogRequest(*requestInfo)
-}
-
-func (e HttpExecutor) logResponse(logger log.Logger, response *http.Response, body []byte) {
-	responseInfo := log.NewResponseInfo(response.StatusCode, response.Status, response.Proto, response.Header, bytes.NewReader(body))
-	logger.LogResponse(*responseInfo)
-}
-
-func (e HttpExecutor) pathParameters(context ExecutionContext) []ExecutionParameter {
-	pathParameters := context.Parameters.Path()
-	if context.Organization != "" {
-		pathParameters = append(pathParameters, *NewExecutionParameter("organization", context.Organization, "path"))
-	}
-	if context.Tenant != "" {
-		pathParameters = append(pathParameters, *NewExecutionParameter("tenant", context.Tenant, "path"))
+	if ctx.Tenant != "" {
+		pathParameters = append(pathParameters, *NewExecutionParameter("tenant", ctx.Tenant, "path"))
 	}
 	return pathParameters
 }
 
-func (e HttpExecutor) call(context ExecutionContext, writer output.OutputWriter, logger log.Logger) error {
-	uri, err := e.formatUri(context.BaseUri, context.Route, e.pathParameters(context), context.Parameters.Query())
+func (e HttpExecutor) httpClientSettings(ctx ExecutionContext) network.HttpClientSettings {
+	return *network.NewHttpClientSettings(
+		ctx.Debug,
+		ctx.Settings.OperationId,
+		ctx.Settings.Timeout,
+		ctx.Settings.MaxAttempts,
+		ctx.Settings.Insecure)
+}
+
+func (e HttpExecutor) Call(ctx ExecutionContext, writer output.OutputWriter, logger log.Logger) error {
+	uri, err := e.formatUri(ctx.BaseUri, ctx.Route, e.pathParameters(ctx), ctx.Parameters.Query())
 	if err != nil {
 		return err
 	}
-	requestError := make(chan error)
-	bodyReader, contentType, contentLength, size := e.writeBody(context, requestError)
+	context, cancel := context.WithCancelCause(context.Background())
+	bodyReader, contentType, contentLength, size := e.writeBody(ctx, cancel)
 	uploadBar := visualization.NewProgressBar(logger)
 	uploadReader := e.progressReader("uploading...", "completing  ", bodyReader, size, uploadBar)
 	defer uploadBar.Remove()
-	request, err := http.NewRequest(context.Method, uri.String(), uploadReader)
-	if err != nil {
-		return fmt.Errorf("Error preparing request: %w", err)
-	}
-	if contentType != "" {
-		request.Header.Add("Content-Type", contentType)
-	}
-	if contentLength != -1 {
-		request.ContentLength = contentLength
-	}
-	e.addHeaders(request, context.Parameters.Header())
-	auth, err := e.executeAuthenticators(context.AuthConfig, context.IdentityUri, context.Debug, context.Insecure, request)
+
+	auth, err := e.executeAuthenticators(ctx, uri.String())
 	if err != nil {
 		return err
 	}
-	for k, v := range auth.RequestHeader {
-		request.Header.Add(k, v)
-	}
 
-	transport := &http.Transport{
-		TLSClientConfig:       &tls.Config{InsecureSkipVerify: context.Insecure}, //nolint // This is user configurable and disabled by default
-		ResponseHeaderTimeout: context.Timeout,
+	header := http.Header{}
+	if contentType != "" {
+		header.Set("Content-Type", contentType)
 	}
-	client := &http.Client{Transport: transport}
-	if context.Debug {
-		e.logRequest(logger, request)
+	e.addHeaders(header, ctx.Parameters.Header())
+	for k, v := range auth.RequestHeader {
+		header.Set(k, v)
 	}
-	response, err := e.send(client, request, requestError)
+	request := network.NewHttpRequest(ctx.Method, uri.String(), header, uploadReader, contentLength)
+
+	client := network.NewHttpClient(logger, e.httpClientSettings(ctx))
+	response, err := client.SendWithContext(request, context)
 	if err != nil {
-		return resiliency.Retryable(fmt.Errorf("Error sending request: %w", err))
+		return err
 	}
 	defer response.Body.Close()
 	downloadBar := visualization.NewProgressBar(logger)
@@ -360,11 +315,7 @@ func (e HttpExecutor) call(context ExecutionContext, writer output.OutputWriter,
 	defer downloadBar.Remove()
 	body, err := io.ReadAll(downloadReader)
 	if err != nil {
-		return resiliency.Retryable(fmt.Errorf("Error reading response body: %w", err))
-	}
-	e.logResponse(logger, response, body)
-	if response.StatusCode >= 500 {
-		return resiliency.Retryable(fmt.Errorf("Service returned status code '%v' and body '%v'", response.StatusCode, string(body)))
+		return fmt.Errorf("Error reading response body: %w", err)
 	}
 	err = writer.WriteResponse(*output.NewResponseInfo(response.StatusCode, response.Status, response.Proto, response.Header, bytes.NewReader(body)))
 	if err != nil {

--- a/executor/plugin_executor.go
+++ b/executor/plugin_executor.go
@@ -2,10 +2,8 @@ package executor
 
 import (
 	"errors"
-	"net/url"
 
 	"github.com/UiPath/uipathcli/auth"
-	"github.com/UiPath/uipathcli/config"
 	"github.com/UiPath/uipathcli/log"
 	"github.com/UiPath/uipathcli/output"
 	"github.com/UiPath/uipathcli/plugin"
@@ -19,20 +17,30 @@ type PluginExecutor struct {
 	authenticators []auth.Authenticator
 }
 
-func (e PluginExecutor) executeAuthenticators(baseUri url.URL, authConfig config.AuthConfig, identityUri url.URL, debug bool, insecure bool) (*auth.AuthenticatorResult, error) {
-	authRequest := *auth.NewAuthenticatorRequest(baseUri.String(), map[string]string{})
-	ctx := *auth.NewAuthenticatorContext(authConfig.Type, authConfig.Config, identityUri, debug, insecure, authRequest)
+func (e PluginExecutor) authenticatorContext(ctx ExecutionContext) auth.AuthenticatorContext {
+	authRequest := *auth.NewAuthenticatorRequest(ctx.BaseUri.String(), map[string]string{})
+	return *auth.NewAuthenticatorContext(
+		ctx.AuthConfig.Type,
+		ctx.AuthConfig.Config,
+		ctx.IdentityUri,
+		ctx.Settings.OperationId,
+		ctx.Settings.Insecure,
+		authRequest)
+}
+
+func (e PluginExecutor) executeAuthenticators(ctx ExecutionContext) (*auth.AuthenticatorResult, error) {
+	authContext := e.authenticatorContext(ctx)
 	for _, authProvider := range e.authenticators {
-		result := authProvider.Auth(ctx)
+		result := authProvider.Auth(authContext)
 		if result.Error != "" {
 			return nil, errors.New(result.Error)
 		}
-		ctx.Config = result.Config
+		authContext.Config = result.Config
 		for k, v := range result.RequestHeader {
-			ctx.Request.Header[k] = v
+			authContext.Request.Header[k] = v
 		}
 	}
-	return auth.AuthenticatorSuccess(ctx.Request.Header, ctx.Config), nil
+	return auth.AuthenticatorSuccess(authContext.Request.Header, authContext.Config), nil
 }
 
 func (e PluginExecutor) convertToPluginParameters(parameters []ExecutionParameter) []plugin.ExecutionParameter {
@@ -50,24 +58,24 @@ func (e PluginExecutor) pluginAuth(auth *auth.AuthenticatorResult) plugin.AuthRe
 	}
 }
 
-func (e PluginExecutor) Call(context ExecutionContext, writer output.OutputWriter, logger log.Logger) error {
-	auth, err := e.executeAuthenticators(context.BaseUri, context.AuthConfig, context.IdentityUri, context.Debug, context.Insecure)
+func (e PluginExecutor) Call(ctx ExecutionContext, writer output.OutputWriter, logger log.Logger) error {
+	auth, err := e.executeAuthenticators(ctx)
 	if err != nil {
 		return err
 	}
 
 	pluginAuth := e.pluginAuth(auth)
-	pluginParams := e.convertToPluginParameters(context.Parameters)
+	pluginParams := e.convertToPluginParameters(ctx.Parameters)
 	pluginContext := plugin.NewExecutionContext(
-		context.Organization,
-		context.Tenant,
-		context.BaseUri,
+		ctx.Organization,
+		ctx.Tenant,
+		ctx.BaseUri,
 		pluginAuth,
-		context.Input,
+		ctx.Input,
 		pluginParams,
-		context.Insecure,
-		context.Debug)
-	return context.Plugin.Execute(*pluginContext, writer, logger)
+		ctx.Debug,
+		*plugin.NewExecutionSettings(ctx.Settings.OperationId, ctx.Settings.Timeout, ctx.Settings.MaxAttempts, ctx.Settings.Insecure))
+	return ctx.Plugin.Execute(*pluginContext, writer, logger)
 }
 
 func NewPluginExecutor(authenticators []auth.Authenticator) *PluginExecutor {

--- a/plugin/command_plugin.go
+++ b/plugin/command_plugin.go
@@ -16,5 +16,5 @@ import (
 // The Execute() operation is invoked when the user runs the CLI command.
 type CommandPlugin interface {
 	Command() Command
-	Execute(context ExecutionContext, writer output.OutputWriter, logger log.Logger) error
+	Execute(ctx ExecutionContext, writer output.OutputWriter, logger log.Logger) error
 }

--- a/plugin/execution_context.go
+++ b/plugin/execution_context.go
@@ -14,8 +14,8 @@ type ExecutionContext struct {
 	Auth         AuthResult
 	Input        stream.Stream
 	Parameters   []ExecutionParameter
-	Insecure     bool
 	Debug        bool
+	Settings     ExecutionSettings
 }
 
 func NewExecutionContext(
@@ -25,7 +25,7 @@ func NewExecutionContext(
 	auth AuthResult,
 	input stream.Stream,
 	parameters []ExecutionParameter,
-	insecure bool,
-	debug bool) *ExecutionContext {
-	return &ExecutionContext{organization, tenant, baseUri, auth, input, parameters, insecure, debug}
+	debug bool,
+	settings ExecutionSettings) *ExecutionContext {
+	return &ExecutionContext{organization, tenant, baseUri, auth, input, parameters, debug, settings}
 }

--- a/plugin/execution_settings.go
+++ b/plugin/execution_settings.go
@@ -1,0 +1,26 @@
+package plugin
+
+import (
+	"time"
+)
+
+// The ExecutionSettings provides global settings for executing commands.
+type ExecutionSettings struct {
+	OperationId string
+	Timeout     time.Duration
+	MaxAttempts int
+	Insecure    bool
+}
+
+func NewExecutionSettings(
+	operationId string,
+	timeout time.Duration,
+	maxAttempts int,
+	insecure bool) *ExecutionSettings {
+	return &ExecutionSettings{
+		operationId,
+		timeout,
+		maxAttempts,
+		insecure,
+	}
+}

--- a/plugin/studio/package_analyze_command.go
+++ b/plugin/studio/package_analyze_command.go
@@ -38,14 +38,14 @@ func (c PackageAnalyzeCommand) Command() plugin.Command {
 		WithParameter("stop-on-rule-violation", plugin.ParameterTypeBoolean, "Fail when any rule is violated", false)
 }
 
-func (c PackageAnalyzeCommand) Execute(context plugin.ExecutionContext, writer output.OutputWriter, logger log.Logger) error {
-	source, err := c.getSource(context)
+func (c PackageAnalyzeCommand) Execute(ctx plugin.ExecutionContext, writer output.OutputWriter, logger log.Logger) error {
+	source, err := c.getSource(ctx)
 	if err != nil {
 		return err
 	}
-	treatWarningsAsErrors := c.getBoolParameter("treat-warnings-as-errors", context.Parameters)
-	stopOnRuleViolation := c.getBoolParameter("stop-on-rule-violation", context.Parameters)
-	exitCode, result, err := c.execute(source, treatWarningsAsErrors, stopOnRuleViolation, context.Debug, logger)
+	treatWarningsAsErrors := c.getBoolParameter("treat-warnings-as-errors", ctx.Parameters)
+	stopOnRuleViolation := c.getBoolParameter("stop-on-rule-violation", ctx.Parameters)
+	exitCode, result, err := c.execute(source, treatWarningsAsErrors, stopOnRuleViolation, ctx.Debug, logger)
 	if err != nil {
 		return err
 	}
@@ -246,8 +246,8 @@ func (c PackageAnalyzeCommand) newAnalyzingProgressBar(logger log.Logger) chan s
 	return cancel
 }
 
-func (c PackageAnalyzeCommand) getSource(context plugin.ExecutionContext) (string, error) {
-	source := c.getParameter("source", ".", context.Parameters)
+func (c PackageAnalyzeCommand) getSource(ctx plugin.ExecutionContext) (string, error) {
+	source := c.getParameter("source", ".", ctx.Parameters)
 	source, _ = filepath.Abs(source)
 	fileInfo, err := os.Stat(source)
 	if err != nil {

--- a/plugin/studio/package_pack_command.go
+++ b/plugin/studio/package_pack_command.go
@@ -42,23 +42,23 @@ func (c PackagePackCommand) Command() plugin.Command {
 		WithParameter("release-notes", plugin.ParameterTypeString, "Add release notes", false)
 }
 
-func (c PackagePackCommand) Execute(context plugin.ExecutionContext, writer output.OutputWriter, logger log.Logger) error {
-	source, err := c.getSource(context)
+func (c PackagePackCommand) Execute(ctx plugin.ExecutionContext, writer output.OutputWriter, logger log.Logger) error {
+	source, err := c.getSource(ctx)
 	if err != nil {
 		return err
 	}
-	destination := c.getDestination(context)
-	packageVersion := c.getParameter("package-version", "", context.Parameters)
-	autoVersion := c.getBoolParameter("auto-version", context.Parameters)
-	outputType := c.getParameter("output-type", "", context.Parameters)
+	destination := c.getDestination(ctx)
+	packageVersion := c.getParameter("package-version", "", ctx.Parameters)
+	autoVersion := c.getBoolParameter("auto-version", ctx.Parameters)
+	outputType := c.getParameter("output-type", "", ctx.Parameters)
 	if outputType != "" && !slices.Contains(OutputTypeAllowedValues, outputType) {
 		return fmt.Errorf("Invalid output type '%s', allowed values: %s", outputType, strings.Join(OutputTypeAllowedValues, ", "))
 	}
-	splitOutput := c.getBoolParameter("split-output", context.Parameters)
-	releaseNotes := c.getParameter("release-notes", "", context.Parameters)
+	splitOutput := c.getBoolParameter("split-output", ctx.Parameters)
+	releaseNotes := c.getParameter("release-notes", "", ctx.Parameters)
 	params := newPackagePackParams(source, destination, packageVersion, autoVersion, outputType, splitOutput, releaseNotes)
 
-	result, err := c.execute(*params, context.Debug, logger)
+	result, err := c.execute(*params, ctx.Debug, logger)
 	if err != nil {
 		return err
 	}
@@ -200,8 +200,8 @@ func (c PackagePackCommand) newPackagingProgressBar(logger log.Logger) chan stru
 	return cancel
 }
 
-func (c PackagePackCommand) getSource(context plugin.ExecutionContext) (string, error) {
-	source := c.getParameter("source", ".", context.Parameters)
+func (c PackagePackCommand) getSource(ctx plugin.ExecutionContext) (string, error) {
+	source := c.getParameter("source", ".", ctx.Parameters)
 	source, _ = filepath.Abs(source)
 	fileInfo, err := os.Stat(source)
 	if err != nil {
@@ -213,8 +213,8 @@ func (c PackagePackCommand) getSource(context plugin.ExecutionContext) (string, 
 	return source, nil
 }
 
-func (c PackagePackCommand) getDestination(context plugin.ExecutionContext) string {
-	destination := c.getParameter("destination", ".", context.Parameters)
+func (c PackagePackCommand) getDestination(ctx plugin.ExecutionContext) string {
+	destination := c.getParameter("destination", ".", ctx.Parameters)
 	destination, _ = filepath.Abs(destination)
 	return destination
 }

--- a/plugin/studio/package_publish_params.go
+++ b/plugin/studio/package_publish_params.go
@@ -8,8 +8,8 @@ type packagePublishParams struct {
 	Version  string
 	BaseUri  string
 	Auth     plugin.AuthResult
-	Insecure bool
 	Debug    bool
+	Settings plugin.ExecutionSettings
 }
 
 func newPackagePublishParams(
@@ -18,7 +18,7 @@ func newPackagePublishParams(
 	version string,
 	baseUri string,
 	auth plugin.AuthResult,
-	insecure bool,
-	debug bool) *packagePublishParams {
-	return &packagePublishParams{source, name, version, baseUri, auth, insecure, debug}
+	debug bool,
+	settings plugin.ExecutionSettings) *packagePublishParams {
+	return &packagePublishParams{source, name, version, baseUri, auth, debug, settings}
 }

--- a/plugin/studio/studio_plugin_test.go
+++ b/plugin/studio/studio_plugin_test.go
@@ -593,7 +593,7 @@ func TestPublishOrchestratorErrorReturnsError(t *testing.T) {
 
 	result := test.RunCli([]string{"studio", "package", "publish", "--organization", "my-org", "--tenant", "my-tenant", "--source", nupkgPath}, context)
 
-	if result.Error == nil || result.Error.Error() != "Orchestrator returned status code '503' and body '{}'" {
+	if result.Error == nil || result.Error.Error() != "Service returned status code '503' and body '{}'" {
 		t.Errorf("Expected orchestrator error, but got: %v", result.Error)
 	}
 }

--- a/test/plugin_test.go
+++ b/test/plugin_test.go
@@ -202,8 +202,8 @@ profiles:
 
 	RunCli([]string{"mypluginservice", "my-plugin-command"}, context)
 
-	if !pluginCommand.Context.Insecure {
-		t.Errorf("Expected insecure flag to be true, but got: %v", pluginCommand.Context.Insecure)
+	if !pluginCommand.Context.Settings.Insecure {
+		t.Errorf("Expected insecure flag to be true, but got: %v", pluginCommand.Context.Settings.Insecure)
 	}
 }
 
@@ -283,7 +283,7 @@ func (c SimplePluginCommand) Command() plugin.Command {
 		WithOperation("my-plugin-command", "Simple Command", "This is a simple plugin command")
 }
 
-func (c SimplePluginCommand) Execute(context plugin.ExecutionContext, writer output.OutputWriter, logger log.Logger) error {
+func (c SimplePluginCommand) Execute(ctx plugin.ExecutionContext, writer output.OutputWriter, logger log.Logger) error {
 	logger.LogError("Simple plugin logging output")
 	return writer.WriteResponse(*output.NewResponseInfo(200, "200 OK", "https", map[string][]string{}, bytes.NewReader([]byte("Simple plugin output"))))
 }
@@ -298,8 +298,8 @@ func (c ContextPluginCommand) Command() plugin.Command {
 		WithParameter("filter", plugin.ParameterTypeString, "This is a filter", false)
 }
 
-func (c *ContextPluginCommand) Execute(context plugin.ExecutionContext, writer output.OutputWriter, logger log.Logger) error {
-	c.Context = context
+func (c *ContextPluginCommand) Execute(ctx plugin.ExecutionContext, writer output.OutputWriter, logger log.Logger) error {
+	c.Context = ctx
 	return nil
 }
 
@@ -310,7 +310,7 @@ func (c ErrorPluginCommand) Command() plugin.Command {
 		WithOperation("my-failed-command", "Command fails", "This command always fails")
 }
 
-func (c ErrorPluginCommand) Execute(context plugin.ExecutionContext, writer output.OutputWriter, logger log.Logger) error {
+func (c ErrorPluginCommand) Execute(ctx plugin.ExecutionContext, writer output.OutputWriter, logger log.Logger) error {
 	return fmt.Errorf("Internal server error when calling mypluginservice")
 }
 
@@ -322,7 +322,7 @@ func (c HideOperationPluginCommand) Command() plugin.Command {
 		IsHidden()
 }
 
-func (c HideOperationPluginCommand) Execute(context plugin.ExecutionContext, writer output.OutputWriter, logger log.Logger) error {
+func (c HideOperationPluginCommand) Execute(ctx plugin.ExecutionContext, writer output.OutputWriter, logger log.Logger) error {
 	return fmt.Errorf("my-hidden-command is not supported")
 }
 
@@ -334,6 +334,6 @@ func (c ParametrizedPluginCommand) Command() plugin.Command {
 		WithParameter("take", plugin.ParameterTypeInteger, "This is a take parameter", true)
 }
 
-func (c ParametrizedPluginCommand) Execute(context plugin.ExecutionContext, writer output.OutputWriter, logger log.Logger) error {
+func (c ParametrizedPluginCommand) Execute(ctx plugin.ExecutionContext, writer output.OutputWriter, logger log.Logger) error {
 	return nil
 }

--- a/utils/network/http_client.go
+++ b/utils/network/http_client.go
@@ -1,0 +1,145 @@
+package network
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"fmt"
+	"io"
+	"net/http"
+	"runtime"
+
+	"github.com/UiPath/uipathcli/log"
+	"github.com/UiPath/uipathcli/utils"
+	"github.com/UiPath/uipathcli/utils/resiliency"
+)
+
+type HttpClient struct {
+	logger   log.Logger
+	settings HttpClientSettings
+}
+
+const bufferLimit = 10 * 1024 * 1024
+const loggingLimit = 1 * 1024 * 1024
+
+var UserAgent = fmt.Sprintf("uipathcli/%s (%s; %s)", utils.Version, runtime.GOOS, runtime.GOARCH)
+
+func (c HttpClient) Send(request *HttpRequest) (*HttpResponse, error) {
+	return c.sendWithRetries(request, context.Background())
+}
+
+func (c HttpClient) SendWithContext(request *HttpRequest, ctx context.Context) (*HttpResponse, error) {
+	return c.sendWithRetries(request, ctx)
+}
+
+func (c HttpClient) sendWithRetries(request *HttpRequest, ctx context.Context) (*HttpResponse, error) {
+	request.Header.Set("User-Agent", UserAgent)
+	request.Header.Set("x-request-id", c.settings.OperationId)
+
+	if c.settings.Debug {
+		request.Body = newResettableReader(request.Body, bufferLimit, func(body []byte) { c.logRequest(request, body) })
+	} else if c.settings.MaxAttempts > 1 {
+		request.Body = newResettableReader(request.Body, bufferLimit, func(body []byte) {})
+	}
+
+	var response *HttpResponse
+	var err error
+	err = resiliency.RetryN(c.settings.MaxAttempts, func(attempt int) error {
+		if attempt > 1 && !c.resetReader(request.Body) {
+			return err
+		}
+
+		response, err = c.send(request, ctx)
+		if err != nil {
+			return resiliency.Retryable(err)
+		}
+
+		if c.settings.Debug {
+			response.Body = newResettableReader(response.Body, bufferLimit, func(body []byte) { c.logResponse(response, body) })
+		}
+
+		if response.StatusCode == 0 || response.StatusCode >= 500 {
+			defer response.Body.Close()
+			body, err := io.ReadAll(response.Body)
+			if err != nil {
+				return resiliency.Retryable(fmt.Errorf("Error reading response: %w", err))
+			}
+			return resiliency.Retryable(fmt.Errorf("Service returned status code '%v' and body '%v'", response.StatusCode, string(body)))
+		}
+		return nil
+	})
+	return response, err
+}
+
+func (c HttpClient) resetReader(reader io.Reader) bool {
+	resettableReader, ok := reader.(*resettableReader)
+	if ok {
+		return resettableReader.Reset()
+	}
+	return false
+}
+
+func (c HttpClient) send(request *HttpRequest, ctx context.Context) (*HttpResponse, error) {
+	transport := &http.Transport{
+		TLSClientConfig:       &tls.Config{InsecureSkipVerify: c.settings.Insecure}, //nolint // This is user configurable and disabled by default
+		ResponseHeaderTimeout: c.settings.Timeout,
+	}
+	client := &http.Client{Transport: transport}
+
+	responseChan := make(chan *HttpResponse)
+	ctx, cancel := context.WithCancelCause(ctx)
+	go func(client *http.Client, request *HttpRequest) {
+		req, err := http.NewRequest(request.Method, request.URL, request.Body)
+		if err != nil {
+			cancel(fmt.Errorf("Error preparing request: %w", err))
+			return
+		}
+		req.Header = request.Header
+		req.ContentLength = request.ContentLength
+
+		resp, err := client.Do(req)
+		if err != nil {
+			cancel(fmt.Errorf("Error sending request: %w", err))
+			return
+		}
+
+		response := NewHttpResponse(
+			resp.Status,
+			resp.StatusCode,
+			resp.Proto,
+			resp.Header,
+			resp.Body,
+			resp.ContentLength)
+		responseChan <- response
+	}(client, request)
+
+	select {
+	case <-ctx.Done():
+		return nil, fmt.Errorf("Error sending request: %w", context.Cause(ctx))
+	case response := <-responseChan:
+		return response, nil
+	}
+}
+
+func (c HttpClient) logRequest(request *HttpRequest, body []byte) {
+	reader := bytes.NewReader(c.truncate(body, loggingLimit))
+	requestInfo := log.NewRequestInfo(request.Method, request.URL, request.Proto, request.Header, reader)
+	c.logger.LogRequest(*requestInfo)
+}
+
+func (c HttpClient) logResponse(response *HttpResponse, body []byte) {
+	reader := bytes.NewReader(c.truncate(body, loggingLimit))
+	responseInfo := log.NewResponseInfo(response.StatusCode, response.Status, response.Proto, response.Header, reader)
+	c.logger.LogResponse(*responseInfo)
+}
+
+func (c HttpClient) truncate(data []byte, size int) []byte {
+	if len(data) > size {
+		return data[:size]
+	}
+	return data
+}
+
+func NewHttpClient(logger log.Logger, settings HttpClientSettings) *HttpClient {
+	return &HttpClient{logger, settings}
+}

--- a/utils/network/http_client_settings.go
+++ b/utils/network/http_client_settings.go
@@ -1,0 +1,26 @@
+package network
+
+import "time"
+
+type HttpClientSettings struct {
+	Debug       bool
+	OperationId string
+	Timeout     time.Duration
+	MaxAttempts int
+	Insecure    bool
+}
+
+func NewHttpClientSettings(
+	debug bool,
+	operationId string,
+	timeout time.Duration,
+	maxAttempts int,
+	insecure bool) *HttpClientSettings {
+	return &HttpClientSettings{
+		debug,
+		operationId,
+		timeout,
+		maxAttempts,
+		insecure,
+	}
+}

--- a/utils/network/http_request.go
+++ b/utils/network/http_request.go
@@ -1,0 +1,32 @@
+package network
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+)
+
+type HttpRequest struct {
+	Proto         string // e.g. "HTTP/1.0"
+	Method        string
+	URL           string
+	Header        http.Header
+	Body          io.Reader
+	ContentLength int64
+}
+
+func NewHttpGetRequest(url string, header http.Header) *HttpRequest {
+	return NewHttpRequest(http.MethodGet, url, header, &bytes.Buffer{}, -1)
+}
+
+func NewHttpPostRequest(url string, header http.Header, body io.Reader, contentLength int64) *HttpRequest {
+	return NewHttpRequest(http.MethodPost, url, header, body, contentLength)
+}
+
+func NewHttpPutRequest(url string, header http.Header, body io.Reader, contentLength int64) *HttpRequest {
+	return NewHttpRequest(http.MethodPut, url, header, body, contentLength)
+}
+
+func NewHttpRequest(method string, url string, header http.Header, body io.Reader, contentLength int64) *HttpRequest {
+	return &HttpRequest{"HTTP/1.1", method, url, header, body, contentLength}
+}

--- a/utils/network/http_response.go
+++ b/utils/network/http_response.go
@@ -1,0 +1,19 @@
+package network
+
+import (
+	"io"
+	"net/http"
+)
+
+type HttpResponse struct {
+	Status        string // e.g. "200 OK"
+	StatusCode    int    // e.g. 200
+	Proto         string // e.g. "HTTP/1.0"
+	Header        http.Header
+	Body          io.ReadCloser
+	ContentLength int64
+}
+
+func NewHttpResponse(status string, statusCode int, proto string, header http.Header, body io.ReadCloser, contentLength int64) *HttpResponse {
+	return &HttpResponse{status, statusCode, proto, header, body, contentLength}
+}

--- a/utils/network/resettable_reader.go
+++ b/utils/network/resettable_reader.go
@@ -1,0 +1,61 @@
+package network
+
+import (
+	"bytes"
+	"io"
+)
+
+type resettableReader struct {
+	reader           io.Reader
+	buffer           *bytes.Buffer
+	bufferLimit      int64
+	bytesRead        int64
+	onFinishCallback func([]byte)
+}
+
+func (r *resettableReader) Read(p []byte) (int, error) {
+	n, err := r.reader.Read(p)
+	r.bytesRead = r.bytesRead + int64(n)
+
+	if n > 0 && !r.bufferExceeded() {
+		_, _ = r.buffer.Write(p[:n])
+	}
+	if err == io.EOF {
+		r.onFinishCallback(r.buffer.Bytes())
+	}
+	return n, err
+}
+
+func (r *resettableReader) Reset() bool {
+	if r.bufferExceeded() {
+		return false
+	}
+
+	r.bytesRead = 0
+	data := r.buffer.Bytes()
+	r.reader = io.NopCloser(bytes.NewReader(data))
+	r.buffer = new(bytes.Buffer)
+	return true
+}
+
+func (r *resettableReader) bufferExceeded() bool {
+	return r.bytesRead > r.bufferLimit
+}
+
+func (r *resettableReader) Close() error {
+	closer, ok := r.reader.(io.Closer)
+	if ok {
+		return closer.Close()
+	}
+	return nil
+}
+
+func newResettableReader(reader io.Reader, bufferLimit int64, onFinishCallback func([]byte)) *resettableReader {
+	return &resettableReader{
+		reader:           reader,
+		buffer:           new(bytes.Buffer),
+		bufferLimit:      bufferLimit,
+		bytesRead:        0,
+		onFinishCallback: onFinishCallback,
+	}
+}

--- a/utils/resiliency/retry.go
+++ b/utils/resiliency/retry.go
@@ -7,15 +7,15 @@ import "time"
 const MaxAttempts = 3
 
 // Retries the given function up to 3 times when it returns an RetryableError.
-func Retry(f func() error) error {
+func Retry(f func(attempt int) error) error {
 	return RetryN(MaxAttempts, f)
 }
 
 // Retries the given function up to n times when it returns an RetryableError.
-func RetryN(maxAttempts int, f func() error) error {
+func RetryN(maxAttempts int, f func(attempt int) error) error {
 	var err error
 	for i := 1; ; i++ {
-		err = f()
+		err = f(i)
 		_, retryable := err.(*RetryableError)
 		if !retryable || i == maxAttempts {
 			return err


### PR DESCRIPTION
Moved common code for handling HTTP requests in a new shared network package to avoid duplication and ensure that each plugin handles network requests the same way.

The common HTTP client code takes care of a couple of cross-cutting concerns needed by all plugins and the main HTTP executor:

- Logs request and response when debug flag is set. Added a new resettableReader which preserves the request and response bodies while they are being read and forwards them to the debug logger.

- Added retries for all HTTP requests. This also leverages the resettableReader to ensure the request body can be replayed.

- The `CommandBuilder` generates now an operation id which is set on every request the uipathcli performs. The same operation id is kept for the duration of the whole command execution which makes it easier to correlate multiple requests performed by a single command.

- The `HttpClient` also sets transport-related settings like certificate validation and response header timeout.

- Using the built-in context instead of a custom requestError channel.