### PR TITLE
Add command to clear auth token cache

### DIFF
--- a/commandline/cache_clear_command_handler.go
+++ b/commandline/cache_clear_command_handler.go
@@ -1,0 +1,33 @@
+package commandline
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/UiPath/uipathcli/utils/directories"
+)
+
+// cacheClearCommandHandler implements command to clear auth token cache
+type cacheClearCommandHandler struct {
+	StdOut io.Writer
+}
+
+func (h cacheClearCommandHandler) Clear() error {
+	cacheDirectory, err := directories.Cache()
+	if err != nil {
+		return err
+	}
+	err = os.RemoveAll(cacheDirectory)
+	if err != nil {
+		return fmt.Errorf("Could not clear cache: %v", err)
+	}
+	fmt.Fprintln(h.StdOut, "Cache has been successfully cleared")
+	return nil
+}
+
+func newCacheClearCommandHandler(stdOut io.Writer) *cacheClearCommandHandler {
+	return &cacheClearCommandHandler{
+		StdOut: stdOut,
+	}
+}

--- a/commandline/command_builder.go
+++ b/commandline/command_builder.go
@@ -586,6 +586,7 @@ func (b CommandBuilder) createConfigCommand() *CommandDefinition {
 
 	subcommands := []*CommandDefinition{
 		b.createConfigSetCommand(),
+		b.createCacheCommand(),
 	}
 
 	return NewCommand("config", "Interactive Configuration", "Interactive command to configure the CLI").
@@ -623,6 +624,33 @@ func (b CommandBuilder) createConfigSetCommand() *CommandDefinition {
 			handler := newConfigCommandHandler(b.StdIn, b.StdOut, b.ConfigProvider)
 			return handler.Set(key, value, profileName)
 		})
+}
+
+func (b CommandBuilder) createCacheClearCommand() *CommandDefinition {
+	flags := NewFlagBuilder().
+		AddHelpFlag().
+		Build()
+
+	return NewCommand("clear", "Clears the cache", "Clears the cache").
+		WithFlags(flags).
+		WithAction(func(context *CommandExecContext) error {
+			handler := newCacheClearCommandHandler(b.StdOut)
+			return handler.Clear()
+		})
+}
+
+func (b CommandBuilder) createCacheCommand() *CommandDefinition {
+	flags := NewFlagBuilder().
+		AddHelpFlag().
+		Build()
+
+	subcommands := []*CommandDefinition{
+		b.createCacheClearCommand(),
+	}
+
+	return NewCommand("cache", "Caching-related commands", "Caching-related commands").
+		WithFlags(flags).
+		WithSubcommands(subcommands)
 }
 
 func (b CommandBuilder) loadDefinitions(args []string, serviceVersion string) ([]parser.Definition, error) {


### PR DESCRIPTION
The uipathcli caches temporary access tokens for 1 hour during which they are valid. Only after the auth token expires a new token is retrieved from the identity server.

Due to the caching of the access token, adding or removing scopes will not take effect immediately. It takes up to 1 hour until the updated scopes will be used.

Added command to clear cache so that the next command will retrieve a new auth token:

```bash
uipath config cache clear

Cache has been successfully cleared
```

Issue: https://github.com/UiPath/uipathcli/issues/160