### PR TITLE
Add support to run tests from multiple sources in parallel

### DIFF
--- a/commandline/type_converter.go
+++ b/commandline/type_converter.go
@@ -267,7 +267,10 @@ func (c typeConverter) splitEscapedMaxCount(str string, separator byte, maxCount
 				}
 				break
 			}
-
+		} else if char != separator && escaping {
+			escaping = false
+			item = append(item, '\\')
+			item = append(item, char)
 		} else {
 			escaping = false
 			item = append(item, char)

--- a/commandline/type_converter_test.go
+++ b/commandline/type_converter_test.go
@@ -198,6 +198,24 @@ func TestConvertStringAvoidEscapeEqualSign(t *testing.T) {
 	}
 }
 
+func TestConvertPreserveEscapeCharacter(t *testing.T) {
+	converter := newTypeConverter()
+
+	parameter := newParameter("values", parser.ParameterTypeStringArray, []parser.Parameter{})
+	result, _ := converter.Convert("..\\path\\myfile.txt,..\\path\\myfile2.txt", parameter)
+
+	values := result.([]string)
+	if len(values) != 2 {
+		t.Errorf("values array should contain two entries, but got: %v", len(values))
+	}
+	if values[0] != "..\\path\\myfile.txt" {
+		t.Errorf("values array should contain first path, but got: %v", values[0])
+	}
+	if values[1] != "..\\path\\myfile2.txt" {
+		t.Errorf("values array should contain second path, but got: %v", values[1])
+	}
+}
+
 func getValue(result interface{}, key string) interface{} {
 	return result.(map[string]interface{})[key]
 }

--- a/plugin/studio/multi_logger.go
+++ b/plugin/studio/multi_logger.go
@@ -1,0 +1,48 @@
+package studio
+
+import (
+	"sync"
+
+	"github.com/UiPath/uipathcli/log"
+)
+
+var mltiLoggerMutex sync.Mutex
+
+type MultiLogger struct {
+	logger log.Logger
+	prefix string
+}
+
+func (l MultiLogger) LogRequest(request log.RequestInfo) {
+	mltiLoggerMutex.Lock()
+	defer mltiLoggerMutex.Unlock()
+
+	l.logger.Log(l.prefix)
+	l.logger.LogRequest(request)
+}
+
+func (l MultiLogger) LogResponse(response log.ResponseInfo) {
+	mltiLoggerMutex.Lock()
+	defer mltiLoggerMutex.Unlock()
+
+	l.logger.Log(l.prefix)
+	l.logger.LogResponse(response)
+}
+
+func (l MultiLogger) Log(message string) {
+	mltiLoggerMutex.Lock()
+	defer mltiLoggerMutex.Unlock()
+
+	l.logger.Log(l.prefix + message)
+}
+
+func (l MultiLogger) LogError(message string) {
+	mltiLoggerMutex.Lock()
+	defer mltiLoggerMutex.Unlock()
+
+	l.logger.LogError(l.prefix + message)
+}
+
+func NewMultiLogger(logger log.Logger, prefix string) *MultiLogger {
+	return &MultiLogger{logger, prefix}
+}

--- a/plugin/studio/studio_plugin_test.go
+++ b/plugin/studio/studio_plugin_test.go
@@ -818,27 +818,31 @@ func TestRunPassed(t *testing.T) {
 
 	stdout := parseOutput(t, result.StdOut)
 	expected := map[string]interface{}{
-		"canceledCount": 0.0,
-		"endTime":       "2025-03-17T12:10:18.183Z",
-		"failuresCount": 0.0,
-		"id":            349562.0,
-		"name":          "Automated - MyProcess_Tests - 1.0.195912597",
-		"passedCount":   1.0,
-		"startTime":     "2025-03-17T12:10:09.053Z",
-		"status":        "Passed",
-		"testCaseExecutions": []interface{}{
+		"testSetExecutions": []interface{}{
 			map[string]interface{}{
-				"endTime":    "2025-03-17T12:10:18.083Z",
-				"error":      nil,
-				"id":         704170.0,
-				"name":       "TestCase.xaml",
-				"startTime":  "2025-03-17T12:10:09.087Z",
-				"status":     "Passed",
-				"testCaseId": 169537.0,
+				"canceledCount": 0.0,
+				"endTime":       "2025-03-17T12:10:18.183Z",
+				"failuresCount": 0.0,
+				"id":            349562.0,
+				"name":          "Automated - MyProcess_Tests - 1.0.195912597",
+				"passedCount":   1.0,
+				"startTime":     "2025-03-17T12:10:09.053Z",
+				"status":        "Passed",
+				"testCaseExecutions": []interface{}{
+					map[string]interface{}{
+						"endTime":    "2025-03-17T12:10:18.083Z",
+						"error":      nil,
+						"id":         704170.0,
+						"name":       "TestCase.xaml",
+						"startTime":  "2025-03-17T12:10:09.087Z",
+						"status":     "Passed",
+						"testCaseId": 169537.0,
+					},
+				},
+				"testCasesCount": 1.0,
+				"testSetId":      25819.0,
 			},
 		},
-		"testCasesCount": 1.0,
-		"testSetId":      25819.0,
 	}
 	if !reflect.DeepEqual(expected, stdout) {
 		t.Errorf("Expected output '%v', but got: '%v'", expected, stdout)
@@ -891,36 +895,40 @@ func TestRunFailed(t *testing.T) {
 
 	stdout := parseOutput(t, result.StdOut)
 	expected := map[string]interface{}{
-		"canceledCount": 0.0,
-		"endTime":       "2025-03-17T12:10:25.058Z",
-		"failuresCount": 1.0,
-		"id":            349001.0,
-		"name":          "Automated - MyLibrary - 1.0.195912597",
-		"passedCount":   1.0,
-		"startTime":     "2025-03-17T12:10:09.087Z",
-		"status":        "Failed",
-		"testCaseExecutions": []interface{}{
+		"testSetExecutions": []interface{}{
 			map[string]interface{}{
-				"endTime":    "2025-03-17T12:10:18.083Z",
-				"error":      nil,
-				"id":         704123.0,
-				"name":       "TestCase.xaml",
-				"startTime":  "2025-03-17T12:10:09.087Z",
-				"status":     "Passed",
-				"testCaseId": 169537.0,
-			},
-			map[string]interface{}{
-				"endTime":    "2025-03-17T12:10:25.058Z",
-				"error":      "There was an error",
-				"id":         704124.0,
-				"name":       "TestCase2.xaml",
-				"startTime":  "2025-03-17T12:10:21.015Z",
-				"status":     "Failed",
-				"testCaseId": 169538.0,
+				"canceledCount": 0.0,
+				"endTime":       "2025-03-17T12:10:25.058Z",
+				"failuresCount": 1.0,
+				"id":            349001.0,
+				"name":          "Automated - MyLibrary - 1.0.195912597",
+				"passedCount":   1.0,
+				"startTime":     "2025-03-17T12:10:09.087Z",
+				"status":        "Failed",
+				"testCaseExecutions": []interface{}{
+					map[string]interface{}{
+						"endTime":    "2025-03-17T12:10:18.083Z",
+						"error":      nil,
+						"id":         704123.0,
+						"name":       "TestCase.xaml",
+						"startTime":  "2025-03-17T12:10:09.087Z",
+						"status":     "Passed",
+						"testCaseId": 169537.0,
+					},
+					map[string]interface{}{
+						"endTime":    "2025-03-17T12:10:25.058Z",
+						"error":      "There was an error",
+						"id":         704124.0,
+						"name":       "TestCase2.xaml",
+						"startTime":  "2025-03-17T12:10:21.015Z",
+						"status":     "Failed",
+						"testCaseId": 169538.0,
+					},
+				},
+				"testCasesCount": 2.0,
+				"testSetId":      29991.0,
 			},
 		},
-		"testCasesCount": 2.0,
-		"testSetId":      29991.0,
 	}
 	if !reflect.DeepEqual(expected, stdout) {
 		t.Errorf("Expected output '%v', but got: '%v'", expected, stdout)
@@ -965,27 +973,31 @@ func TestRunUpdatesExistingRelease(t *testing.T) {
 
 	stdout := parseOutput(t, result.StdOut)
 	expected := map[string]interface{}{
-		"canceledCount": 0.0,
-		"endTime":       "2025-03-17T12:10:18.083Z",
-		"failuresCount": 0.0,
-		"id":            349001.0,
-		"name":          "Automated - MyLibrary - 1.0.195912597",
-		"passedCount":   1.0,
-		"startTime":     "2025-03-17T12:10:09.087Z",
-		"status":        "Passed",
-		"testCaseExecutions": []interface{}{
+		"testSetExecutions": []interface{}{
 			map[string]interface{}{
-				"endTime":    "2025-03-17T12:10:18.083Z",
-				"error":      nil,
-				"id":         704123.0,
-				"name":       "TestCase.xaml",
-				"startTime":  "2025-03-17T12:10:09.087Z",
-				"status":     "Passed",
-				"testCaseId": 169537.0,
+				"canceledCount": 0.0,
+				"endTime":       "2025-03-17T12:10:18.083Z",
+				"failuresCount": 0.0,
+				"id":            349001.0,
+				"name":          "Automated - MyLibrary - 1.0.195912597",
+				"passedCount":   1.0,
+				"startTime":     "2025-03-17T12:10:09.087Z",
+				"status":        "Passed",
+				"testCaseExecutions": []interface{}{
+					map[string]interface{}{
+						"endTime":    "2025-03-17T12:10:18.083Z",
+						"error":      nil,
+						"id":         704123.0,
+						"name":       "TestCase.xaml",
+						"startTime":  "2025-03-17T12:10:09.087Z",
+						"status":     "Passed",
+						"testCaseId": 169537.0,
+					},
+				},
+				"testCasesCount": 1.0,
+				"testSetId":      29991.0,
 			},
 		},
-		"testCasesCount": 1.0,
-		"testSetId":      29991.0,
 	}
 	if !reflect.DeepEqual(expected, stdout) {
 		t.Errorf("Expected output '%v', but got: '%v'", expected, stdout)

--- a/plugin/studio/test_run_params.go
+++ b/plugin/studio/test_run_params.go
@@ -1,18 +1,26 @@
 package studio
 
-import "time"
+import (
+	"time"
+
+	"github.com/UiPath/uipathcli/log"
+)
 
 type testRunParams struct {
-	NupkgPath      string
-	ProcessKey     string
-	ProcessVersion string
-	Timeout        time.Duration
+	ExecutionId int
+	Uipcli      *uipcli
+	Logger      log.Logger
+	Source      string
+	Destination string
+	Timeout     time.Duration
 }
 
 func newTestRunParams(
-	nupkgPath string,
-	processKey string,
-	processVersion string,
+	executionId int,
+	uipcli *uipcli,
+	logger log.Logger,
+	source string,
+	destination string,
 	timeout time.Duration) *testRunParams {
-	return &testRunParams{nupkgPath, processKey, processVersion, timeout}
+	return &testRunParams{executionId, uipcli, logger, source, destination, timeout}
 }

--- a/plugin/studio/test_run_report.go
+++ b/plugin/studio/test_run_report.go
@@ -1,0 +1,9 @@
+package studio
+
+type testRunReport struct {
+	TestCaseExecutions []testRunResult `json:"testSetExecutions"`
+}
+
+func newTestRunReport(testCaseExecutions []testRunResult) *testRunReport {
+	return &testRunReport{testCaseExecutions}
+}

--- a/plugin/studio/test_run_status.go
+++ b/plugin/studio/test_run_status.go
@@ -1,0 +1,34 @@
+package studio
+
+const (
+	TestRunStatusPackaging = "packaging"
+	TestRunStatusUploading = "uploading"
+	TestRunStatusRunning   = "running"
+	TestRunStatusDone      = "done"
+	TestRunStatusError     = "error"
+)
+
+type testRunStatus struct {
+	ExecutionId    int
+	State          string
+	TotalTests     int
+	CompletedTests int
+	Result         *testRunResult
+	Err            error
+}
+
+func newTestRunStatusUploading(executionId int) *testRunStatus {
+	return &testRunStatus{executionId, TestRunStatusUploading, 0, 0, nil, nil}
+}
+
+func newTestRunStatusRunning(executionId int, totalTests int, completedTests int) *testRunStatus {
+	return &testRunStatus{executionId, TestRunStatusRunning, totalTests, completedTests, nil, nil}
+}
+
+func newTestRunStatusDone(executionId int, totalTests int, result *testRunResult) *testRunStatus {
+	return &testRunStatus{executionId, TestRunStatusDone, totalTests, totalTests, result, nil}
+}
+
+func newTestRunStatusError(executionId int, err error) *testRunStatus {
+	return &testRunStatus{executionId, TestRunStatusError, 0, 0, nil, err}
+}

--- a/plugin/studio/uipcli.go
+++ b/plugin/studio/uipcli.go
@@ -97,9 +97,9 @@ func (c uipcli) wait(cmd process.ExecCmd, wg *sync.WaitGroup) {
 func (c uipcli) readOutput(output io.Reader, wg *sync.WaitGroup) {
 	defer wg.Done()
 	scanner := bufio.NewScanner(output)
-	scanner.Split(bufio.ScanRunes)
+	scanner.Split(bufio.ScanLines)
 	for scanner.Scan() {
-		c.Logger.Log(scanner.Text())
+		c.Logger.Log(scanner.Text() + "\n")
 	}
 }
 

--- a/test/execution_test.go
+++ b/test/execution_test.go
@@ -1707,11 +1707,16 @@ paths:
       operationId: ping
 `
 
+	callCount := 0
 	context := NewContextBuilder().
 		WithDefinition("service", definition).
-		WithNextResponse(500, "Internal Server Error").
-		WithNextResponse(500, "Internal Server Error").
-		WithResponse(200, `{"hello":"world"}`).
+		WithResponseHandler(func(request RequestData) ResponseData {
+			callCount++
+			if callCount == 3 {
+				return ResponseData{Status: 200, Body: `{"hello":"world"}`}
+			}
+			return ResponseData{Status: 500, Body: "Internal Server Error"}
+		}).
 		Build()
 
 	result := RunCli([]string{"service", "ping", "--debug"}, context)

--- a/test/wait_test.go
+++ b/test/wait_test.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"strconv"
 	"testing"
 )
 
@@ -82,20 +83,22 @@ paths:
       summary: Simple ping
 `
 
+	callCount := 0
 	context := NewContextBuilder().
 		WithDefinition("myservice", definition).
-		WithNextResponse(200, `{"version":1}`).
-		WithNextResponse(200, `{"version":1}`).
-		WithResponse(200, `{"version":2}`).
+		WithResponseHandler(func(request RequestData) ResponseData {
+			callCount++
+			return ResponseData{Status: 200, Body: `{"version":` + strconv.Itoa(callCount) + `}`}
+		}).
 		Build()
 
-	result := RunCli([]string{"myservice", "ping", "--wait", "version == `2`"}, context)
+	result := RunCli([]string{"myservice", "ping", "--wait", "version == `3`"}, context)
 
 	if result.Error != nil {
 		t.Errorf("Unexpected error, got: %v", result.Error)
 	}
 	expectedOutput := `{
-  "version": 2
+  "version": 3
 }
 `
 	if result.StdOut != expectedOutput {
@@ -112,14 +115,16 @@ paths:
       summary: Simple ping
 `
 
+	callCount := 0
 	context := NewContextBuilder().
 		WithDefinition("myservice", definition).
-		WithNextResponse(200, `{"version":1}`).
-		WithNextResponse(200, `{"version":1}`).
-		WithResponse(200, `{"version":2}`).
+		WithResponseHandler(func(request RequestData) ResponseData {
+			callCount++
+			return ResponseData{Status: 200, Body: `{"version":` + strconv.Itoa(callCount) + `}`}
+		}).
 		Build()
 
-	result := RunCli([]string{"myservice", "ping", "--wait", "version == `2`"}, context)
+	result := RunCli([]string{"myservice", "ping", "--wait", "version == `3`"}, context)
 
 	if result.Error != nil {
 		t.Errorf("Unexpected error, got: %v", result.Error)

--- a/utils/api/orchestrator_client.go
+++ b/utils/api/orchestrator_client.go
@@ -487,7 +487,7 @@ func (c OrchestratorClient) convertToTestCaseExecutions(json []testCaseExecution
 }
 
 func (c OrchestratorClient) progressReader(text string, completedText string, reader io.Reader, length int64, progressBar *visualization.ProgressBar) io.Reader {
-	if length < 10*1024*1024 {
+	if progressBar == nil || length < 10*1024*1024 {
 		return reader
 	}
 	return visualization.NewProgressReader(reader, func(progress visualization.Progress) {


### PR DESCRIPTION
Extended the existing `uipath studio test run` command to support testing multiple projects in parallel.

The `--source` parameter takes now a comma-separated list of project paths, packages all projects in parallel and kicks off the test runs in orchestrator.

Fixed bug in the `type_converter` where the backslash character was dropped even when it was not used to escape the separator.

Added MultiLogger so that parallel debug log output is prefixed with [1], [2], etc... and can be correlated.

Added registering ResponseHandler in the tests which is more flexible than the next response API and allows returning different results based on some request data or test state. It is used to count the number of calls and to return different results based on the request body.