### PR TITLE
Add support for authenticated library feeds

### DIFF
--- a/plugin/studio/package_pack_command.go
+++ b/plugin/studio/package_pack_command.go
@@ -53,7 +53,18 @@ func (c PackagePackCommand) Execute(ctx plugin.ExecutionContext, writer output.O
 	}
 	splitOutput := c.getBoolParameter("split-output", ctx.Parameters)
 	releaseNotes := c.getParameter("release-notes", "", ctx.Parameters)
-	params := newPackagePackParams(source, destination, packageVersion, autoVersion, outputType, splitOutput, releaseNotes)
+	params := newPackagePackParams(
+		ctx.Organization,
+		ctx.Tenant,
+		ctx.BaseUri,
+		ctx.Auth.Token,
+		source,
+		destination,
+		packageVersion,
+		autoVersion,
+		outputType,
+		splitOutput,
+		releaseNotes)
 
 	result, err := c.execute(*params, ctx.Debug, logger)
 	if err != nil {
@@ -139,6 +150,14 @@ func (c PackagePackCommand) preparePackArguments(params packagePackParams) []str
 	}
 	if params.ReleaseNotes != "" {
 		args = append(args, "--releaseNotes", params.ReleaseNotes)
+	}
+	if params.AuthToken != nil && params.Organization != "" {
+		args = append(args, "--libraryOrchestratorUrl", params.BaseUri.String())
+		args = append(args, "--libraryOrchestratorAuthToken", params.AuthToken.Value)
+		args = append(args, "--libraryOrchestratorAccountName", params.Organization)
+		if params.Tenant != "" {
+			args = append(args, "--libraryOrchestratorTenant", params.Tenant)
+		}
 	}
 	return args
 }

--- a/plugin/studio/package_pack_params.go
+++ b/plugin/studio/package_pack_params.go
@@ -1,6 +1,16 @@
 package studio
 
+import (
+	"net/url"
+
+	"github.com/UiPath/uipathcli/auth"
+)
+
 type packagePackParams struct {
+	Organization   string
+	Tenant         string
+	BaseUri        url.URL
+	AuthToken      *auth.AuthToken
 	Source         string
 	Destination    string
 	PackageVersion string
@@ -11,6 +21,10 @@ type packagePackParams struct {
 }
 
 func newPackagePackParams(
+	organization string,
+	tenant string,
+	baseUri url.URL,
+	authToken *auth.AuthToken,
 	source string,
 	destination string,
 	packageVersion string,
@@ -18,5 +32,5 @@ func newPackagePackParams(
 	outputType string,
 	splitOutput bool,
 	releaseNotes string) *packagePackParams {
-	return &packagePackParams{source, destination, packageVersion, autoVersion, outputType, splitOutput, releaseNotes}
+	return &packagePackParams{organization, tenant, baseUri, authToken, source, destination, packageVersion, autoVersion, outputType, splitOutput, releaseNotes}
 }

--- a/plugin/studio/projects/crossplatform/project.json
+++ b/plugin/studio/projects/crossplatform/project.json
@@ -29,7 +29,8 @@
     "readyForPiP": false,
     "startsInPiP": false,
     "mustRestoreAllDependencies": true,
-    "pipType": "ChildSession"
+    "pipType": "ChildSession",
+    "robotVersion": "25.0.0"
   },
   "designOptions": {
     "projectProfile": "Developement",

--- a/plugin/studio/projects/windows/project.json
+++ b/plugin/studio/projects/windows/project.json
@@ -31,7 +31,8 @@
     "readyForPiP": false,
     "startsInPiP": false,
     "mustRestoreAllDependencies": true,
-    "pipType": "ChildSession"
+    "pipType": "ChildSession",
+    "robotVersion": "25.0.0"
   },
   "designOptions": {
     "projectProfile": "Developement",

--- a/plugin/studio/setup_test.go
+++ b/plugin/studio/setup_test.go
@@ -2,11 +2,13 @@ package studio
 
 import (
 	"archive/zip"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"testing"
 )
 
@@ -96,6 +98,23 @@ func writeNupkgArchive(t *testing.T, path string, nuspec string) {
 	if err != nil {
 		t.Fatal(err)
 	}
+}
+
+func parseOutput(t *testing.T, output string) map[string]interface{} {
+	stdout := map[string]interface{}{}
+	err := json.Unmarshal([]byte(output), &stdout)
+	if err != nil {
+		t.Errorf("Failed to deserialize command output: %v", err)
+	}
+	return stdout
+}
+
+func getArgumentValue(args []string, name string) string {
+	index := slices.Index(args, name)
+	if index == -1 {
+		return ""
+	}
+	return args[index+1]
 }
 
 func studioCrossPlatformProjectDirectory() string {

--- a/plugin/studio/studio_plugin_notwin_test.go
+++ b/plugin/studio/studio_plugin_notwin_test.go
@@ -4,6 +4,7 @@ package studio
 
 import (
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
@@ -42,11 +43,9 @@ func TestPackOnLinuxWithCorrectArguments(t *testing.T) {
 	if commandArgs[3] != filepath.Join(source, "project.json") {
 		t.Errorf("Expected 4th argument to be the project.json, but got: %v", commandArgs[3])
 	}
-	if commandArgs[4] != "--output" {
-		t.Errorf("Expected 5th argument to be output, but got: %v", commandArgs[4])
-	}
-	if commandArgs[5] != destination {
-		t.Errorf("Expected 6th argument to be the output path, but got: %v", commandArgs[5])
+	output := getArgumentValue(commandArgs, "--output")
+	if output != destination {
+		t.Errorf("Expected --output argument to be %s, but got: %v", destination, commandArgs)
 	}
 }
 
@@ -155,19 +154,15 @@ func TestRunOnLinuxWithCorrectPackArguments(t *testing.T) {
 	if commandArgs[3] != filepath.Join(source, "project.json") {
 		t.Errorf("Expected 4th argument to be the project.json, but got: %v", commandArgs[3])
 	}
-	if commandArgs[4] != "--outputType" {
-		t.Errorf("Expected 5th argument to be outputType, but got: %v", commandArgs[4])
+	output := getArgumentValue(commandArgs, "--output")
+	if output == "" {
+		t.Errorf("Expected --output argument to be set, but got: %v", commandArgs)
 	}
-	if commandArgs[5] != "Tests" {
-		t.Errorf("Expected 6th argument to be Tests, but got: %v", commandArgs[5])
+	outputType := getArgumentValue(commandArgs, "--outputType")
+	if outputType != "Tests" {
+		t.Errorf("Expected --outputType argument to be Tests, but got: %v", commandArgs)
 	}
-	if commandArgs[6] != "--autoVersion" {
-		t.Errorf("Expected 7th argument to be autoVersion, but got: %v", commandArgs[6])
-	}
-	if commandArgs[7] != "--output" {
-		t.Errorf("Expected 8th argument to be output, but got: %v", commandArgs[7])
-	}
-	if commandArgs[8] == "" {
-		t.Errorf("Expected 9th argument to be the output file, but got: %v", commandArgs[8])
+	if !slices.Contains(commandArgs, "--autoVersion") {
+		t.Errorf("Expected --autoVersion argument to be set, but got: %v", commandArgs)
 	}
 }

--- a/plugin/studio/uipcli.go
+++ b/plugin/studio/uipcli.go
@@ -14,11 +14,8 @@ import (
 	"github.com/UiPath/uipathcli/utils/process"
 )
 
-const uipcliCrossPlatformVersion = "24.12.9111.31003"
-const uipcliCrossPlatformUrl = "https://uipath.pkgs.visualstudio.com/Public.Feeds/_apis/packaging/feeds/1c781268-d43d-45ab-9dfc-0151a1c740b7/nuget/packages/UiPath.CLI/versions/" + uipcliCrossPlatformVersion + "/content"
-
-const uipcliWindowsVersion = "24.12.9111.31003"
-const uipcliWindowsUrl = "https://uipath.pkgs.visualstudio.com/Public.Feeds/_apis/packaging/feeds/1c781268-d43d-45ab-9dfc-0151a1c740b7/nuget/packages/UiPath.CLI.Windows/versions/" + uipcliWindowsVersion + "/content"
+const uipcliCrossPlatformUrl = "https://github.com/UiPath/uipathcli/releases/download/plugins-v2.0.0/UiPath.CLI.24.12.9208.28468.nupkg"
+const uipcliWindowsUrl = "https://github.com/UiPath/uipathcli/releases/download/plugins-v2.0.0/UiPath.CLI.Windows.24.12.9208.28468.nupkg"
 
 const dotnetLinuxX64Url = "https://aka.ms/dotnet/8.0/dotnet-runtime-linux-x64.tar.gz"
 const dotnetMacOsX64Url = "https://aka.ms/dotnet/8.0/dotnet-runtime-osx-x64.tar.gz"


### PR DESCRIPTION
Use the provided auth token from the configured identity client to authenticate with the connected Orchestrator when restoring packages so that library packages can be retrieved from authenticated feeds.

Extended the `uipath studio package pack` and `uipath studio test run` commands to use the existing auth token for authentication with the Orchestrator feeds.

Implementation details:

- Using the latest uipcli which supports JWT bearer tokens and passing the short-lived token to the uipcli.

- Reduced the boilerplate in the studio plugin tests.

Issue: https://github.com/UiPath/uipathcli/issues/149