### PR TITLE
Add new api package with orchestrator and du client

### DIFF
--- a/auth/auth_token.go
+++ b/auth/auth_token.go
@@ -1,0 +1,12 @@
+package auth
+
+// AuthToken for authenticating with external APIs. Tokens are typically
+// JWT bearer tokens.
+type AuthToken struct {
+	Type  string
+	Value string
+}
+
+func NewBearerToken(value string) *AuthToken {
+	return &AuthToken{"Bearer", value}
+}

--- a/auth/authenticator_result.go
+++ b/auth/authenticator_result.go
@@ -3,15 +3,14 @@ package auth
 // The AuthenticatorResult indicates if the authentication was successful
 // and returns the authentication credentials.
 type AuthenticatorResult struct {
-	Error         string                 `json:"error"`
-	RequestHeader map[string]string      `json:"requestHeader"`
-	Config        map[string]interface{} `json:"config"`
+	Error string
+	Token *AuthToken
 }
 
 func AuthenticatorError(err error) *AuthenticatorResult {
-	return &AuthenticatorResult{err.Error(), map[string]string{}, map[string]interface{}{}}
+	return &AuthenticatorResult{err.Error(), nil}
 }
 
-func AuthenticatorSuccess(requestHeader map[string]string, config map[string]interface{}) *AuthenticatorResult {
-	return &AuthenticatorResult{"", requestHeader, config}
+func AuthenticatorSuccess(token *AuthToken) *AuthenticatorResult {
+	return &AuthenticatorResult{"", token}
 }

--- a/auth/bearer_authenticator.go
+++ b/auth/bearer_authenticator.go
@@ -18,7 +18,7 @@ type BearerAuthenticator struct {
 
 func (a BearerAuthenticator) Auth(ctx AuthenticatorContext) AuthenticatorResult {
 	if !a.enabled(ctx) {
-		return *AuthenticatorSuccess(ctx.Request.Header, ctx.Config)
+		return *AuthenticatorSuccess(nil)
 	}
 	config, err := a.getConfig(ctx)
 	if err != nil {
@@ -38,8 +38,7 @@ func (a BearerAuthenticator) Auth(ctx AuthenticatorContext) AuthenticatorResult 
 	if err != nil {
 		return *AuthenticatorError(fmt.Errorf("Error retrieving bearer token: %w", err))
 	}
-	ctx.Request.Header["Authorization"] = "Bearer " + tokenResponse.AccessToken
-	return *AuthenticatorSuccess(ctx.Request.Header, ctx.Config)
+	return *AuthenticatorSuccess(NewBearerToken(tokenResponse.AccessToken))
 }
 
 func (a BearerAuthenticator) enabled(ctx AuthenticatorContext) bool {

--- a/auth/identity_client.go
+++ b/auth/identity_client.go
@@ -51,7 +51,7 @@ func (c identityClient) retrieveToken(baseUri url.URL, form url.Values, operatio
 	header := http.Header{
 		"Content-Type": {"application/x-www-form-urlencoded"},
 	}
-	request := network.NewHttpPostRequest(uri.String(), header, strings.NewReader(form.Encode()), -1)
+	request := network.NewHttpPostRequest(uri.String(), nil, header, strings.NewReader(form.Encode()), -1)
 
 	clientSettings := network.NewHttpClientSettings(false, operationId, time.Duration(60)*time.Second, 3, insecure)
 	client := network.NewHttpClient(nil, *clientSettings)

--- a/auth/oauth_authenticator.go
+++ b/auth/oauth_authenticator.go
@@ -29,7 +29,7 @@ type OAuthAuthenticator struct {
 
 func (a OAuthAuthenticator) Auth(ctx AuthenticatorContext) AuthenticatorResult {
 	if !a.enabled(ctx) {
-		return *AuthenticatorSuccess(ctx.Request.Header, ctx.Config)
+		return *AuthenticatorSuccess(nil)
 	}
 	config, err := a.getConfig(ctx)
 	if err != nil {
@@ -39,8 +39,7 @@ func (a OAuthAuthenticator) Auth(ctx AuthenticatorContext) AuthenticatorResult {
 	if err != nil {
 		return *AuthenticatorError(fmt.Errorf("Error retrieving access token: %w", err))
 	}
-	ctx.Request.Header["Authorization"] = "Bearer " + token
-	return *AuthenticatorSuccess(ctx.Request.Header, ctx.Config)
+	return *AuthenticatorSuccess(NewBearerToken(token))
 }
 
 func (a OAuthAuthenticator) retrieveToken(identityBaseUri url.URL, config oauthAuthenticatorConfig, operationId string, insecure bool) (string, error) {

--- a/auth/oauth_authenticator_test.go
+++ b/auth/oauth_authenticator_test.go
@@ -32,29 +32,8 @@ func TestOAuthAuthenticatorNotEnabled(t *testing.T) {
 	if result.Error != "" {
 		t.Errorf("Expected no error when oauth flow is skipped, but got: %v", result.Error)
 	}
-	if len(result.RequestHeader) != 0 {
-		t.Errorf("Expected request header to be empty, but got: %v", result.RequestHeader)
-	}
-}
-
-func TestOAuthAuthenticatorPreservesExistingHeaders(t *testing.T) {
-	config := map[string]interface{}{
-		"redirectUri": "http://localhost:0",
-		"scopes":      "OR.Users",
-	}
-	headers := map[string]string{
-		"my-header": "my-value",
-	}
-	request := NewAuthenticatorRequest("http:/localhost", headers)
-	context := NewAuthenticatorContext("login", config, createIdentityUrl(""), "77a4d29d6c01dd5f146974cabdef3524", false, *request)
-
-	authenticator := NewOAuthAuthenticator(cache.NewFileCache(), *NewBrowserLauncher())
-	result := authenticator.Auth(*context)
-	if result.Error != "" {
-		t.Errorf("Expected no error when performing oauth flow, but got: %v", result.Error)
-	}
-	if result.RequestHeader["my-header"] != "my-value" {
-		t.Errorf("Request header should not be changed, but got: %v", result.RequestHeader)
+	if result.Token != nil {
+		t.Errorf("Expected auth token to be empty, but got: %v", result.Token)
 	}
 }
 
@@ -106,9 +85,11 @@ func TestOAuthFlowSuccessful(t *testing.T) {
 	if result.Error != "" {
 		t.Errorf("Expected no error when performing oauth flow, but got: %v", result.Error)
 	}
-	authorizationHeader := result.RequestHeader["Authorization"]
-	if authorizationHeader != "Bearer my-access-token" {
-		t.Errorf("Expected JWT bearer token in authorization header, but got: %v", authorizationHeader)
+	if result.Token.Type != "Bearer" {
+		t.Errorf("Expected JWT bearer token, but got: %v", result.Token.Type)
+	}
+	if result.Token.Value != "my-access-token" {
+		t.Errorf("Expected value for JWT bearer token, but got: %v", result.Token.Value)
 	}
 }
 
@@ -130,9 +111,11 @@ func TestOAuthFlowIsCached(t *testing.T) {
 	if result.Error != "" {
 		t.Errorf("Expected no error when performing oauth flow, but got: %v", result.Error)
 	}
-	authorizationHeader := result.RequestHeader["Authorization"]
-	if authorizationHeader != "Bearer my-access-token" {
-		t.Errorf("Expected JWT bearer token in authorization header, but got: %v", authorizationHeader)
+	if result.Token.Type != "Bearer" {
+		t.Errorf("Expected JWT bearer token, but got: %v", result.Token.Type)
+	}
+	if result.Token.Value != "my-access-token" {
+		t.Errorf("Expected value for JWT bearer token, but got: %v", result.Token.Value)
 	}
 }
 

--- a/auth/pat_authenticator.go
+++ b/auth/pat_authenticator.go
@@ -12,14 +12,13 @@ type PatAuthenticator struct{}
 
 func (a PatAuthenticator) Auth(ctx AuthenticatorContext) AuthenticatorResult {
 	if !a.enabled(ctx) {
-		return *AuthenticatorSuccess(ctx.Request.Header, ctx.Config)
+		return *AuthenticatorSuccess(nil)
 	}
 	pat, err := a.getPat(ctx)
 	if err != nil {
 		return *AuthenticatorError(fmt.Errorf("Invalid PAT authenticator configuration: %w", err))
 	}
-	ctx.Request.Header["Authorization"] = "Bearer " + pat
-	return *AuthenticatorSuccess(ctx.Request.Header, ctx.Config)
+	return *AuthenticatorSuccess(NewBearerToken(pat))
 }
 
 func (a PatAuthenticator) enabled(ctx AuthenticatorContext) bool {

--- a/plugin/auth_result.go
+++ b/plugin/auth_result.go
@@ -1,8 +1,10 @@
 package plugin
 
+import "github.com/UiPath/uipathcli/auth"
+
 // AuthResult provides authentication information provided by the configured
-// authenticators. Typically, it contains the Authorization HTTP header with
-// a bearer token.
+// authenticators. Typically, it contains the JWT bearer token for authenticating
+// with the external APIs.
 type AuthResult struct {
-	Header map[string]string
+	Token *auth.AuthToken
 }

--- a/plugin/digitizer/digitize_response.go
+++ b/plugin/digitizer/digitize_response.go
@@ -1,5 +1,0 @@
-package digitzer
-
-type digitizeResponse struct {
-	DocumentId string `json:"documentId"`
-}

--- a/plugin/digitizer/digitize_result_response.go
+++ b/plugin/digitizer/digitize_result_response.go
@@ -1,5 +1,0 @@
-package digitzer
-
-type digitizeResultResponse struct {
-	Status string `json:"status"`
-}

--- a/plugin/external_plugin.go
+++ b/plugin/external_plugin.go
@@ -91,7 +91,7 @@ func (p ExternalPlugin) download(name string, url string, destination string, pr
 	}
 	defer out.Close()
 
-	request := network.NewHttpGetRequest(url, http.Header{})
+	request := network.NewHttpGetRequest(url, nil, http.Header{})
 	clientSettings := network.NewHttpClientSettings(false, "", 0, 1, false)
 	client := network.NewHttpClient(nil, *clientSettings)
 	response, err := client.Send(request)

--- a/plugin/orchestrator/url_response.go
+++ b/plugin/orchestrator/url_response.go
@@ -1,5 +1,0 @@
-package orchestrator
-
-type urlResponse struct {
-	Uri string `json:"Uri"`
-}

--- a/plugin/studio/package_publish_command.go
+++ b/plugin/studio/package_publish_command.go
@@ -13,6 +13,7 @@ import (
 	"github.com/UiPath/uipathcli/log"
 	"github.com/UiPath/uipathcli/output"
 	"github.com/UiPath/uipathcli/plugin"
+	"github.com/UiPath/uipathcli/utils/api"
 	"github.com/UiPath/uipathcli/utils/stream"
 	"github.com/UiPath/uipathcli/utils/visualization"
 )
@@ -63,9 +64,9 @@ func (c PackagePublishCommand) publish(params packagePublishParams, logger log.L
 	uploadBar := visualization.NewProgressBar(logger)
 	defer uploadBar.Remove()
 
-	client := newOrchestratorClient(params.BaseUri, params.Auth, params.Debug, params.Settings, logger)
+	client := api.NewOrchestratorClient(params.BaseUri, params.Auth.Token, params.Debug, params.Settings, logger)
 	err := client.Upload(file, uploadBar)
-	if errors.Is(err, ErrPackageAlreadyExists) {
+	if errors.Is(err, api.ErrPackageAlreadyExists) {
 		errorMessage := fmt.Sprintf("Package '%s' already exists", filepath.Base(params.Source))
 		return newFailedPackagePublishResult(errorMessage, params.Source, params.Name, params.Version), nil
 	}

--- a/plugin/studio/test_case_run_result.go
+++ b/plugin/studio/test_case_run_result.go
@@ -1,6 +1,10 @@
 package studio
 
-import "time"
+import (
+	"time"
+
+	"github.com/UiPath/uipathcli/utils/api"
+)
 
 type testCaseRunResult struct {
 	Status     string    `json:"status"`
@@ -12,7 +16,7 @@ type testCaseRunResult struct {
 	EndTime    time.Time `json:"endTime"`
 }
 
-func newTestCaseRunResult(execution TestCaseExecution) *testCaseRunResult {
+func newTestCaseRunResult(execution api.TestCaseExecution) *testCaseRunResult {
 	var err *string
 	if execution.Status == "Failed" && execution.Info != "" {
 		err = &execution.Info

--- a/plugin/studio/test_run_command.go
+++ b/plugin/studio/test_run_command.go
@@ -13,6 +13,7 @@ import (
 	"github.com/UiPath/uipathcli/log"
 	"github.com/UiPath/uipathcli/output"
 	"github.com/UiPath/uipathcli/plugin"
+	"github.com/UiPath/uipathcli/utils/api"
 	"github.com/UiPath/uipathcli/utils/directories"
 	"github.com/UiPath/uipathcli/utils/process"
 	"github.com/UiPath/uipathcli/utils/stream"
@@ -98,13 +99,13 @@ func (c TestRunCommand) execute(source string, timeout time.Duration, ctx plugin
 	return newTestRunResult(*execution), nil
 }
 
-func (c TestRunCommand) runTests(params testRunParams, ctx plugin.ExecutionContext, logger log.Logger) (*TestExecution, error) {
+func (c TestRunCommand) runTests(params testRunParams, ctx plugin.ExecutionContext, logger log.Logger) (*api.TestExecution, error) {
 	progressBar := visualization.NewProgressBar(logger)
 	defer progressBar.Remove()
 	progressBar.UpdatePercentage("uploading...", 0)
 
 	baseUri := c.formatUri(ctx.BaseUri, ctx.Organization, ctx.Tenant)
-	client := newOrchestratorClient(baseUri, ctx.Auth, ctx.Debug, ctx.Settings, logger)
+	client := api.NewOrchestratorClient(baseUri, ctx.Auth.Token, ctx.Debug, ctx.Settings, logger)
 	folderId, err := client.GetSharedFolderId()
 	if err != nil {
 		return nil, err
@@ -126,7 +127,7 @@ func (c TestRunCommand) runTests(params testRunParams, ctx plugin.ExecutionConte
 	if err != nil {
 		return nil, err
 	}
-	return client.WaitForTestExecutionToFinish(folderId, executionId, params.Timeout, func(execution TestExecution) {
+	return client.WaitForTestExecutionToFinish(folderId, executionId, params.Timeout, func(execution api.TestExecution) {
 		total := len(execution.TestCaseExecutions)
 		completed := 0
 		for _, testCase := range execution.TestCaseExecutions {

--- a/plugin/studio/test_run_result.go
+++ b/plugin/studio/test_run_result.go
@@ -1,6 +1,10 @@
 package studio
 
-import "time"
+import (
+	"time"
+
+	"github.com/UiPath/uipathcli/utils/api"
+)
 
 type testRunResult struct {
 	Status             string              `json:"status"`
@@ -16,7 +20,7 @@ type testRunResult struct {
 	TestCaseExecutions []testCaseRunResult `json:"testCaseExecutions"`
 }
 
-func newTestRunResult(execution TestExecution) *testRunResult {
+func newTestRunResult(execution api.TestExecution) *testRunResult {
 	testCasesCount := 0
 	passedCount := 0
 	failuresCount := 0

--- a/test/plugin_test.go
+++ b/test/plugin_test.go
@@ -175,10 +175,15 @@ paths:
 	if !strings.Contains(pluginCommand.Context.BaseUri.String(), "http://127.0.0.1") {
 		t.Errorf("Expected plugin command to retrieve base uri, but got: %v", pluginCommand.Context.BaseUri.String())
 	}
-	expectedAuthorization := "Bearer my-jwt-access-token"
-	authorization := pluginCommand.Context.Auth.Header["Authorization"]
-	if authorization != expectedAuthorization {
-		t.Errorf("Expected plugin command to retrieve authorization header %v, but got: %v", expectedAuthorization, authorization)
+	expectedAuthTokenType := "Bearer"
+	actualAuthTokenType := pluginCommand.Context.Auth.Token.Type
+	if actualAuthTokenType != expectedAuthTokenType {
+		t.Errorf("Expected plugin command to retrieve auth token type %v, but got: %v", expectedAuthTokenType, actualAuthTokenType)
+	}
+	expectedAuthToken := "my-jwt-access-token"
+	actualAuthToken := pluginCommand.Context.Auth.Token.Value
+	if actualAuthToken != expectedAuthToken {
+		t.Errorf("Expected plugin command to retrieve auth token %v, but got: %v", expectedAuthToken, actualAuthToken)
 	}
 }
 

--- a/utils/api/du_client.go
+++ b/utils/api/du_client.go
@@ -1,0 +1,169 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/textproto"
+
+	"github.com/UiPath/uipathcli/auth"
+	"github.com/UiPath/uipathcli/log"
+	"github.com/UiPath/uipathcli/plugin"
+	"github.com/UiPath/uipathcli/utils/network"
+	"github.com/UiPath/uipathcli/utils/stream"
+	"github.com/UiPath/uipathcli/utils/visualization"
+)
+
+type DuClient struct {
+	baseUri  string
+	token    *auth.AuthToken
+	debug    bool
+	settings plugin.ExecutionSettings
+	logger   log.Logger
+}
+
+func (c DuClient) StartDigitization(projectId string, file stream.Stream, contentType string, uploadBar *visualization.ProgressBar) (string, error) {
+	context, cancel := context.WithCancelCause(context.Background())
+	request := c.createStartDigitizationRequest(projectId, file, contentType, uploadBar, cancel)
+	client := network.NewHttpClient(c.logger, c.httpClientSettings())
+	response, err := client.SendWithContext(request, context)
+	if err != nil {
+		return "", err
+	}
+	defer response.Body.Close()
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		return "", fmt.Errorf("Error reading response: %w", err)
+	}
+	if response.StatusCode != http.StatusAccepted {
+		return "", fmt.Errorf("Digitizer returned status code '%v' and body '%v'", response.StatusCode, string(body))
+	}
+	var result digitizeResponse
+	err = json.Unmarshal(body, &result)
+	if err != nil {
+		return "", fmt.Errorf("Error parsing json response: %w", err)
+	}
+	return result.DocumentId, nil
+}
+
+func (c DuClient) createStartDigitizationRequest(projectId string, file stream.Stream, contentType string, uploadBar *visualization.ProgressBar, cancel context.CancelCauseFunc) *network.HttpRequest {
+	streamSize, _ := file.Size()
+	bodyReader, bodyWriter := io.Pipe()
+	formDataContentType := c.writeMultipartBody(bodyWriter, file, contentType, cancel)
+	uploadReader := c.progressReader("uploading...", "completing  ", bodyReader, streamSize, uploadBar)
+
+	uri := c.baseUri + fmt.Sprintf("/api/framework/projects/%s/digitization/start?api-version=1", projectId)
+	header := http.Header{
+		"Content-Type": {formDataContentType},
+	}
+	return network.NewHttpPostRequest(uri, c.toAuthorization(c.token), header, uploadReader, -1)
+}
+
+func (c DuClient) GetDigitizationResult(projectId string, documentId string) (string, error) {
+	request := c.createDigitizeStatusRequest(projectId, documentId)
+	client := network.NewHttpClient(c.logger, c.httpClientSettings())
+	response, err := client.Send(request)
+	if err != nil {
+		return "", err
+	}
+	defer response.Body.Close()
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		return "", fmt.Errorf("Error reading response: %w", err)
+	}
+	if response.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("Digitizer returned status code '%v' and body '%v'", response.StatusCode, string(body))
+	}
+	var result digitizeResultResponse
+	err = json.Unmarshal(body, &result)
+	if err != nil {
+		return "", fmt.Errorf("Error parsing json response: %w", err)
+	}
+	if result.Status == "NotStarted" || result.Status == "Running" {
+		return "", nil
+	}
+	return string(body), err
+}
+
+func (c DuClient) createDigitizeStatusRequest(projectId string, documentId string) *network.HttpRequest {
+	uri := c.baseUri + fmt.Sprintf("/api/framework/projects/%s/digitization/result/%s?api-version=1", projectId, documentId)
+	return network.NewHttpGetRequest(uri, c.toAuthorization(c.token), http.Header{})
+}
+
+func (c DuClient) writeMultipartBody(bodyWriter *io.PipeWriter, stream stream.Stream, contentType string, cancel context.CancelCauseFunc) string {
+	formWriter := multipart.NewWriter(bodyWriter)
+	go func() {
+		defer bodyWriter.Close()
+		defer formWriter.Close()
+		err := c.writeMultipartForm(formWriter, stream, contentType)
+		if err != nil {
+			cancel(err)
+			return
+		}
+	}()
+	return formWriter.FormDataContentType()
+}
+
+func (c DuClient) writeMultipartForm(writer *multipart.Writer, stream stream.Stream, contentType string) error {
+	filePart := textproto.MIMEHeader{}
+	filePart.Set("Content-Disposition", fmt.Sprintf(`form-data; name="file"; filename="%s"`, stream.Name()))
+	filePart.Set("Content-Type", contentType)
+	w, err := writer.CreatePart(filePart)
+	if err != nil {
+		return fmt.Errorf("Error creating form field 'file': %w", err)
+	}
+	data, err := stream.Data()
+	if err != nil {
+		return err
+	}
+	defer data.Close()
+	_, err = io.Copy(w, data)
+	if err != nil {
+		return fmt.Errorf("Error writing form field 'file': %w", err)
+	}
+	return nil
+}
+
+func (c DuClient) progressReader(text string, completedText string, reader io.Reader, length int64, progressBar *visualization.ProgressBar) io.Reader {
+	if length < 10*1024*1024 {
+		return reader
+	}
+	return visualization.NewProgressReader(reader, func(progress visualization.Progress) {
+		displayText := text
+		if progress.Completed {
+			displayText = completedText
+		}
+		progressBar.UpdateProgress(displayText, progress.BytesRead, length, progress.BytesPerSecond)
+	})
+}
+
+func (c DuClient) httpClientSettings() network.HttpClientSettings {
+	return *network.NewHttpClientSettings(
+		c.debug,
+		c.settings.OperationId,
+		c.settings.Timeout,
+		c.settings.MaxAttempts,
+		c.settings.Insecure)
+}
+
+func (c DuClient) toAuthorization(token *auth.AuthToken) *network.Authorization {
+	if token == nil {
+		return nil
+	}
+	return network.NewAuthorization(token.Type, token.Value)
+}
+
+func NewDuClient(baseUri string, token *auth.AuthToken, debug bool, settings plugin.ExecutionSettings, logger log.Logger) *DuClient {
+	return &DuClient{baseUri, token, debug, settings, logger}
+}
+
+type digitizeResponse struct {
+	DocumentId string `json:"documentId"`
+}
+
+type digitizeResultResponse struct {
+	Status string `json:"status"`
+}

--- a/utils/api/release.go
+++ b/utils/api/release.go
@@ -1,4 +1,4 @@
-package studio
+package api
 
 type Release struct {
 	Id   int

--- a/utils/api/test_case_execution.go
+++ b/utils/api/test_case_execution.go
@@ -1,4 +1,4 @@
-package studio
+package api
 
 import "time"
 

--- a/utils/api/test_execution.go
+++ b/utils/api/test_execution.go
@@ -1,4 +1,4 @@
-package studio
+package api
 
 import "time"
 

--- a/utils/network/authorization.go
+++ b/utils/network/authorization.go
@@ -1,0 +1,15 @@
+package network
+
+// Authorization represents the values of the http authorization header
+//
+// Example:
+// Authorization.Type: "Bearer"
+// Authorization.Value: "<jwt-bearer-token>"
+type Authorization struct {
+	Type  string
+	Value string
+}
+
+func NewAuthorization(type_ string, value string) *Authorization {
+	return &Authorization{type_, value}
+}

--- a/utils/network/http_client.go
+++ b/utils/network/http_client.go
@@ -35,6 +35,9 @@ func (c HttpClient) SendWithContext(request *HttpRequest, ctx context.Context) (
 func (c HttpClient) sendWithRetries(request *HttpRequest, ctx context.Context) (*HttpResponse, error) {
 	request.Header.Set("User-Agent", UserAgent)
 	request.Header.Set("x-request-id", c.settings.OperationId)
+	if request.Authorization != nil {
+		request.Header.Set("Authorization", fmt.Sprintf("%s %s", request.Authorization.Type, request.Authorization.Value))
+	}
 
 	if c.settings.Debug {
 		request.Body = newResettableReader(request.Body, bufferLimit, func(body []byte) { c.logRequest(request, body) })

--- a/utils/network/http_request.go
+++ b/utils/network/http_request.go
@@ -10,27 +10,28 @@ type HttpRequest struct {
 	Proto         string // e.g. "HTTP/1.0"
 	Method        string
 	URL           string
+	Authorization *Authorization
 	Header        http.Header
 	Body          io.Reader
 	ContentLength int64
 }
 
-func NewHttpGetRequest(url string, header http.Header) *HttpRequest {
-	return NewHttpRequest(http.MethodGet, url, header, &bytes.Buffer{}, -1)
+func NewHttpGetRequest(url string, authorization *Authorization, header http.Header) *HttpRequest {
+	return NewHttpRequest(http.MethodGet, url, authorization, header, &bytes.Buffer{}, -1)
 }
 
-func NewHttpPostRequest(url string, header http.Header, body io.Reader, contentLength int64) *HttpRequest {
-	return NewHttpRequest(http.MethodPost, url, header, body, contentLength)
+func NewHttpPostRequest(url string, authorization *Authorization, header http.Header, body io.Reader, contentLength int64) *HttpRequest {
+	return NewHttpRequest(http.MethodPost, url, authorization, header, body, contentLength)
 }
 
-func NewHttpPutRequest(url string, header http.Header, body io.Reader, contentLength int64) *HttpRequest {
-	return NewHttpRequest(http.MethodPut, url, header, body, contentLength)
+func NewHttpPutRequest(url string, authorization *Authorization, header http.Header, body io.Reader, contentLength int64) *HttpRequest {
+	return NewHttpRequest(http.MethodPut, url, authorization, header, body, contentLength)
 }
 
-func NewHttpPatchRequest(url string, header http.Header, body io.Reader, contentLength int64) *HttpRequest {
-	return NewHttpRequest(http.MethodPatch, url, header, body, contentLength)
+func NewHttpPatchRequest(url string, authorization *Authorization, header http.Header, body io.Reader, contentLength int64) *HttpRequest {
+	return NewHttpRequest(http.MethodPatch, url, authorization, header, body, contentLength)
 }
 
-func NewHttpRequest(method string, url string, header http.Header, body io.Reader, contentLength int64) *HttpRequest {
-	return &HttpRequest{"HTTP/1.1", method, url, header, body, contentLength}
+func NewHttpRequest(method string, url string, authorization *Authorization, header http.Header, body io.Reader, contentLength int64) *HttpRequest {
+	return &HttpRequest{"HTTP/1.1", method, url, authorization, header, body, contentLength}
 }


### PR DESCRIPTION
- Moved the orchestrator client to new api package.

- Extracted client-related logic from the DigitizeCommand and Upload/DownloadCommand into the new api package.

- Changed auth module to only return the auth token and no more additional headers to simplify the auth module.