### PR TITLE
Add restore command for UiPath Studio projects

### DIFF
--- a/main.go
+++ b/main.go
@@ -70,6 +70,7 @@ func main() {
 				plugin_studio.NewPackagePublishCommand(),
 				plugin_studio.NewPackagePackCommand(),
 				plugin_studio.NewPackageAnalyzeCommand(),
+				plugin_studio.NewPackageRestoreCommand(),
 				plugin_studio.NewTestRunCommand(),
 			},
 		),

--- a/plugin/studio/package_restore_command.go
+++ b/plugin/studio/package_restore_command.go
@@ -1,0 +1,178 @@
+package studio
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/UiPath/uipathcli/log"
+	"github.com/UiPath/uipathcli/output"
+	"github.com/UiPath/uipathcli/plugin"
+	"github.com/UiPath/uipathcli/utils/process"
+	"github.com/UiPath/uipathcli/utils/visualization"
+)
+
+// The PackageRestoreCommand restores the packages of the project
+type PackageRestoreCommand struct {
+	Exec process.ExecProcess
+}
+
+func (c PackageRestoreCommand) Command() plugin.Command {
+	return *plugin.NewCommand("studio").
+		WithCategory("package", "Package", "UiPath Studio package-related actions").
+		WithOperation("restore", "Package Project", "Restores the packages of the project").
+		WithParameter("source", plugin.ParameterTypeString, "Path to a project.json file or a folder containing project.json file (default: .)", false).
+		WithParameter("destination", plugin.ParameterTypeString, "The output folder (default ./packages)", false)
+}
+
+func (c PackageRestoreCommand) Execute(ctx plugin.ExecutionContext, writer output.OutputWriter, logger log.Logger) error {
+	source, err := c.getSource(ctx)
+	if err != nil {
+		return err
+	}
+	destination := c.getDestination(ctx)
+
+	params := newPackageRestoreParams(
+		ctx.Organization,
+		ctx.Tenant,
+		ctx.BaseUri,
+		ctx.Auth.Token,
+		source,
+		destination)
+
+	result, err := c.execute(*params, ctx.Debug, logger)
+	if err != nil {
+		return err
+	}
+
+	json, err := json.Marshal(result)
+	if err != nil {
+		return fmt.Errorf("restore command failed: %v", err)
+	}
+	return writer.WriteResponse(*output.NewResponseInfo(200, "200 OK", "HTTP/1.1", map[string][]string{}, bytes.NewReader(json)))
+}
+
+func (c PackageRestoreCommand) execute(params packageRestoreParams, debug bool, logger log.Logger) (*packageRestoreResult, error) {
+	projectReader := newStudioProjectReader(params.Source)
+	project, err := projectReader.ReadMetadata()
+	if err != nil {
+		return nil, err
+	}
+	supported, err := project.TargetFramework.IsSupported()
+	if !supported {
+		return nil, err
+	}
+
+	uipcli := newUipcli(c.Exec, logger)
+	err = uipcli.Initialize(project.TargetFramework)
+	if err != nil {
+		return nil, err
+	}
+
+	if !debug {
+		bar := c.newProgressBar(logger)
+		defer close(bar)
+	}
+	args := c.prepareRestoreArguments(params)
+	exitCode, stdErr, err := uipcli.ExecuteAndWait(args...)
+	if err != nil {
+		return nil, err
+	}
+
+	var result *packageRestoreResult
+	if exitCode == 0 {
+		if err != nil {
+			return nil, err
+		}
+		result = newSucceededPackageRestoreResult(
+			params.Destination,
+			project.Name,
+			project.Description,
+			project.ProjectId)
+	} else {
+		result = newFailedPackageRestoreResult(
+			stdErr,
+			&project.Name,
+			&project.Description,
+			&project.ProjectId)
+	}
+	return result, nil
+}
+
+func (c PackageRestoreCommand) prepareRestoreArguments(params packageRestoreParams) []string {
+	source, _ := strings.CutSuffix(params.Source, defaultProjectJson)
+	args := []string{"package", "restore", source, "--restoreFolder", params.Destination}
+	if params.AuthToken != nil && params.Organization != "" {
+		args = append(args, "--libraryOrchestratorUrl", params.BaseUri.String())
+		args = append(args, "--libraryOrchestratorAuthToken", params.AuthToken.Value)
+		args = append(args, "--libraryOrchestratorAccountName", params.Organization)
+		if params.Tenant != "" {
+			args = append(args, "--libraryOrchestratorTenant", params.Tenant)
+		}
+	}
+	return args
+}
+
+func (c PackageRestoreCommand) newProgressBar(logger log.Logger) chan struct{} {
+	progressBar := visualization.NewProgressBar(logger)
+	ticker := time.NewTicker(10 * time.Millisecond)
+	cancel := make(chan struct{})
+	var percent float64 = 0
+	go func() {
+		for {
+			select {
+			case <-ticker.C:
+				progressBar.UpdatePercentage("restoring...  ", percent)
+				percent = percent + 1
+				if percent > 100 {
+					percent = 0
+				}
+			case <-cancel:
+				ticker.Stop()
+				progressBar.Remove()
+				return
+			}
+		}
+	}()
+	return cancel
+}
+
+func (c PackageRestoreCommand) getSource(ctx plugin.ExecutionContext) (string, error) {
+	source := c.getParameter("source", ".", ctx.Parameters)
+	source, _ = filepath.Abs(source)
+	fileInfo, err := os.Stat(source)
+	if err != nil {
+		return "", fmt.Errorf("%s not found", defaultProjectJson)
+	}
+	if fileInfo.IsDir() {
+		source = filepath.Join(source, defaultProjectJson)
+	}
+	return source, nil
+}
+
+func (c PackageRestoreCommand) getDestination(ctx plugin.ExecutionContext) string {
+	destination := c.getParameter("destination", "./packages/", ctx.Parameters)
+	destination, _ = filepath.Abs(destination)
+	return destination
+}
+
+func (c PackageRestoreCommand) getParameter(name string, defaultValue string, parameters []plugin.ExecutionParameter) string {
+	result := defaultValue
+	for _, p := range parameters {
+		if p.Name == name {
+			if data, ok := p.Value.(string); ok {
+				result = data
+				break
+			}
+		}
+	}
+	return result
+}
+
+func NewPackageRestoreCommand() *PackageRestoreCommand {
+	return &PackageRestoreCommand{process.NewExecProcess()}
+}

--- a/plugin/studio/package_restore_params.go
+++ b/plugin/studio/package_restore_params.go
@@ -1,0 +1,26 @@
+package studio
+
+import (
+	"net/url"
+
+	"github.com/UiPath/uipathcli/auth"
+)
+
+type packageRestoreParams struct {
+	Organization string
+	Tenant       string
+	BaseUri      url.URL
+	AuthToken    *auth.AuthToken
+	Source       string
+	Destination  string
+}
+
+func newPackageRestoreParams(
+	organization string,
+	tenant string,
+	baseUri url.URL,
+	authToken *auth.AuthToken,
+	source string,
+	destination string) *packageRestoreParams {
+	return &packageRestoreParams{organization, tenant, baseUri, authToken, source, destination}
+}

--- a/plugin/studio/package_restore_result.go
+++ b/plugin/studio/package_restore_result.go
@@ -1,0 +1,18 @@
+package studio
+
+type packageRestoreResult struct {
+	Status      string  `json:"status"`
+	Name        *string `json:"name"`
+	Description *string `json:"description"`
+	ProjectId   *string `json:"projectId"`
+	Output      *string `json:"output"`
+	Error       *string `json:"error"`
+}
+
+func newSucceededPackageRestoreResult(output string, name string, description string, projectId string) *packageRestoreResult {
+	return &packageRestoreResult{"Succeeded", &name, &description, &projectId, &output, nil}
+}
+
+func newFailedPackageRestoreResult(err string, name *string, description *string, projectId *string) *packageRestoreResult {
+	return &packageRestoreResult{"Failed", name, description, projectId, nil, &err}
+}

--- a/plugin/studio/studio_plugin_test.go
+++ b/plugin/studio/studio_plugin_test.go
@@ -1230,6 +1230,117 @@ profiles:
 	}
 }
 
+func TestRestoreNonExistentProjectShowsProjectJsonNotFound(t *testing.T) {
+	context := test.NewContextBuilder().
+		WithDefinition("studio", studioDefinition).
+		WithCommandPlugin(NewPackageRestoreCommand()).
+		Build()
+
+	result := test.RunCli([]string{"studio", "package", "restore", "--source", "non-existent"}, context)
+
+	if !strings.Contains(result.StdErr, "project.json not found") {
+		t.Errorf("Expected stderr to show that project.json was not found, but got: %v", result.StdErr)
+	}
+}
+
+func TestRestoreCrossPlatformSuccessfully(t *testing.T) {
+	context := test.NewContextBuilder().
+		WithDefinition("studio", studioDefinition).
+		WithCommandPlugin(NewPackageRestoreCommand()).
+		Build()
+
+	source := studioCrossPlatformProjectDirectory()
+	destination := createDirectory(t)
+	result := test.RunCli([]string{"studio", "package", "restore", "--source", source, "--destination", destination}, context)
+
+	stdout := parseOutput(t, result.StdOut)
+	if stdout["status"] != "Succeeded" {
+		t.Errorf("Expected status to be Succeeded, but got: %v", result.StdOut)
+	}
+	if stdout["error"] != nil {
+		t.Errorf("Expected error to be nil, but got: %v", result.StdOut)
+	}
+	if stdout["name"] != "MyProcess" {
+		t.Errorf("Expected name to be set, but got: %v", result.StdOut)
+	}
+	if stdout["description"] != "Blank Process" {
+		t.Errorf("Expected version to be set, but got: %v", result.StdOut)
+	}
+	if stdout["projectId"] != "9011ee47-8dd4-4726-8850-299bd6ef057c" {
+		t.Errorf("Expected projectId to be set, but got: %v", result.StdOut)
+	}
+	if stdout["output"] != destination {
+		t.Errorf("Expected output path to be set, but got: %v", result.StdOut)
+	}
+}
+
+func TestRestoreWithLibraryAuthentication(t *testing.T) {
+	config := `
+profiles:
+  - name: default
+    organization: my-org
+    tenant: my-tenant
+    auth:
+      clientId: success-client-id
+      clientSecret: success-client-secret
+`
+	commandArgs := []string{}
+	exec := process.NewExecCustomProcess(0, "", "", func(name string, args []string) {
+		commandArgs = args
+	})
+	context := test.NewContextBuilder().
+		WithDefinition("studio", studioDefinition).
+		WithConfig(config).
+		WithResponse(200, "").
+		WithIdentityResponse(200, `{"access_token": "my-jwt-access-token", "expires_in": 3600, "token_type": "Bearer", "scope": "OR.Ping"}`).
+		WithCommandPlugin(PackageRestoreCommand{exec}).
+		Build()
+
+	source := studioCrossPlatformProjectDirectory()
+	destination := createDirectory(t)
+	test.RunCli([]string{"studio", "package", "restore", "--source", source, "--destination", destination}, context)
+
+	orchestratorUrl := getArgumentValue(commandArgs, "--libraryOrchestratorUrl")
+	if !strings.HasPrefix(orchestratorUrl, "http") {
+		t.Errorf("Expected orchestrator url as argument, but got: %v", commandArgs)
+	}
+
+	authToken := getArgumentValue(commandArgs, "--libraryOrchestratorAuthToken")
+	if authToken != "my-jwt-access-token" {
+		t.Errorf("Expected jwt bearer token as argument, but got: %v", commandArgs)
+	}
+
+	organization := getArgumentValue(commandArgs, "--libraryOrchestratorAccountName")
+	if organization != "my-org" {
+		t.Errorf("Expected organization as argument, but got: %v", commandArgs)
+	}
+
+	tenant := getArgumentValue(commandArgs, "--libraryOrchestratorTenant")
+	if tenant != "my-tenant" {
+		t.Errorf("Expected tenant as argument, but got: %v", commandArgs)
+	}
+}
+
+func TestFailedRestoreReturnsFailureStatus(t *testing.T) {
+	exec := process.NewExecCustomProcess(1, "Restore output", "There was an error", func(name string, args []string) {})
+	context := test.NewContextBuilder().
+		WithDefinition("studio", studioDefinition).
+		WithCommandPlugin(PackageRestoreCommand{exec}).
+		Build()
+
+	source := studioCrossPlatformProjectDirectory()
+	destination := createDirectory(t)
+	result := test.RunCli([]string{"studio", "package", "restore", "--source", source, "--destination", destination}, context)
+
+	stdout := parseOutput(t, result.StdOut)
+	if stdout["status"] != "Failed" {
+		t.Errorf("Expected status to be Failed, but got: %v", result.StdOut)
+	}
+	if stdout["error"] != "There was an error" {
+		t.Errorf("Expected error to be set, but got: %v", result.StdOut)
+	}
+}
+
 func findViolation(violations []interface{}, errorCode string) map[string]interface{} {
 	var violation map[string]interface{}
 	for _, v := range violations {

--- a/plugin/studio/studio_plugin_windows_test.go
+++ b/plugin/studio/studio_plugin_windows_test.go
@@ -252,3 +252,27 @@ func TestRunOnWindowsWithCorrectPackArguments(t *testing.T) {
 		t.Errorf("Expected --autoVersion argument to be set, but got: %v", commandArgs)
 	}
 }
+
+func TestRestoreWindowsSuccessfully(t *testing.T) {
+	context := test.NewContextBuilder().
+		WithDefinition("studio", studioDefinition).
+		WithCommandPlugin(NewPackageRestoreCommand()).
+		Build()
+
+	source := studioWindowsProjectDirectory()
+	destination := createDirectory(t)
+	result := test.RunCli([]string{"studio", "package", "restore", "--source", source, "--destination", destination}, context)
+
+	stdout := parseOutput(t, result.StdOut)
+	expected := map[string]interface{}{
+		"status":      "Succeeded",
+		"error":       nil,
+		"name":        "MyWindowsProcess",
+		"description": "Blank Process",
+		"projectId":   "94c4c9c1-68c3-45d4-be14-d4427f17eddd",
+		"output":      destination,
+	}
+	if !reflect.DeepEqual(expected, stdout) {
+		t.Errorf("Expected output '%v', but got: '%v'", expected, stdout)
+	}
+}


### PR DESCRIPTION
Add `uipath studio package restore` command to restore package dependencies of the UiPath Studio Project.

Supported arguments:

- `--source <path-to-studio-project>`
  The path to the UiPath Studio Project 
  (defaults to the current working directory)

- `--destination <target-package-folder>`
  Target folder for the dependency packages
  (defaults to `packages/` in the current working directory)

Implements https://github.com/UiPath/uipathcli/issues/159