### PR TITLE
Add run command to execute tests on UiPath Orchestrator

### DIFF
--- a/main.go
+++ b/main.go
@@ -70,6 +70,7 @@ func main() {
 				plugin_studio.NewPackagePublishCommand(),
 				plugin_studio.NewPackagePackCommand(),
 				plugin_studio.NewPackageAnalyzeCommand(),
+				plugin_studio.NewTestRunCommand(),
 			},
 		),
 		*configProvider,

--- a/plugin/studio/nupkg_reader.go
+++ b/plugin/studio/nupkg_reader.go
@@ -44,7 +44,7 @@ func (r nupkgReader) readNuspec(source string, file *zip.File) (*nuspec, error) 
 	if err != nil {
 		return nil, fmt.Errorf("Could not read nuspec in package '%s': %v", source, err)
 	}
-	return newNuspec(nuspec.Metadata.Title, nuspec.Metadata.Version), nil
+	return newNuspec(nuspec.Metadata.Id, nuspec.Metadata.Title, nuspec.Metadata.Version), nil
 }
 
 func findLatestNupkg(directory string) string {

--- a/plugin/studio/nuspec.go
+++ b/plugin/studio/nuspec.go
@@ -1,10 +1,11 @@
 package studio
 
 type nuspec struct {
+	Id      string
 	Title   string
 	Version string
 }
 
-func newNuspec(title string, version string) *nuspec {
-	return &nuspec{title, version}
+func newNuspec(id string, title string, version string) *nuspec {
+	return &nuspec{id, title, version}
 }

--- a/plugin/studio/nuspec_xml.go
+++ b/plugin/studio/nuspec_xml.go
@@ -8,6 +8,7 @@ type nuspecXml struct {
 }
 
 type nuspecPackageMetadataXml struct {
+	Id      string `xml:"id"`
 	Title   string `xml:"title"`
 	Version string `xml:"version"`
 }

--- a/plugin/studio/orchestrator_client.go
+++ b/plugin/studio/orchestrator_client.go
@@ -1,0 +1,527 @@
+package studio
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/textproto"
+	"strconv"
+	"time"
+
+	"github.com/UiPath/uipathcli/log"
+	"github.com/UiPath/uipathcli/plugin"
+	"github.com/UiPath/uipathcli/utils/network"
+	"github.com/UiPath/uipathcli/utils/stream"
+	"github.com/UiPath/uipathcli/utils/visualization"
+)
+
+var ErrPackageAlreadyExists = errors.New("Package already exists")
+
+type orchestratorClient struct {
+	baseUri  string
+	auth     plugin.AuthResult
+	debug    bool
+	settings plugin.ExecutionSettings
+	logger   log.Logger
+}
+
+func (c orchestratorClient) GetSharedFolderId() (int, error) {
+	request := c.createGetFolderRequest()
+	client := network.NewHttpClient(c.logger, c.httpClientSettings())
+	response, err := client.Send(request)
+	if err != nil {
+		return -1, err
+	}
+	defer response.Body.Close()
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		return -1, fmt.Errorf("Error reading response: %w", err)
+	}
+	if response.StatusCode != http.StatusOK {
+		return -1, fmt.Errorf("Orchestrator returned status code '%v' and body '%v'", response.StatusCode, string(body))
+	}
+
+	var result getFoldersResponseJson
+	err = json.Unmarshal(body, &result)
+	if err != nil {
+		return -1, fmt.Errorf("Orchestrator returned invalid response body '%v'", string(body))
+	}
+	folderId := c.findFolderId(result)
+	if folderId == nil {
+		return -1, fmt.Errorf("Could not find 'Shared' orchestrator folder.")
+	}
+	return *folderId, nil
+}
+
+func (c orchestratorClient) createGetFolderRequest() *network.HttpRequest {
+	uri := c.baseUri + "/odata/Folders"
+	header := http.Header{
+		"Content-Type": {"application/json"},
+	}
+	for key, value := range c.auth.Header {
+		header.Set(key, value)
+	}
+	return network.NewHttpGetRequest(uri, header)
+}
+
+func (c orchestratorClient) findFolderId(result getFoldersResponseJson) *int {
+	for _, value := range result.Value {
+		if value.Name == "Shared" {
+			return &value.Id
+		}
+	}
+	if len(result.Value) > 0 {
+		return &result.Value[0].Id
+	}
+	return nil
+}
+
+func (c orchestratorClient) Upload(file stream.Stream, uploadBar *visualization.ProgressBar) error {
+	context, cancel := context.WithCancelCause(context.Background())
+	request := c.createUploadRequest(file, uploadBar, cancel)
+	client := network.NewHttpClient(c.logger, c.httpClientSettings())
+	response, err := client.SendWithContext(request, context)
+	if err != nil {
+		return err
+	}
+	defer response.Body.Close()
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		return fmt.Errorf("Error reading response: %w", err)
+	}
+	if response.StatusCode == http.StatusConflict {
+		return ErrPackageAlreadyExists
+	}
+	if response.StatusCode != http.StatusOK {
+		return fmt.Errorf("Orchestrator returned status code '%v' and body '%v'", response.StatusCode, string(body))
+	}
+	return nil
+}
+
+func (c orchestratorClient) createUploadRequest(file stream.Stream, uploadBar *visualization.ProgressBar, cancel context.CancelCauseFunc) *network.HttpRequest {
+	bodyReader, bodyWriter := io.Pipe()
+	streamSize, _ := file.Size()
+	contentType := c.writeMultipartBody(bodyWriter, file, "application/octet-stream", cancel)
+	uploadReader := c.progressReader("uploading...", "completing  ", bodyReader, streamSize, uploadBar)
+
+	uri := c.baseUri + "/odata/Processes/UiPath.Server.Configuration.OData.UploadPackage"
+	header := http.Header{
+		"Content-Type": {contentType},
+	}
+	for key, value := range c.auth.Header {
+		header.Set(key, value)
+	}
+	return network.NewHttpPostRequest(uri, header, uploadReader, -1)
+}
+
+func (c orchestratorClient) writeMultipartBody(bodyWriter *io.PipeWriter, stream stream.Stream, contentType string, cancel context.CancelCauseFunc) string {
+	formWriter := multipart.NewWriter(bodyWriter)
+	go func() {
+		defer bodyWriter.Close()
+		defer formWriter.Close()
+		err := c.writeMultipartForm(formWriter, stream, contentType)
+		if err != nil {
+			cancel(err)
+			return
+		}
+	}()
+	return formWriter.FormDataContentType()
+}
+
+func (c orchestratorClient) writeMultipartForm(writer *multipart.Writer, stream stream.Stream, contentType string) error {
+	filePart := textproto.MIMEHeader{}
+	filePart.Set("Content-Disposition", fmt.Sprintf(`form-data; name="file"; filename="%s"`, stream.Name()))
+	filePart.Set("Content-Type", contentType)
+	w, err := writer.CreatePart(filePart)
+	if err != nil {
+		return fmt.Errorf("Error creating form field 'file': %w", err)
+	}
+	data, err := stream.Data()
+	if err != nil {
+		return err
+	}
+	defer data.Close()
+	_, err = io.Copy(w, data)
+	if err != nil {
+		return fmt.Errorf("Error writing form field 'file': %w", err)
+	}
+	return nil
+}
+
+func (c orchestratorClient) GetReleases(folderId int, processKey string) ([]Release, error) {
+	request := c.createGetReleasesRequest(folderId, processKey)
+	client := network.NewHttpClient(c.logger, c.httpClientSettings())
+	response, err := client.Send(request)
+	if err != nil {
+		return []Release{}, err
+	}
+	defer response.Body.Close()
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		return []Release{}, fmt.Errorf("Error reading response: %w", err)
+	}
+	if response.StatusCode != http.StatusOK {
+		return []Release{}, fmt.Errorf("Orchestrator returned status code '%v' and body '%v'", response.StatusCode, string(body))
+	}
+
+	var result getReleasesResponseJson
+	err = json.Unmarshal(body, &result)
+	if err != nil {
+		return []Release{}, fmt.Errorf("Orchestrator returned invalid response body '%v'", string(body))
+	}
+	return c.convertToReleases(result), nil
+}
+
+func (c orchestratorClient) convertToReleases(json getReleasesResponseJson) []Release {
+	releases := []Release{}
+	for _, v := range json.Value {
+		releases = append(releases, *NewRelease(v.Id, v.Name))
+	}
+	return releases
+}
+
+func (c orchestratorClient) createGetReleasesRequest(folderId int, processKey string) *network.HttpRequest {
+	uri := c.baseUri + "/odata/Releases?$filter=ProcessKey%20eq%20'" + processKey + "'"
+	header := http.Header{
+		"Content-Type":                {"application/json"},
+		"X-Uipath-Organizationunitid": {strconv.Itoa(folderId)},
+	}
+	for key, value := range c.auth.Header {
+		header.Set(key, value)
+	}
+	return network.NewHttpGetRequest(uri, header)
+}
+
+func (c orchestratorClient) CreateOrUpdateRelease(folderId int, processKey string, processVersion string) (int, error) {
+	releases, err := c.GetReleases(folderId, processKey)
+	if err != nil {
+		return -1, err
+	}
+	if len(releases) > 0 {
+		return c.UpdateRelease(folderId, releases[0].Id, processKey, processVersion)
+	}
+	return c.CreateRelease(folderId, processKey, processVersion)
+}
+
+func (c orchestratorClient) CreateRelease(folderId int, processKey string, processVersion string) (int, error) {
+	request, err := c.createNewReleaseRequest(folderId, processKey, processVersion)
+	if err != nil {
+		return -1, err
+	}
+	client := network.NewHttpClient(c.logger, c.httpClientSettings())
+	response, err := client.Send(request)
+	if err != nil {
+		return -1, err
+	}
+	defer response.Body.Close()
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		return -1, fmt.Errorf("Error reading response: %w", err)
+	}
+	if response.StatusCode != http.StatusCreated {
+		return -1, fmt.Errorf("Orchestrator returned status code '%v' and body '%v'", response.StatusCode, string(body))
+	}
+
+	var result createReleaseResponseJson
+	err = json.Unmarshal(body, &result)
+	if err != nil {
+		return -1, fmt.Errorf("Orchestrator returned invalid response body '%v'", string(body))
+	}
+	return result.Id, nil
+}
+
+func (c orchestratorClient) createNewReleaseRequest(folderId int, processKey string, processVersion string) (*network.HttpRequest, error) {
+	json, err := json.Marshal(createReleaseRequestJson{
+		Name:           processKey,
+		ProcessKey:     processKey,
+		ProcessVersion: processVersion,
+	})
+	if err != nil {
+		return nil, err
+	}
+	uri := c.baseUri + "/odata/Releases"
+	header := http.Header{
+		"Content-Type":                {"application/json"},
+		"X-Uipath-Organizationunitid": {strconv.Itoa(folderId)},
+	}
+	for key, value := range c.auth.Header {
+		header.Set(key, value)
+	}
+	return network.NewHttpPostRequest(uri, header, bytes.NewBuffer(json), -1), nil
+}
+
+func (c orchestratorClient) UpdateRelease(folderId int, releaseId int, processKey string, processVersion string) (int, error) {
+	request, err := c.createUpdateReleaseRequest(folderId, releaseId, processKey, processVersion)
+	if err != nil {
+		return -1, err
+	}
+	client := network.NewHttpClient(c.logger, c.httpClientSettings())
+	response, err := client.Send(request)
+	if err != nil {
+		return -1, err
+	}
+	defer response.Body.Close()
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		return -1, fmt.Errorf("Error reading response: %w", err)
+	}
+	if response.StatusCode != http.StatusOK {
+		return -1, fmt.Errorf("Orchestrator returned status code '%v' and body '%v'", response.StatusCode, string(body))
+	}
+	return releaseId, nil
+}
+
+func (c orchestratorClient) createUpdateReleaseRequest(folderId int, releaseId int, processKey string, processVersion string) (*network.HttpRequest, error) {
+	json, err := json.Marshal(createReleaseRequestJson{
+		Name:           processKey,
+		ProcessKey:     processKey,
+		ProcessVersion: processVersion,
+	})
+	if err != nil {
+		return nil, err
+	}
+	uri := c.baseUri + fmt.Sprintf("/odata/Releases(%d)", releaseId)
+	header := http.Header{
+		"Content-Type":                {"application/json"},
+		"X-Uipath-Organizationunitid": {strconv.Itoa(folderId)},
+	}
+	for key, value := range c.auth.Header {
+		header.Set(key, value)
+	}
+	return network.NewHttpPatchRequest(uri, header, bytes.NewBuffer(json), -1), nil
+}
+
+func (c orchestratorClient) CreateTestSet(folderId int, releaseId int, processVersion string) (int, error) {
+	request, err := c.createTestSetRequest(folderId, releaseId, processVersion)
+	if err != nil {
+		return -1, err
+	}
+	client := network.NewHttpClient(c.logger, c.httpClientSettings())
+	response, err := client.Send(request)
+	if err != nil {
+		return -1, err
+	}
+	defer response.Body.Close()
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		return -1, fmt.Errorf("Error reading response: %w", err)
+	}
+	if response.StatusCode != http.StatusCreated {
+		return -1, fmt.Errorf("Orchestrator returned status code '%v' and body '%v'", response.StatusCode, string(body))
+	}
+	return strconv.Atoi(string(body))
+}
+
+func (c orchestratorClient) createTestSetRequest(folderId int, releaseId int, processVersion string) (*network.HttpRequest, error) {
+	json, err := json.Marshal(createTestSetRequestJson{
+		ReleaseId:     releaseId,
+		VersionNumber: processVersion,
+	})
+	if err != nil {
+		return nil, err
+	}
+	uri := c.baseUri + "/api/TestAutomation/CreateTestSetForReleaseVersion"
+	header := http.Header{
+		"Content-Type":                {"application/json"},
+		"X-Uipath-Organizationunitid": {strconv.Itoa(folderId)},
+	}
+	for key, value := range c.auth.Header {
+		header.Set(key, value)
+	}
+	return network.NewHttpPostRequest(uri, header, bytes.NewBuffer(json), -1), nil
+}
+
+func (c orchestratorClient) ExecuteTestSet(folderId int, testSetId int) (int, error) {
+	request := c.createExecuteTestSetRequest(folderId, testSetId)
+	client := network.NewHttpClient(c.logger, c.httpClientSettings())
+	response, err := client.Send(request)
+	if err != nil {
+		return -1, err
+	}
+	defer response.Body.Close()
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		return -1, fmt.Errorf("Error reading response: %w", err)
+	}
+	if response.StatusCode != http.StatusOK {
+		return -1, fmt.Errorf("Orchestrator returned status code '%v' and body '%v'", response.StatusCode, string(body))
+	}
+	return strconv.Atoi(string(body))
+}
+
+func (c orchestratorClient) createExecuteTestSetRequest(folderId int, testSetId int) *network.HttpRequest {
+	uri := c.baseUri + fmt.Sprintf("/api/TestAutomation/StartTestSetExecution?testSetId=%d&triggerType=ExternalTool", testSetId)
+	header := http.Header{
+		"Content-Type":                {"application/json"},
+		"X-Uipath-Organizationunitid": {strconv.Itoa(folderId)},
+	}
+	for key, value := range c.auth.Header {
+		header.Set(key, value)
+	}
+	return network.NewHttpPostRequest(uri, header, bytes.NewReader([]byte{}), -1)
+}
+
+func (c orchestratorClient) WaitForTestExecutionToFinish(folderId int, executionId int, timeout time.Duration, statusFunc func(TestExecution)) (*TestExecution, error) {
+	startTime := time.Now()
+	for {
+		execution, err := c.GetTestExecution(folderId, executionId)
+		if err != nil {
+			return nil, err
+		}
+		statusFunc(*execution)
+		if execution.IsCompleted() {
+			return execution, nil
+		}
+		if time.Since(startTime) >= timeout {
+			return nil, fmt.Errorf("Timeout waiting for test execution '%d' to finish.", executionId)
+		}
+		time.Sleep(1 * time.Second)
+	}
+}
+
+func (c orchestratorClient) GetTestExecution(folderId int, executionId int) (*TestExecution, error) {
+	request := c.createGetTestExecutionRequest(folderId, executionId)
+	client := network.NewHttpClient(c.logger, c.httpClientSettings())
+	response, err := client.Send(request)
+	if err != nil {
+		return nil, err
+	}
+	defer response.Body.Close()
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		return nil, fmt.Errorf("Error reading response: %w", err)
+	}
+	if response.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("Orchestrator returned status code '%v' and body '%v'", response.StatusCode, string(body))
+	}
+
+	var result getTestExecutionResponseJson
+	err = json.Unmarshal(body, &result)
+	if err != nil {
+		return nil, fmt.Errorf("Orchestrator returned invalid response body '%v'", string(body))
+	}
+	return c.convertToTestExecution(result), nil
+}
+
+func (c orchestratorClient) createGetTestExecutionRequest(folderId int, executionId int) *network.HttpRequest {
+	uri := c.baseUri + fmt.Sprintf("/odata/TestSetExecutions(%d)?$expand=TestCaseExecutions($expand=TestCaseAssertions)", executionId)
+	header := http.Header{
+		"Content-Type":                {"application/json"},
+		"X-Uipath-Organizationunitid": {strconv.Itoa(folderId)},
+	}
+	for key, value := range c.auth.Header {
+		header.Set(key, value)
+	}
+	return network.NewHttpGetRequest(uri, header)
+}
+
+func (c orchestratorClient) convertToTestExecution(json getTestExecutionResponseJson) *TestExecution {
+	return NewTestExecution(
+		json.Id,
+		json.Status,
+		json.TestSetId,
+		json.Name,
+		json.StartTime,
+		json.EndTime,
+		c.convertToTestCaseExecutions(json.TestCaseExecutions))
+}
+
+func (c orchestratorClient) convertToTestCaseExecutions(json []testCaseExecutionJson) []TestCaseExecution {
+	executions := []TestCaseExecution{}
+	for _, v := range json {
+		execution := NewTestCaseExecution(
+			v.Id,
+			v.Status,
+			v.TestCaseId,
+			v.EntryPointPath,
+			v.Info,
+			v.StartTime,
+			v.EndTime)
+		executions = append(executions, *execution)
+	}
+	return executions
+}
+
+func (c orchestratorClient) progressReader(text string, completedText string, reader io.Reader, length int64, progressBar *visualization.ProgressBar) io.Reader {
+	if length < 10*1024*1024 {
+		return reader
+	}
+	return visualization.NewProgressReader(reader, func(progress visualization.Progress) {
+		displayText := text
+		if progress.Completed {
+			displayText = completedText
+		}
+		progressBar.UpdateProgress(displayText, progress.BytesRead, length, progress.BytesPerSecond)
+	})
+}
+
+func (c orchestratorClient) httpClientSettings() network.HttpClientSettings {
+	return *network.NewHttpClientSettings(
+		c.debug,
+		c.settings.OperationId,
+		c.settings.Timeout,
+		c.settings.MaxAttempts,
+		c.settings.Insecure)
+}
+
+type createReleaseRequestJson struct {
+	Name           string `json:"name"`
+	ProcessKey     string `json:"processKey"`
+	ProcessVersion string `json:"processVersion"`
+}
+
+type createTestSetRequestJson struct {
+	ReleaseId     int    `json:"releaseId"`
+	VersionNumber string `json:"versionNumber"`
+}
+
+type getFoldersResponseJson struct {
+	Value []getFoldersResponseValueJson `json:"value"`
+}
+
+type getFoldersResponseValueJson struct {
+	Id   int    `json:"Id"`
+	Name string `json:"FullyQualifiedName"`
+}
+
+type getReleasesResponseJson struct {
+	Value []getReleasesResponseValueJson `json:"value"`
+}
+
+type getReleasesResponseValueJson struct {
+	Id   int    `json:"Id"`
+	Name string `json:"Name"`
+}
+
+type createReleaseResponseJson struct {
+	Id int `json:"id"`
+}
+
+type getTestExecutionResponseJson struct {
+	Id                 int                     `json:"Id"`
+	Status             string                  `json:"Status"`
+	TestSetId          int                     `json:"TestSetId"`
+	Name               string                  `json:"Name"`
+	StartTime          time.Time               `json:"StartTime"`
+	EndTime            time.Time               `json:"EndTime"`
+	TestCaseExecutions []testCaseExecutionJson `json:"TestCaseExecutions"`
+}
+
+type testCaseExecutionJson struct {
+	Id             int       `json:"Id"`
+	Status         string    `json:"Status"`
+	TestCaseId     int       `json:"TestCaseId"`
+	EntryPointPath string    `json:"EntryPointPath"`
+	Info           string    `json:"Info"`
+	StartTime      time.Time `json:"StartTime"`
+	EndTime        time.Time `json:"EndTime"`
+}
+
+func newOrchestratorClient(baseUri string, auth plugin.AuthResult, debug bool, settings plugin.ExecutionSettings, logger log.Logger) *orchestratorClient {
+	return &orchestratorClient{baseUri, auth, debug, settings, logger}
+}

--- a/plugin/studio/release.go
+++ b/plugin/studio/release.go
@@ -1,0 +1,10 @@
+package studio
+
+type Release struct {
+	Id   int
+	Name string
+}
+
+func NewRelease(id int, name string) *Release {
+	return &Release{id, name}
+}

--- a/plugin/studio/setup_test.go
+++ b/plugin/studio/setup_test.go
@@ -77,6 +77,7 @@ func createNupkgArchive(t *testing.T, nuspec string) string {
 }
 
 func writeNupkgArchive(t *testing.T, path string, nuspec string) {
+	_ = os.MkdirAll(filepath.Dir(path), 0700)
 	archive, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {
 		t.Fatal(err)

--- a/plugin/studio/studio_plugin_notwin_test.go
+++ b/plugin/studio/studio_plugin_notwin_test.go
@@ -124,3 +124,50 @@ func TestPackWindowsProjectOnLinuxReturnsCompatibilityError(t *testing.T) {
 		t.Errorf("Expected compatibility error, but got: %v", result.Error)
 	}
 }
+
+func TestRunOnLinuxWithCorrectPackArguments(t *testing.T) {
+	commandName := ""
+	commandArgs := []string{}
+	exec := process.NewExecCustomProcess(0, "Done", "", func(name string, args []string) {
+		commandName = name
+		commandArgs = args
+	})
+	context := test.NewContextBuilder().
+		WithDefinition("studio", studioDefinition).
+		WithCommandPlugin(TestRunCommand{exec}).
+		Build()
+
+	source := studioCrossPlatformProjectDirectory()
+	test.RunCli([]string{"studio", "test", "run", "--source", source, "--organization", "my-org", "--tenant", "my-tenant"}, context)
+
+	if !strings.HasSuffix(commandName, "dotnet") {
+		t.Errorf("Expected command name to be dotnet, but got: %v", commandName)
+	}
+	if !strings.HasSuffix(commandArgs[0], "uipcli.dll") {
+		t.Errorf("Expected 1st argument to be the uipcli.dll, but got: %v", commandArgs[0])
+	}
+	if commandArgs[1] != "package" {
+		t.Errorf("Expected 2nd argument to be package, but got: %v", commandArgs[1])
+	}
+	if commandArgs[2] != "pack" {
+		t.Errorf("Expected 3rd argument to be pack, but got: %v", commandArgs[2])
+	}
+	if commandArgs[3] != filepath.Join(source, "project.json") {
+		t.Errorf("Expected 4th argument to be the project.json, but got: %v", commandArgs[3])
+	}
+	if commandArgs[4] != "--outputType" {
+		t.Errorf("Expected 5th argument to be outputType, but got: %v", commandArgs[4])
+	}
+	if commandArgs[5] != "Tests" {
+		t.Errorf("Expected 6th argument to be Tests, but got: %v", commandArgs[5])
+	}
+	if commandArgs[6] != "--autoVersion" {
+		t.Errorf("Expected 7th argument to be autoVersion, but got: %v", commandArgs[6])
+	}
+	if commandArgs[7] != "--output" {
+		t.Errorf("Expected 8th argument to be output, but got: %v", commandArgs[7])
+	}
+	if commandArgs[8] == "" {
+		t.Errorf("Expected 9th argument to be the output file, but got: %v", commandArgs[8])
+	}
+}

--- a/plugin/studio/studio_plugin_windows_test.go
+++ b/plugin/studio/studio_plugin_windows_test.go
@@ -248,3 +248,50 @@ func TestAnalyzeCrossPlatformProjectOnWindowsWithCorrectArguments(t *testing.T) 
 		t.Errorf("Expected 4th argument to be the project.json, but got: %v", commandArgs[3])
 	}
 }
+
+func TestRunOnWindowsWithCorrectPackArguments(t *testing.T) {
+	commandName := ""
+	commandArgs := []string{}
+	exec := process.NewExecCustomProcess(0, "Done", "", func(name string, args []string) {
+		commandName = name
+		commandArgs = args
+	})
+	context := test.NewContextBuilder().
+		WithDefinition("studio", studioDefinition).
+		WithCommandPlugin(TestRunCommand{exec}).
+		Build()
+
+	source := studioCrossPlatformProjectDirectory()
+	test.RunCli([]string{"studio", "test", "run", "--source", source, "--organization", "my-org", "--tenant", "my-tenant"}, context)
+
+	if !strings.HasSuffix(commandName, "dotnet.exe") {
+		t.Errorf("Expected command name to be dotnet.exe, but got: %v", commandName)
+	}
+	if !strings.HasSuffix(commandArgs[0], "uipcli.dll") {
+		t.Errorf("Expected 1st argument to be the uipcli.dll, but got: %v", commandArgs[0])
+	}
+	if commandArgs[1] != "package" {
+		t.Errorf("Expected 2nd argument to be package, but got: %v", commandArgs[1])
+	}
+	if commandArgs[2] != "pack" {
+		t.Errorf("Expected 3rd argument to be pack, but got: %v", commandArgs[2])
+	}
+	if commandArgs[3] != filepath.Join(source, "project.json") {
+		t.Errorf("Expected 4th argument to be the project.json, but got: %v", commandArgs[3])
+	}
+	if commandArgs[4] != "--outputType" {
+		t.Errorf("Expected 5th argument to be outputType, but got: %v", commandArgs[4])
+	}
+	if commandArgs[5] != "Tests" {
+		t.Errorf("Expected 6th argument to be Tests, but got: %v", commandArgs[5])
+	}
+	if commandArgs[6] != "--autoVersion" {
+		t.Errorf("Expected 7th argument to be autoVersion, but got: %v", commandArgs[6])
+	}
+	if commandArgs[7] != "--output" {
+		t.Errorf("Expected 8th argument to be output, but got: %v", commandArgs[7])
+	}
+	if commandArgs[8] == "" {
+		t.Errorf("Expected 9th argument to be the output file, but got: %v", commandArgs[8])
+	}
+}

--- a/plugin/studio/test_case_execution.go
+++ b/plugin/studio/test_case_execution.go
@@ -1,0 +1,21 @@
+package studio
+
+import "time"
+
+type TestCaseExecution struct {
+	Id             int
+	Status         string
+	TestCaseId     int
+	EntryPointPath string
+	Info           string
+	StartTime      time.Time
+	EndTime        time.Time
+}
+
+func NewTestCaseExecution(id int, status string, testCaseId int, entryPointPath string, info string, startTime time.Time, endTime time.Time) *TestCaseExecution {
+	return &TestCaseExecution{id, status, testCaseId, entryPointPath, info, startTime, endTime}
+}
+
+func (e TestCaseExecution) IsCompleted() bool {
+	return e.Status == "Passed" || e.Status == "Failed" || e.Status == "Cancelled"
+}

--- a/plugin/studio/test_case_run_result.go
+++ b/plugin/studio/test_case_run_result.go
@@ -1,0 +1,28 @@
+package studio
+
+import "time"
+
+type testCaseRunResult struct {
+	Status     string    `json:"status"`
+	Id         int       `json:"id"`
+	TestCaseId int       `json:"testCaseId"`
+	Name       string    `json:"name"`
+	Error      *string   `json:"error"`
+	StartTime  time.Time `json:"startTime"`
+	EndTime    time.Time `json:"endTime"`
+}
+
+func newTestCaseRunResult(execution TestCaseExecution) *testCaseRunResult {
+	var err *string
+	if execution.Status == "Failed" && execution.Info != "" {
+		err = &execution.Info
+	}
+	return &testCaseRunResult{
+		execution.Status,
+		execution.Id,
+		execution.TestCaseId,
+		execution.EntryPointPath,
+		err,
+		execution.StartTime,
+		execution.EndTime}
+}

--- a/plugin/studio/test_execution.go
+++ b/plugin/studio/test_execution.go
@@ -1,0 +1,21 @@
+package studio
+
+import "time"
+
+type TestExecution struct {
+	Id                 int
+	Status             string
+	TestSetId          int
+	Name               string
+	StartTime          time.Time
+	EndTime            time.Time
+	TestCaseExecutions []TestCaseExecution
+}
+
+func NewTestExecution(id int, status string, testSetId int, name string, startTime time.Time, endTime time.Time, testCaseExecutions []TestCaseExecution) *TestExecution {
+	return &TestExecution{id, status, testSetId, name, startTime, endTime, testCaseExecutions}
+}
+
+func (e TestExecution) IsCompleted() bool {
+	return e.Status == "Passed" || e.Status == "Failed" || e.Status == "Cancelled"
+}

--- a/plugin/studio/test_run_command.go
+++ b/plugin/studio/test_run_command.go
@@ -1,0 +1,226 @@
+package studio
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/UiPath/uipathcli/log"
+	"github.com/UiPath/uipathcli/output"
+	"github.com/UiPath/uipathcli/plugin"
+	"github.com/UiPath/uipathcli/utils/directories"
+	"github.com/UiPath/uipathcli/utils/process"
+	"github.com/UiPath/uipathcli/utils/stream"
+	"github.com/UiPath/uipathcli/utils/visualization"
+)
+
+// The TestRunCommand packs a project as a test package,
+// uploads it to the connected Orchestrator instances
+// and runs the tests.
+type TestRunCommand struct {
+	Exec process.ExecProcess
+}
+
+func (c TestRunCommand) Command() plugin.Command {
+	return *plugin.NewCommand("studio").
+		WithCategory("test", "Test", "Tests your UiPath studio packages").
+		WithOperation("run", "Run Tests", "Tests a given package").
+		WithParameter("source", plugin.ParameterTypeString, "Path to a project.json file or a folder containing project.json file (default: .)", false).
+		WithParameter("timeout", plugin.ParameterTypeInteger, "Time to wait in seconds for tests to finish (default: 3600)", false)
+}
+
+func (c TestRunCommand) Execute(ctx plugin.ExecutionContext, writer output.OutputWriter, logger log.Logger) error {
+	source, err := c.getSource(ctx)
+	if err != nil {
+		return err
+	}
+	timeout := time.Duration(c.getIntParameter("timeout", 3600, ctx.Parameters)) * time.Second
+	result, err := c.execute(source, timeout, ctx, logger)
+	if err != nil {
+		return err
+	}
+
+	json, err := json.Marshal(result)
+	if err != nil {
+		return fmt.Errorf("pack command failed: %v", err)
+	}
+	return writer.WriteResponse(*output.NewResponseInfo(200, "200 OK", "HTTP/1.1", map[string][]string{}, bytes.NewReader(json)))
+}
+
+func (c TestRunCommand) execute(source string, timeout time.Duration, ctx plugin.ExecutionContext, logger log.Logger) (*testRunResult, error) {
+	projectReader := newStudioProjectReader(source)
+	project, err := projectReader.ReadMetadata()
+	if err != nil {
+		return nil, err
+	}
+	supported, err := project.TargetFramework.IsSupported()
+	if !supported {
+		return nil, err
+	}
+	tmp, err := directories.Temp()
+	if err != nil {
+		return nil, err
+	}
+	destination := filepath.Join(tmp, ctx.Settings.OperationId)
+	defer os.RemoveAll(destination)
+
+	uipcli := newUipcli(c.Exec, logger)
+	err = uipcli.Initialize(project.TargetFramework)
+	if err != nil {
+		return nil, err
+	}
+
+	exitCode, stdErr, err := c.executeUipcli(uipcli, source, destination, ctx.Debug, logger)
+	if err != nil {
+		return nil, err
+	}
+	if exitCode != 0 {
+		return nil, fmt.Errorf("Error packaging tests: %v", stdErr)
+	}
+
+	nupkgPath := findLatestNupkg(destination)
+	nupkgReader := newNupkgReader(nupkgPath)
+	nuspec, err := nupkgReader.ReadNuspec()
+	if err != nil {
+		return nil, err
+	}
+
+	params := newTestRunParams(nupkgPath, nuspec.Id, nuspec.Version, timeout)
+	execution, err := c.runTests(*params, ctx, logger)
+	if err != nil {
+		return nil, err
+	}
+	return newTestRunResult(*execution), nil
+}
+
+func (c TestRunCommand) runTests(params testRunParams, ctx plugin.ExecutionContext, logger log.Logger) (*TestExecution, error) {
+	progressBar := visualization.NewProgressBar(logger)
+	defer progressBar.Remove()
+	progressBar.UpdatePercentage("uploading...", 0)
+
+	baseUri := c.formatUri(ctx.BaseUri, ctx.Organization, ctx.Tenant)
+	client := newOrchestratorClient(baseUri, ctx.Auth, ctx.Debug, ctx.Settings, logger)
+	folderId, err := client.GetSharedFolderId()
+	if err != nil {
+		return nil, err
+	}
+	file := stream.NewFileStream(params.NupkgPath)
+	err = client.Upload(file, progressBar)
+	if err != nil {
+		return nil, err
+	}
+	releaseId, err := client.CreateOrUpdateRelease(folderId, params.ProcessKey, params.ProcessVersion)
+	if err != nil {
+		return nil, err
+	}
+	testSetId, err := client.CreateTestSet(folderId, releaseId, params.ProcessVersion)
+	if err != nil {
+		return nil, err
+	}
+	executionId, err := client.ExecuteTestSet(folderId, testSetId)
+	if err != nil {
+		return nil, err
+	}
+	return client.WaitForTestExecutionToFinish(folderId, executionId, params.Timeout, func(execution TestExecution) {
+		total := len(execution.TestCaseExecutions)
+		completed := 0
+		for _, testCase := range execution.TestCaseExecutions {
+			if testCase.IsCompleted() {
+				completed++
+			}
+		}
+		progressBar.UpdateSteps("running...  ", completed, total)
+	})
+}
+
+func (c TestRunCommand) executeUipcli(uipcli *uipcli, source string, destination string, debug bool, logger log.Logger) (int, string, error) {
+	if !debug {
+		bar := c.newPackagingProgressBar(logger)
+		defer close(bar)
+	}
+	args := []string{"package", "pack", source, "--outputType", "Tests", "--autoVersion", "--output", destination}
+	return uipcli.ExecuteAndWait(args...)
+}
+
+func (c TestRunCommand) newPackagingProgressBar(logger log.Logger) chan struct{} {
+	progressBar := visualization.NewProgressBar(logger)
+	ticker := time.NewTicker(10 * time.Millisecond)
+	cancel := make(chan struct{})
+	var percent float64 = 0
+	go func() {
+		for {
+			select {
+			case <-ticker.C:
+				progressBar.UpdatePercentage("packaging...  ", percent)
+				percent = percent + 1
+				if percent > 100 {
+					percent = 0
+				}
+			case <-cancel:
+				ticker.Stop()
+				progressBar.Remove()
+				return
+			}
+		}
+	}()
+	return cancel
+}
+
+func (c TestRunCommand) getSource(ctx plugin.ExecutionContext) (string, error) {
+	source := c.getParameter("source", ".", ctx.Parameters)
+	source, _ = filepath.Abs(source)
+	fileInfo, err := os.Stat(source)
+	if err != nil {
+		return "", fmt.Errorf("%s not found", defaultProjectJson)
+	}
+	if fileInfo.IsDir() {
+		source = filepath.Join(source, defaultProjectJson)
+	}
+	return source, nil
+}
+
+func (c TestRunCommand) getIntParameter(name string, defaultValue int, parameters []plugin.ExecutionParameter) int {
+	result := defaultValue
+	for _, p := range parameters {
+		if p.Name == name {
+			if data, ok := p.Value.(int); ok {
+				result = data
+				break
+			}
+		}
+	}
+	return result
+}
+
+func (c TestRunCommand) getParameter(name string, defaultValue string, parameters []plugin.ExecutionParameter) string {
+	result := defaultValue
+	for _, p := range parameters {
+		if p.Name == name {
+			if data, ok := p.Value.(string); ok {
+				result = data
+				break
+			}
+		}
+	}
+	return result
+}
+
+func (c TestRunCommand) formatUri(baseUri url.URL, org string, tenant string) string {
+	path := baseUri.Path
+	if baseUri.Path == "" {
+		path = "/{organization}/{tenant}/orchestrator_"
+	}
+	path = strings.ReplaceAll(path, "{organization}", org)
+	path = strings.ReplaceAll(path, "{tenant}", tenant)
+	path = strings.TrimSuffix(path, "/")
+	return fmt.Sprintf("%s://%s%s", baseUri.Scheme, baseUri.Host, path)
+}
+
+func NewTestRunCommand() *TestRunCommand {
+	return &TestRunCommand{process.NewExecProcess()}
+}

--- a/plugin/studio/test_run_params.go
+++ b/plugin/studio/test_run_params.go
@@ -1,0 +1,18 @@
+package studio
+
+import "time"
+
+type testRunParams struct {
+	NupkgPath      string
+	ProcessKey     string
+	ProcessVersion string
+	Timeout        time.Duration
+}
+
+func newTestRunParams(
+	nupkgPath string,
+	processKey string,
+	processVersion string,
+	timeout time.Duration) *testRunParams {
+	return &testRunParams{nupkgPath, processKey, processVersion, timeout}
+}

--- a/plugin/studio/test_run_result.go
+++ b/plugin/studio/test_run_result.go
@@ -1,0 +1,50 @@
+package studio
+
+import "time"
+
+type testRunResult struct {
+	Status             string              `json:"status"`
+	Id                 int                 `json:"id"`
+	TestSetId          int                 `json:"testSetId"`
+	Name               string              `json:"name"`
+	StartTime          time.Time           `json:"startTime"`
+	EndTime            time.Time           `json:"endTime"`
+	TestCasesCount     int                 `json:"testCasesCount"`
+	PassedCount        int                 `json:"passedCount"`
+	FailuresCount      int                 `json:"failuresCount"`
+	CanceledCount      int                 `json:"canceledCount"`
+	TestCaseExecutions []testCaseRunResult `json:"testCaseExecutions"`
+}
+
+func newTestRunResult(execution TestExecution) *testRunResult {
+	testCasesCount := 0
+	passedCount := 0
+	failuresCount := 0
+	canceledCount := 0
+
+	testCaseRunResults := []testCaseRunResult{}
+	for _, execution := range execution.TestCaseExecutions {
+		testCasesCount++
+		if execution.Status == "Passed" {
+			passedCount++
+		} else if execution.Status == "Failed" {
+			failuresCount++
+		} else if execution.Status == "Cancelling" || execution.Status == "Cancelled" {
+			canceledCount++
+		}
+		testCaseRunResults = append(testCaseRunResults, *newTestCaseRunResult(execution))
+	}
+	return &testRunResult{
+		execution.Status,
+		execution.Id,
+		execution.TestSetId,
+		execution.Name,
+		execution.StartTime,
+		execution.EndTime,
+		testCasesCount,
+		passedCount,
+		failuresCount,
+		canceledCount,
+		testCaseRunResults,
+	}
+}

--- a/plugin/studio/uipcli.go
+++ b/plugin/studio/uipcli.go
@@ -1,10 +1,13 @@
 package studio
 
 import (
+	"bufio"
 	"fmt"
+	"io"
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 
 	"github.com/UiPath/uipathcli/log"
 	"github.com/UiPath/uipathcli/plugin"
@@ -54,6 +57,53 @@ func (c uipcli) Execute(args ...string) (process.ExecCmd, error) {
 	args = append(c.args, args...)
 	cmd := c.Exec.Command(c.path, args...)
 	return cmd, nil
+}
+
+func (c uipcli) ExecuteAndWait(args ...string) (int, string, error) {
+	cmd, err := c.Execute(args...)
+	if err != nil {
+		return 1, "", err
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return 1, "", fmt.Errorf("Could not run command: %v", err)
+	}
+	defer stdout.Close()
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return 1, "", fmt.Errorf("Could not run command: %v", err)
+	}
+	defer stderr.Close()
+	err = cmd.Start()
+	if err != nil {
+		return 1, "", fmt.Errorf("Could not run command: %v", err)
+	}
+
+	stderrOutputBuilder := new(strings.Builder)
+	stderrReader := io.TeeReader(stderr, stderrOutputBuilder)
+
+	var wg sync.WaitGroup
+	wg.Add(3)
+	go c.readOutput(stdout, &wg)
+	go c.readOutput(stderrReader, &wg)
+	go c.wait(cmd, &wg)
+	wg.Wait()
+
+	return cmd.ExitCode(), stderrOutputBuilder.String(), nil
+}
+
+func (c uipcli) wait(cmd process.ExecCmd, wg *sync.WaitGroup) {
+	defer wg.Done()
+	_ = cmd.Wait()
+}
+
+func (c uipcli) readOutput(output io.Reader, wg *sync.WaitGroup) {
+	defer wg.Done()
+	scanner := bufio.NewScanner(output)
+	scanner.Split(bufio.ScanRunes)
+	for scanner.Scan() {
+		c.Logger.Log(scanner.Text())
+	}
 }
 
 func (c uipcli) getUipcliPath(targetFramework TargetFramework) (string, error) {

--- a/utils/network/http_request.go
+++ b/utils/network/http_request.go
@@ -27,6 +27,10 @@ func NewHttpPutRequest(url string, header http.Header, body io.Reader, contentLe
 	return NewHttpRequest(http.MethodPut, url, header, body, contentLength)
 }
 
+func NewHttpPatchRequest(url string, header http.Header, body io.Reader, contentLength int64) *HttpRequest {
+	return NewHttpRequest(http.MethodPatch, url, header, body, contentLength)
+}
+
 func NewHttpRequest(method string, url string, header http.Header, body io.Reader, contentLength int64) *HttpRequest {
 	return &HttpRequest{"HTTP/1.1", method, url, header, body, contentLength}
 }

--- a/utils/visualization/progress_bar.go
+++ b/utils/visualization/progress_bar.go
@@ -16,9 +16,24 @@ type ProgressBar struct {
 	renderedLength int
 }
 
+func (b *ProgressBar) UpdateSteps(text string, current int, total int) {
+	b.logger.LogError("\r")
+	percent := 0.1
+	if total > 0 {
+		percent = float64(current) / float64(total) * 100
+	}
+	steps := fmt.Sprintf(" (%d/%d)", current, total)
+	length := b.renderTick(text, percent, steps)
+	left := b.renderedLength - length
+	if left > 0 {
+		b.logger.LogError(strings.Repeat(" ", left))
+	}
+	b.renderedLength = length
+}
+
 func (b *ProgressBar) UpdatePercentage(text string, percent float64) {
 	b.logger.LogError("\r")
-	length := b.renderTick(text, percent)
+	length := b.renderTick(text, percent, "")
 	left := b.renderedLength - length
 	if left > 0 {
 		b.logger.LogError(strings.Repeat(" ", left))
@@ -43,11 +58,12 @@ func (b *ProgressBar) Remove() {
 	}
 }
 
-func (b ProgressBar) renderTick(text string, percent float64) int {
+func (b ProgressBar) renderTick(text string, percent float64, info string) int {
 	bar := b.createBar(percent)
-	output := fmt.Sprintf("%s      |%s|",
+	output := fmt.Sprintf("%s      |%s|%s",
 		text,
-		bar)
+		bar,
+		info)
 	b.logger.LogError(output)
 	return utf8.RuneCountInString(output)
 }

--- a/utils/visualization/progress_bar_test.go
+++ b/utils/visualization/progress_bar_test.go
@@ -105,6 +105,68 @@ func TestProgressBarUpdatePercentageTo100(t *testing.T) {
 	}
 }
 
+func TestProgressBarUpdateStepsWithZeroTotal(t *testing.T) {
+	var output bytes.Buffer
+	progressBar := NewProgressBar(log.NewDefaultLogger(&output))
+
+	progressBar.UpdateSteps("running...", 0, 0)
+
+	lastLine := lastLine(output)
+	if !strings.HasPrefix(lastLine, "running...      |                    | (0/0)") {
+		t.Errorf("Should display step bar, but got: %v", lastLine)
+	}
+}
+func TestProgressBarUpdateStepsShowsSimpleBar(t *testing.T) {
+	var output bytes.Buffer
+	progressBar := NewProgressBar(log.NewDefaultLogger(&output))
+
+	progressBar.UpdateSteps("running...", 0, 1)
+
+	lastLine := lastLine(output)
+	if !strings.HasPrefix(lastLine, "running...      |                    | (0/1)") {
+		t.Errorf("Should display step bar, but got: %v", lastLine)
+	}
+}
+
+func TestProgressBarUpdateStepsMovesBar(t *testing.T) {
+	var output bytes.Buffer
+	progressBar := NewProgressBar(log.NewDefaultLogger(&output))
+	progressBar.UpdateSteps("running...", 0, 10)
+
+	progressBar.UpdateSteps("running...", 1, 10)
+
+	lastLine := lastLine(output)
+	if !strings.HasPrefix(lastLine, "running...      |██                  | (1/10)") {
+		t.Errorf("Should display step bar, but got: %v", lastLine)
+	}
+}
+
+func TestProgressBarUpdateStepsTo100Percent(t *testing.T) {
+	var output bytes.Buffer
+	progressBar := NewProgressBar(log.NewDefaultLogger(&output))
+	progressBar.UpdateSteps("running...", 0, 10)
+	progressBar.UpdateSteps("running...", 5, 10)
+	progressBar.UpdateSteps("running...", 10, 10)
+
+	lastLine := lastLine(output)
+	if !strings.HasPrefix(lastLine, "running...      |████████████████████| (10/10)") {
+		t.Errorf("Should display step bar, but got: %v", lastLine)
+	}
+}
+
+func TestProgressBarSupportsCombinedModes(t *testing.T) {
+	var output bytes.Buffer
+	progressBar := NewProgressBar(log.NewDefaultLogger(&output))
+	progressBar.UpdateSteps("running...", 1, 10)
+	progressBar.UpdatePercentage("running...", 50)
+	progressBar.UpdateProgress("running...", 8, 10, 1)
+
+	lastLine := lastLine(output)
+	if !strings.HasPrefix(lastLine, "running...  80% |████████████████    | (8/10 B, 1 B/s)") {
+		t.Errorf("Should display bar, but got: %v", lastLine)
+	}
+}
+
 func lastLine(output bytes.Buffer) string {
 	lines := strings.Split(output.String(), "\r")
 	return lines[len(lines)-1]


### PR DESCRIPTION
`uipath studio test run` packages the project in the given folder, uploads the package and executes the tests through the connected orchestrator instance.

The run command performs the following steps:
- Builds the given project with output type "Tests"
- Uploads the generated nupkg package to Orchestrator
- Gets the existing releases for the package
- The command will either update the release if it is already present, or generate a new one if it is not.
- Creates a test set based on the latest release
- Starts the execution of the test set
- Waits for the tests to finish

Implementation:

- Added new TestRunCommand `uipath studio test run` with two parameters: 
  `--source .`: Path to UiPath Studio project 
  `--test-timeout 3600`: Time to wait for tests to finish
- Extracted common logic for interacting with the Orchestrator API into `orchestratorClient` and using it from the publish and test run command
- Extended the progress bar to support showing progress based on the number of steps. This is used to display the total number of tests and how many have finished:
  `running...        |███                 | (1/6)`
- Extended the `nupkgReader` to parse the package id from the nuspec which is used to create the release
- Add `ExecuteAndWait` method to `uipcli`

Issue: https://github.com/UiPath/uipathcli/issues/158