### PR TITLE
Add project builder for generating UiPath Studio projects

### DIFF
--- a/plugin/digitizer/digitizer_plugin_test.go
+++ b/plugin/digitizer/digitizer_plugin_test.go
@@ -2,8 +2,6 @@ package digitzer
 
 import (
 	"bytes"
-	"fmt"
-	"os"
 	"strings"
 	"testing"
 
@@ -98,8 +96,7 @@ paths:
 }
 
 func TestDigitizeWithFailedResponseReturnsError(t *testing.T) {
-	path := createFile(t)
-	writeFile(path, []byte("hello-world"))
+	path := test.CreateFileWithContent(t, "hello-world")
 
 	config := `profiles:
 - name: default
@@ -129,8 +126,7 @@ paths:
 }
 
 func TestDigitizeWithFailedResultResponseReturnsError(t *testing.T) {
-	path := createFile(t)
-	writeFile(path, []byte("hello-world"))
+	path := test.CreateFileWithContent(t, "hello-world")
 
 	config := `profiles:
 - name: default
@@ -161,8 +157,7 @@ paths:
 }
 
 func TestDigitizeWithoutProjectIdUsesDefaultProject(t *testing.T) {
-	path := createFile(t)
-	writeFile(path, []byte("hello-world"))
+	path := test.CreateFileWithContent(t, "hello-world")
 
 	config := `profiles:
 - name: default
@@ -207,8 +202,7 @@ paths:
 }
 
 func TestDigitizeSuccessfully(t *testing.T) {
-	path := createFile(t)
-	writeFile(path, []byte("hello-world"))
+	path := test.CreateFileWithContent(t, "hello-world")
 
 	config := `profiles:
 - name: default
@@ -253,8 +247,7 @@ paths:
 }
 
 func TestDigitizeSuccessfullyWithDebugFlag(t *testing.T) {
-	path := createFile(t)
-	writeFile(path, []byte("hello-world"))
+	path := test.CreateFileWithContent(t, "hello-world")
 
 	config := `profiles:
 - name: default
@@ -331,8 +324,7 @@ paths:
 }
 
 func TestDigitizeLargeFileSuccessfully(t *testing.T) {
-	path := createFile(t)
-	writeFile(path, make([]byte, 10*1024*1024))
+	path := test.CreateFileWithBinaryContent(t, make([]byte, 10*1024*1024))
 
 	config := `profiles:
 - name: default
@@ -373,27 +365,5 @@ paths:
 `
 	if result.StdOut != expectedResult {
 		t.Errorf("Expected stdout to show the digitize result, but got: %v", result.StdOut)
-	}
-}
-
-func createFile(t *testing.T) string {
-	tempFile, err := os.CreateTemp("", "uipath-test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer tempFile.Close()
-	t.Cleanup(func() {
-		err := os.Remove(tempFile.Name())
-		if err != nil {
-			t.Fatal(err)
-		}
-	})
-	return tempFile.Name()
-}
-
-func writeFile(name string, data []byte) {
-	err := os.WriteFile(name, data, 0600)
-	if err != nil {
-		panic(fmt.Errorf("Error writing file '%s': %w", name, err))
 	}
 }

--- a/plugin/orchestrator/orchestrator_plugin_test.go
+++ b/plugin/orchestrator/orchestrator_plugin_test.go
@@ -1,11 +1,9 @@
 package orchestrator
 
 import (
-	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"strconv"
 	"strings"
 	"testing"
@@ -126,8 +124,7 @@ func TestUploadWithoutTenantShowsValidationError(t *testing.T) {
 }
 
 func TestUploadWithFailedResponseReturnsError(t *testing.T) {
-	path := createFile(t)
-	writeFile(path, []byte("hello-world"))
+	path := test.CreateFileWithContent(t, "hello-world")
 
 	config := `profiles:
 - name: default
@@ -172,8 +169,7 @@ func TestUploadSuccessfully(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	path := createFile(t)
-	writeFile(path, []byte("hello-world"))
+	path := test.CreateFileWithContent(t, "hello-world")
 
 	config := `profiles:
 - name: default
@@ -224,8 +220,7 @@ func TestUploadLargeFile(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	path := createFile(t)
-	writeFile(path, make([]byte, size))
+	path := test.CreateFileWithBinaryContent(t, make([]byte, size))
 
 	definition := `
 servers:
@@ -259,8 +254,7 @@ func TestUploadWithDebugOutput(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	path := createFile(t)
-	writeFile(path, []byte("hello-world"))
+	path := test.CreateFileWithContent(t, "hello-world")
 
 	definition := `
 servers:
@@ -496,27 +490,5 @@ servers:
 	}
 	if !strings.Contains(result.StdErr, "GET "+srv.URL+"/download/file.txt") {
 		t.Errorf("Expected stderr to contain download request, but got: %v", result.StdErr)
-	}
-}
-
-func createFile(t *testing.T) string {
-	tempFile, err := os.CreateTemp("", "uipath-test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer tempFile.Close()
-	t.Cleanup(func() {
-		err := os.Remove(tempFile.Name())
-		if err != nil {
-			t.Fatal(err)
-		}
-	})
-	return tempFile.Name()
-}
-
-func writeFile(name string, data []byte) {
-	err := os.WriteFile(name, data, 0600)
-	if err != nil {
-		panic(fmt.Errorf("Error writing file '%s': %w", name, err))
 	}
 }

--- a/plugin/studio/projects/crossplatform/Main.xaml
+++ b/plugin/studio/projects/crossplatform/Main.xaml
@@ -1,4 +1,4 @@
-<Activity mc:Ignorable="sap sap2010" x:Class="Main" sap2010:ExpressionActivityEditor.ExpressionActivityEditor="C#" sap:VirtualizedContainerService.HintSize="1360.8,892.8" sap2010:WorkflowViewState.IdRef="ActivityBuilder_1" xmlns="http://schemas.microsoft.com/netfx/2009/xaml/activities" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" xmlns:sap="http://schemas.microsoft.com/netfx/2009/xaml/activities/presentation" xmlns:sap2010="http://schemas.microsoft.com/netfx/2010/xaml/activities/presentation" xmlns:scg="clr-namespace:System.Collections.Generic;assembly=System.Private.CoreLib" xmlns:sco="clr-namespace:System.Collections.ObjectModel;assembly=System.Private.CoreLib" xmlns:ui="http://schemas.uipath.com/workflow/activities" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+<Activity mc:Ignorable="sap sap2010" x:Class="Main" sap2010:ExpressionActivityEditor.ExpressionActivityEditor="C#" sap:VirtualizedContainerService.HintSize="1088.8,636.8" sap2010:WorkflowViewState.IdRef="ActivityBuilder_1" xmlns="http://schemas.microsoft.com/netfx/2009/xaml/activities" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" xmlns:sap="http://schemas.microsoft.com/netfx/2009/xaml/activities/presentation" xmlns:sap2010="http://schemas.microsoft.com/netfx/2010/xaml/activities/presentation" xmlns:scg="clr-namespace:System.Collections.Generic;assembly=System.Private.CoreLib" xmlns:sco="clr-namespace:System.Collections.ObjectModel;assembly=System.Private.CoreLib" xmlns:ui="http://schemas.uipath.com/workflow/activities" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
   <TextExpression.NamespacesForImplementation>
     <sco:Collection x:TypeArguments="x:String">
       <x:String>System.Activities</x:String>
@@ -58,9 +58,9 @@
       <AssemblyReference>UiPath.System.Activities</AssemblyReference>
       <AssemblyReference>UiPath.UiAutomation.Activities</AssemblyReference>
       <AssemblyReference>UiPath.Studio.Constants</AssemblyReference>
-      <AssemblyReference>System.Configuration.ConfigurationManager</AssemblyReference>
-      <AssemblyReference>System.Security.Permissions</AssemblyReference>
       <AssemblyReference>System.Console</AssemblyReference>
+      <AssemblyReference>System.Security.Permissions</AssemblyReference>
+      <AssemblyReference>System.Configuration.ConfigurationManager</AssemblyReference>
       <AssemblyReference>System.ComponentModel</AssemblyReference>
       <AssemblyReference>System.Memory</AssemblyReference>
       <AssemblyReference>System.Private.Uri</AssemblyReference>
@@ -70,16 +70,16 @@
       <AssemblyReference>System.Runtime.Serialization.Primitives</AssemblyReference>
     </sco:Collection>
   </TextExpression.ReferencesForImplementation>
-  <Sequence DisplayName="Main Sequence" sap:VirtualizedContainerService.HintSize="512,254.4" sap2010:WorkflowViewState.IdRef="Sequence_1">
+  <Sequence DisplayName="Main Sequence" sap:VirtualizedContainerService.HintSize="416,254.4" sap2010:WorkflowViewState.IdRef="Sequence_1">
     <sap:WorkflowViewStateService.ViewState>
       <scg:Dictionary x:TypeArguments="x:String, x:Object">
         <x:Boolean x:Key="IsExpanded">True</x:Boolean>
       </scg:Dictionary>
     </sap:WorkflowViewStateService.ViewState>
-    <ui:LogMessage DisplayName="Log Message" sap:VirtualizedContainerService.HintSize="449.6,165.6" sap2010:WorkflowViewState.IdRef="LogMessage_1">
+    <ui:LogMessage DisplayName="Log Message" sap:VirtualizedContainerService.HintSize="353.6,165.6" sap2010:WorkflowViewState.IdRef="LogMessage_1">
       <ui:LogMessage.Message>
         <InArgument x:TypeArguments="x:Object">
-          <CSharpValue x:TypeArguments="x:Object" sap2010:WorkflowViewState.IdRef="CSharpValue`1_1">"Hello World"</CSharpValue>
+          <CSharpValue x:TypeArguments="x:Object">"Hello World"</CSharpValue>
         </InArgument>
       </ui:LogMessage.Message>
     </ui:LogMessage>

--- a/plugin/studio/projects/crossplatform/uipath.policy.default.json
+++ b/plugin/studio/projects/crossplatform/uipath.policy.default.json
@@ -52,43 +52,8 @@
     "preview-packages-enabled-allow-edit": true,
     "default-package-source": [
       {
-        "default-package-source-name": "Local",
-        "default-package-source-source": "C:\\Users\\thomas.schmitt\\AppData\\Local\\Programs\\UiPath\\Studio\\Packages",
-        "is-enabled-default-package-source": true
-      },
-      {
-        "default-package-source-name": "Official",
-        "default-package-source-source": "https://pkgs.dev.azure.com/uipath/Public.Feeds/_packaging/UiPath-Official/nuget/v3/index.json",
-        "is-enabled-default-package-source": false
-      },
-      {
-        "default-package-source-name": "Connect",
-        "default-package-source-source": "https://gallery.uipath.com/api/v3/index.json",
-        "is-enabled-default-package-source": true
-      },
-      {
-        "default-package-source-name": "Marketplace",
-        "default-package-source-source": "https://gallery.uipath.com/api/v2",
-        "is-enabled-default-package-source": true
-      },
-      {
-        "default-package-source-name": "Nuget",
-        "default-package-source-source": "https://api.nuget.org/v3/index.json",
-        "is-enabled-default-package-source": true
-      },
-      {
         "default-package-source-name": "nuget.org",
         "default-package-source-source": "https://api.nuget.org/v3/index.json",
-        "is-enabled-default-package-source": true
-      },
-      {
-        "default-package-source-name": "du-feed",
-        "default-package-source-source": "https://uipath.pkgs.visualstudio.com/DocumentUnderstanding/_packaging/du-feed/nuget/v3/index.json",
-        "is-enabled-default-package-source": true
-      },
-      {
-        "default-package-source-name": "Microsoft Visual Studio Offline Packages",
-        "default-package-source-source": "C:\\Program Files (x86)\\Microsoft SDKs\\NuGetPackages\\",
         "is-enabled-default-package-source": true
       }
     ],
@@ -134,7 +99,7 @@
     "publish-process-url-allow-edit": true,
     "publish-library-url": null,
     "publish-library-url-allow-edit": true,
-    "publish-templates-url": "C:\\Users\\thomas.schmitt\\OneDrive - UiPath\\Documents\\UiPath\\.templates",
+    "publish-templates-url": null,
     "publish-templates-url-allow-edit": true,
     "export-analyzer-results": false,
     "export-analyzer-results-allow-edit": true,

--- a/plugin/studio/projects/windows/Main.xaml
+++ b/plugin/studio/projects/windows/Main.xaml
@@ -35,8 +35,6 @@
       <AssemblyReference>Microsoft.CSharp</AssemblyReference>
       <AssemblyReference>Microsoft.VisualBasic</AssemblyReference>
       <AssemblyReference>mscorlib</AssemblyReference>
-      <AssemblyReference>PresentationCore</AssemblyReference>
-      <AssemblyReference>PresentationFramework</AssemblyReference>
       <AssemblyReference>System</AssemblyReference>
       <AssemblyReference>System.Activities</AssemblyReference>
       <AssemblyReference>System.ComponentModel.TypeConverter</AssemblyReference>
@@ -59,11 +57,7 @@
       <AssemblyReference>System.Xml.Linq</AssemblyReference>
       <AssemblyReference>UiPath.System.Activities</AssemblyReference>
       <AssemblyReference>UiPath.UiAutomation.Activities</AssemblyReference>
-      <AssemblyReference>WindowsBase</AssemblyReference>
       <AssemblyReference>UiPath.Studio.Constants</AssemblyReference>
-      <AssemblyReference>System.Memory.Data</AssemblyReference>
-      <AssemblyReference>UiPath.Excel.Activities.Design</AssemblyReference>
-      <AssemblyReference>NPOI</AssemblyReference>
       <AssemblyReference>System.Console</AssemblyReference>
       <AssemblyReference>System.Security.Permissions</AssemblyReference>
       <AssemblyReference>System.Configuration.ConfigurationManager</AssemblyReference>
@@ -71,7 +65,6 @@
       <AssemblyReference>System.Memory</AssemblyReference>
       <AssemblyReference>System.Private.Uri</AssemblyReference>
       <AssemblyReference>System.Linq.Expressions</AssemblyReference>
-      <AssemblyReference>System.Private.ServiceModel</AssemblyReference>
       <AssemblyReference>System.Runtime.Serialization.Formatters</AssemblyReference>
       <AssemblyReference>System.Private.DataContractSerialization</AssemblyReference>
       <AssemblyReference>System.Runtime.Serialization.Primitives</AssemblyReference>
@@ -86,7 +79,7 @@
     <ui:LogMessage DisplayName="Log Message" sap:VirtualizedContainerService.HintSize="353.6,165.6" sap2010:WorkflowViewState.IdRef="LogMessage_1">
       <ui:LogMessage.Message>
         <InArgument x:TypeArguments="x:Object">
-          <CSharpValue x:TypeArguments="x:Object" sap2010:WorkflowViewState.IdRef="CSharpValue`1_1">"Hello World"</CSharpValue>
+          <CSharpValue x:TypeArguments="x:Object">"Hello World"</CSharpValue>
         </InArgument>
       </ui:LogMessage.Message>
     </ui:LogMessage>

--- a/plugin/studio/projects/windows/project.json
+++ b/plugin/studio/projects/windows/project.json
@@ -4,8 +4,6 @@
   "description": "Blank Process",
   "main": "Main.xaml",
   "dependencies": {
-    "UiPath.Excel.Activities": "[2.23.4]",
-    "UiPath.Mail.Activities": "[1.23.1]",
     "UiPath.System.Activities": "[24.10.3]",
     "UiPath.Testing.Activities": "[24.10.0]",
     "UiPath.UIAutomation.Activities": "[24.10.0]"
@@ -20,7 +18,7 @@
     "netFrameworkLazyLoading": false,
     "isPausable": true,
     "isAttended": false,
-    "requiresUserInteraction": true,
+    "requiresUserInteraction": false,
     "supportsPersistence": false,
     "workflowSerialization": "DataContract",
     "excludedLoggedData": [

--- a/plugin/studio/studio_plugin_notwin_test.go
+++ b/plugin/studio/studio_plugin_notwin_test.go
@@ -24,8 +24,9 @@ func TestPackOnLinuxWithCorrectArguments(t *testing.T) {
 		WithCommandPlugin(PackagePackCommand{exec}).
 		Build()
 
-	source := studioCrossPlatformProjectDirectory()
-	destination := createDirectory(t)
+	source := test.NewCrossPlatformProject(t).
+		Build()
+	destination := test.CreateDirectory(t)
 	test.RunCli([]string{"studio", "package", "pack", "--source", source, "--destination", destination}, context)
 
 	if !strings.HasSuffix(commandName, "dotnet") {
@@ -61,7 +62,8 @@ func TestAnalyzeOnLinuxWithCorrectArguments(t *testing.T) {
 		WithCommandPlugin(PackageAnalyzeCommand{exec}).
 		Build()
 
-	source := studioCrossPlatformProjectDirectory()
+	source := test.NewCrossPlatformProject(t).
+		Build()
 	test.RunCli([]string{"studio", "package", "analyze", "--source", source}, context)
 
 	if !strings.HasSuffix(commandName, "dotnet") {
@@ -91,7 +93,8 @@ func TestAnalyzeWindowsProjectOnLinuxReturnsCompatibilityError(t *testing.T) {
 		WithCommandPlugin(PackageAnalyzeCommand{exec}).
 		Build()
 
-	source := studioWindowsProjectDirectory()
+	source := test.NewWindowsProject(t).
+		Build()
 	result := test.RunCli([]string{"studio", "package", "analyze", "--source", source}, context)
 
 	if called {
@@ -112,8 +115,9 @@ func TestPackWindowsProjectOnLinuxReturnsCompatibilityError(t *testing.T) {
 		WithCommandPlugin(PackagePackCommand{exec}).
 		Build()
 
-	source := studioWindowsProjectDirectory()
-	destination := createDirectory(t)
+	source := test.NewWindowsProject(t).
+		Build()
+	destination := test.CreateDirectory(t)
 	result := test.RunCli([]string{"studio", "package", "pack", "--source", source, "--destination", destination}, context)
 
 	if called {
@@ -136,7 +140,8 @@ func TestRunOnLinuxWithCorrectPackArguments(t *testing.T) {
 		WithCommandPlugin(TestRunCommand{exec}).
 		Build()
 
-	source := studioCrossPlatformProjectDirectory()
+	source := test.NewCrossPlatformProject(t).
+		Build()
 	test.RunCli([]string{"studio", "test", "run", "--source", source, "--organization", "my-org", "--tenant", "my-tenant"}, context)
 
 	if !strings.HasSuffix(commandName, "dotnet") {

--- a/plugin/studio/studio_plugin_windows_test.go
+++ b/plugin/studio/studio_plugin_windows_test.go
@@ -3,8 +3,6 @@
 package studio
 
 import (
-	"encoding/json"
-	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -22,8 +20,9 @@ func TestPackWindowsSuccessfully(t *testing.T) {
 		WithCommandPlugin(NewPackagePackCommand()).
 		Build()
 
-	source := studioWindowsProjectDirectory()
-	destination := createDirectory(t)
+	source := test.NewWindowsProject(t).
+		Build()
+	destination := test.CreateDirectory(t)
 	result := test.RunCli([]string{"studio", "package", "pack", "--source", source, "--destination", destination}, context)
 
 	stdout := parseOutput(t, result.StdOut)
@@ -57,8 +56,9 @@ func TestPackCrossPlatformProjectOnWindowsWithCorrectArguments(t *testing.T) {
 		WithCommandPlugin(PackagePackCommand{exec}).
 		Build()
 
-	source := studioCrossPlatformProjectDirectory()
-	destination := createDirectory(t)
+	source := test.NewCrossPlatformProject(t).
+		Build()
+	destination := test.CreateDirectory(t)
 	test.RunCli([]string{"studio", "package", "pack", "--source", source, "--destination", destination}, context)
 
 	if !strings.HasSuffix(commandName, "dotnet.exe") {
@@ -87,8 +87,9 @@ func TestPackWindowsOnlyProjectOnWindowsWithCorrectArguments(t *testing.T) {
 		WithCommandPlugin(PackagePackCommand{exec}).
 		Build()
 
-	source := studioWindowsProjectDirectory()
-	destination := createDirectory(t)
+	source := test.NewWindowsProject(t).
+		Build()
+	destination := test.CreateDirectory(t)
 	test.RunCli([]string{"studio", "package", "pack", "--source", source, "--destination", destination}, context)
 
 	if !strings.HasSuffix(commandName, "uipcli.exe") {
@@ -107,36 +108,12 @@ func TestAnalyzeWindowsWithErrors(t *testing.T) {
 		WithCommandPlugin(NewPackageAnalyzeCommand()).
 		Build()
 
-	source := studioWindowsProjectDirectory()
+	source := test.NewWindowsProject(t).
+		Build()
 	result := test.RunCli([]string{"studio", "package", "analyze", "--source", source}, context)
 
 	if result.Error == nil {
 		t.Errorf("Expected error not to be nil, but got: %v", result.Error)
-	}
-	stdout := parseOutput(t, result.StdOut)
-	if stdout["status"] != "Failed" {
-		t.Errorf("Expected status to be Failed, but got: %v", result.StdOut)
-	}
-	if stdout["error"] != nil {
-		t.Errorf("Expected no standard error output, but got: %v", result.StdOut)
-	}
-	violations := stdout["violations"].([]interface{})
-	if len(violations) == 0 {
-		t.Errorf("Expected violations not to be empty, but got: %v", result.StdOut)
-	}
-}
-
-func TestAnalyzeWindowsWithErrorsButStopOnRuleViolationFalse(t *testing.T) {
-	context := test.NewContextBuilder().
-		WithDefinition("studio", studioDefinition).
-		WithCommandPlugin(NewPackageAnalyzeCommand()).
-		Build()
-
-	source := studioWindowsProjectDirectory()
-	result := test.RunCli([]string{"studio", "package", "analyze", "--source", source, "--stop-on-rule-violation", "false"}, context)
-
-	if result.Error != nil {
-		t.Errorf("Expected error to be nil, but got: %v", result.Error)
 	}
 	stdout := parseOutput(t, result.StdOut)
 	if stdout["status"] != "Failed" {
@@ -163,7 +140,8 @@ func TestAnalyzeWindowsOnlyProjectOnWindowsWithCorrectArguments(t *testing.T) {
 		WithCommandPlugin(PackageAnalyzeCommand{exec}).
 		Build()
 
-	source := studioWindowsProjectDirectory()
+	source := test.NewWindowsProject(t).
+		Build()
 	test.RunCli([]string{"studio", "package", "analyze", "--source", source}, context)
 
 	if !strings.HasSuffix(commandName, "uipcli.exe") {
@@ -192,7 +170,8 @@ func TestAnalyzeCrossPlatformProjectOnWindowsWithCorrectArguments(t *testing.T) 
 		WithCommandPlugin(PackageAnalyzeCommand{exec}).
 		Build()
 
-	source := studioCrossPlatformProjectDirectory()
+	source := test.NewCrossPlatformProject(t).
+		Build()
 	test.RunCli([]string{"studio", "package", "analyze", "--source", source}, context)
 
 	if !strings.HasSuffix(commandName, "dotnet.exe") {
@@ -224,7 +203,8 @@ func TestRunOnWindowsWithCorrectPackArguments(t *testing.T) {
 		WithCommandPlugin(TestRunCommand{exec}).
 		Build()
 
-	source := studioCrossPlatformProjectDirectory()
+	source := test.NewCrossPlatformProject(t).
+		Build()
 	test.RunCli([]string{"studio", "test", "run", "--source", source, "--organization", "my-org", "--tenant", "my-tenant"}, context)
 
 	if !strings.HasSuffix(commandName, "dotnet.exe") {
@@ -261,8 +241,9 @@ func TestRestoreWindowsSuccessfully(t *testing.T) {
 		WithCommandPlugin(NewPackageRestoreCommand()).
 		Build()
 
-	source := studioWindowsProjectDirectory()
-	destination := createDirectory(t)
+	source := test.NewWindowsProject(t).
+		Build()
+	destination := test.CreateDirectory(t)
 	result := test.RunCli([]string{"studio", "package", "restore", "--source", source, "--destination", destination}, context)
 
 	stdout := parseOutput(t, result.StdOut)
@@ -273,168 +254,6 @@ func TestRestoreWindowsSuccessfully(t *testing.T) {
 		"description": "Blank Process",
 		"projectId":   "94c4c9c1-68c3-45d4-be14-d4427f17eddd",
 		"output":      destination,
-	}
-	if !reflect.DeepEqual(expected, stdout) {
-		t.Errorf("Expected output '%v', but got: '%v'", expected, stdout)
-	}
-}
-
-func TestParallelRunPassed(t *testing.T) {
-	context := test.NewContextBuilder().
-		WithDefinition("studio", studioDefinition).
-		WithCommandPlugin(NewTestRunCommand()).
-		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Folders", 200, `{"value":[{"Id":938064,"FullyQualifiedName":"Shared"}]}`).
-		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Processes/UiPath.Server.Configuration.OData.UploadPackage", 200, `{}`).
-		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Releases?$filter=ProcessKey%20eq%20'MyProcess_Tests'", 200, `{"value":[{"id":10000,"name":"MyProcess_Tests"}]}`).
-		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Releases?$filter=ProcessKey%20eq%20'MyWindowsProcess_Tests'", 200, `{"value":[{"id":20000,"name":"MyWindowsProcess_Tests"}]}`).
-		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Releases(10000)", 200, `{"name":"MyProcess_Tests","processKey":"MyProcess_Tests","processVersion":"1.0.0"}`).
-		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Releases(20000)", 200, `{"name":"MyWindowsProcess_Tests","processKey":"MyWindowsProcess_Tests","processVersion":"2.0.0"}`).
-		WithResponseHandler(func(request test.RequestData) test.ResponseData {
-			if request.URL.Path == "/my-org/my-tenant/orchestrator_/api/TestAutomation/CreateTestSetForReleaseVersion" {
-				body := map[string]interface{}{}
-				err := json.Unmarshal(request.Body, &body)
-				if err != nil {
-					return test.ResponseData{Status: 500, Body: err.Error()}
-				}
-				if body["releaseId"] == 10000.0 {
-					return test.ResponseData{Status: 201, Body: "100002"}
-				}
-				return test.ResponseData{Status: 201, Body: "200002"}
-			}
-			return test.ResponseData{Status: 500, Body: fmt.Sprintf("Unhandled HTTP request %s", request.URL.Path)}
-		}).
-		WithUrlResponse("/my-org/my-tenant/orchestrator_/api/TestAutomation/StartTestSetExecution?testSetId=100002&triggerType=ExternalTool", 200, "100001").
-		WithUrlResponse("/my-org/my-tenant/orchestrator_/api/TestAutomation/StartTestSetExecution?testSetId=200002&triggerType=ExternalTool", 200, "200001").
-		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/TestSets(100002)?$expand=TestCases($expand=Definition;$select=Id,Definition,DefinitionId,ReleaseId,VersionNumber),Packages&$select=TestCases,Name", 200,
-			`{
-               "TestCases":[{
-                 "Id":100004,
-                 "Definition":{
-                   "Name":"MyTestCase",
-                   "PackageIdentifier":"1.1.1"
-                 }
-               }],
-               "Packages":[]
-             }`).
-		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/TestSets(200002)?$expand=TestCases($expand=Definition;$select=Id,Definition,DefinitionId,ReleaseId,VersionNumber),Packages&$select=TestCases,Name", 200,
-			`{
-               "TestCases":[{
-                 "Id":200004,
-                 "Definition":{
-                   "Name":"MySecondTestCase",
-                   "PackageIdentifier":"2.2.2"
-                 }
-               }],
-               "Packages":[]
-             }`).
-		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/TestSetExecutions(100001)?$expand=TestCaseExecutions($expand=TestCaseAssertions)", 200,
-			`{
-               "Name":"Automated - MyProcess_Tests - 1.0.0",
-               "TestSetId":100002,
-               "StartTime":"2025-03-17T12:10:09.053Z",
-               "EndTime":"2025-03-17T12:10:18.183Z",
-               "Status":"Passed",
-               "Id":100001,
-               "TestCaseExecutions":[{
-                 "Id":100003,
-                 "TestCaseId":100004,
-                 "EntryPointPath":"TestCase.xaml",
-                 "StartTime":"2025-03-17T12:10:09.087Z",
-                 "EndTime":"2025-03-17T12:10:18.083Z",
-                 "Status":"Passed"
-               }]
-             }`).
-		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/TestSetExecutions(200001)?$expand=TestCaseExecutions($expand=TestCaseAssertions)", 200,
-			`{
-               "Name":"Automated - MyWindowsProcess_Tests - 2.0.0",
-               "TestSetId":200002,
-               "StartTime":"2025-03-17T12:10:09.053Z",
-               "EndTime":"2025-03-17T12:10:18.183Z",
-               "Status":"Failed",
-               "Id":200001,
-               "TestCaseExecutions":[{
-                 "Id":200003,
-                 "TestCaseId":200004,
-                 "EntryPointPath":"TestCase.xaml",
-                 "StartTime":"2025-03-17T12:10:09.087Z",
-                 "EndTime":"2025-03-17T12:10:18.083Z",
-                 "Status":"Failed"
-               }]
-             }`).
-		Build()
-
-	source1 := studioCrossPlatformProjectDirectory()
-	source2 := studioWindowsProjectDirectory()
-	result := test.RunCli([]string{"studio", "test", "run", "--source", source1 + "," + source2, "--organization", "my-org", "--tenant", "my-tenant"}, context)
-
-	stdout := parseOutput(t, result.StdOut)
-	expected := map[string]interface{}{
-		"testSetExecutions": []interface{}{
-			map[string]interface{}{
-				"canceledCount": 0.0,
-				"endTime":       "2025-03-17T12:10:18.183Z",
-				"failuresCount": 0.0,
-				"id":            100001.0,
-				"name":          "Automated - MyProcess_Tests - 1.0.0",
-				"packages":      []interface{}{},
-				"passedCount":   1.0,
-				"startTime":     "2025-03-17T12:10:09.053Z",
-				"status":        "Passed",
-				"testCaseExecutions": []interface{}{
-					map[string]interface{}{
-						"assertions":              []interface{}{},
-						"dataVariationIdentifier": "",
-						"endTime":                 "2025-03-17T12:10:18.083Z",
-						"entryPointPath":          "TestCase.xaml",
-						"error":                   nil,
-						"id":                      100003.0,
-						"inputArguments":          "",
-						"jobId":                   0.0,
-						"name":                    "MyTestCase",
-						"outputArguments":         "",
-						"packageIdentifier":       "1.1.1",
-						"startTime":               "2025-03-17T12:10:09.087Z",
-						"status":                  "Passed",
-						"testCaseId":              100004.0,
-						"versionNumber":           "",
-					},
-				},
-				"testCasesCount": 1.0,
-				"testSetId":      100002.0,
-			},
-			map[string]interface{}{
-				"canceledCount": 0.0,
-				"endTime":       "2025-03-17T12:10:18.183Z",
-				"failuresCount": 1.0,
-				"id":            200001.0,
-				"name":          "Automated - MyWindowsProcess_Tests - 2.0.0",
-				"packages":      []interface{}{},
-				"passedCount":   0.0,
-				"startTime":     "2025-03-17T12:10:09.053Z",
-				"status":        "Failed",
-				"testCaseExecutions": []interface{}{
-					map[string]interface{}{
-						"assertions":              []interface{}{},
-						"dataVariationIdentifier": "",
-						"endTime":                 "2025-03-17T12:10:18.083Z",
-						"entryPointPath":          "TestCase.xaml",
-						"error":                   nil,
-						"id":                      200003.0,
-						"inputArguments":          "",
-						"jobId":                   0.0,
-						"name":                    "MySecondTestCase",
-						"outputArguments":         "",
-						"packageIdentifier":       "2.2.2",
-						"startTime":               "2025-03-17T12:10:09.087Z",
-						"status":                  "Failed",
-						"testCaseId":              200004.0,
-						"versionNumber":           "",
-					},
-				},
-				"testCasesCount": 1.0,
-				"testSetId":      200002.0,
-			},
-		},
 	}
 	if !reflect.DeepEqual(expected, stdout) {
 		t.Errorf("Expected output '%v', but got: '%v'", expected, stdout)

--- a/plugin/studio/studio_project_reader_test.go
+++ b/plugin/studio/studio_project_reader_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/UiPath/uipathcli/test"
 )
 
 func TestStudioProjectReader_FileNotFound_ReturnsError(t *testing.T) {
@@ -15,7 +17,7 @@ func TestStudioProjectReader_FileNotFound_ReturnsError(t *testing.T) {
 }
 
 func TestStudioProjectReaderInvalidJsonReturnsError(t *testing.T) {
-	path := writeFile(t, "INVALID")
+	path := test.CreateFileWithContent(t, "INVALID")
 
 	studioProjectReader := newStudioProjectReader(path)
 	_, err := studioProjectReader.ReadMetadata()
@@ -25,7 +27,7 @@ func TestStudioProjectReaderInvalidJsonReturnsError(t *testing.T) {
 }
 
 func TestStudioProjectReaderReturnsMetadata(t *testing.T) {
-	path := writeFile(t, `
+	path := test.CreateFileWithContent(t, `
 {
   "name": "My Process",
   "projectId": "5fe987d1-7495-4dc7-bc4c-feaf08600b95",
@@ -54,7 +56,7 @@ func TestStudioProjectReaderReturnsMetadata(t *testing.T) {
 }
 
 func TestStudioProjectReaderReturnsTargetFrameworkWindows(t *testing.T) {
-	path := writeFile(t, `
+	path := test.CreateFileWithContent(t, `
 {
   "targetFramework": "windows"
 }
@@ -71,7 +73,7 @@ func TestStudioProjectReaderReturnsTargetFrameworkWindows(t *testing.T) {
 }
 
 func TestStudioProjectReaderReturnsTargetFrameworkLegacy(t *testing.T) {
-	path := writeFile(t, `
+	path := test.CreateFileWithContent(t, `
 {
   "targetFramework": "Legacy"
 }
@@ -88,7 +90,7 @@ func TestStudioProjectReaderReturnsTargetFrameworkLegacy(t *testing.T) {
 }
 
 func TestStudioProjectReaderUnknownTargetFrameworkDefaultsToCrossPlatform(t *testing.T) {
-	path := writeFile(t, `
+	path := test.CreateFileWithContent(t, `
 {
   "targetFramework": "Unknown"
 }
@@ -105,7 +107,7 @@ func TestStudioProjectReaderUnknownTargetFrameworkDefaultsToCrossPlatform(t *tes
 }
 
 func TestStudioProjectReaderAddToIgnoredFilesCreatesNewSection(t *testing.T) {
-	path := writeFile(t, `
+	path := test.CreateFileWithContent(t, `
 {
   "name": "My Process",
   "projectId": "5fe987d1-7495-4dc7-bc4c-feaf08600b95",
@@ -131,7 +133,7 @@ func TestStudioProjectReaderAddToIgnoredFilesCreatesNewSection(t *testing.T) {
 }
 
 func TestStudioProjectReaderAddToIgnoredFilesAddsToExistingDesignOptions(t *testing.T) {
-	path := writeFile(t, `
+	path := test.CreateFileWithContent(t, `
 {
   "name": "My Process",
   "projectId": "5fe987d1-7495-4dc7-bc4c-feaf08600b95",
@@ -160,7 +162,7 @@ func TestStudioProjectReaderAddToIgnoredFilesAddsToExistingDesignOptions(t *test
 }
 
 func TestStudioProjectReaderAddToIgnoredFilesAddsToExistingProcessOptions(t *testing.T) {
-	path := writeFile(t, `
+	path := test.CreateFileWithContent(t, `
 {
   "name": "My Process",
   "projectId": "5fe987d1-7495-4dc7-bc4c-feaf08600b95",
@@ -191,7 +193,7 @@ func TestStudioProjectReaderAddToIgnoredFilesAddsToExistingProcessOptions(t *tes
 }
 
 func TestStudioProjectReaderAddToIgnoredFilesAddsToExistingIgnoredFiles(t *testing.T) {
-	path := writeFile(t, `
+	path := test.CreateFileWithContent(t, `
 {
   "name": "My Process",
   "projectId": "5fe987d1-7495-4dc7-bc4c-feaf08600b95",
@@ -230,7 +232,7 @@ func TestStudioProjectReaderAddToIgnoredFilesFileNotFoundReturnsError(t *testing
 }
 
 func TestStudioProjectReaderAddToIgnoredFilesInvalidJsonReturnsError(t *testing.T) {
-	path := writeFile(t, "INVALID")
+	path := test.CreateFileWithContent(t, "INVALID")
 
 	studioProjectReader := newStudioProjectReader(path)
 	err := studioProjectReader.AddToIgnoredFiles("*.nupkg")
@@ -240,7 +242,7 @@ func TestStudioProjectReaderAddToIgnoredFilesInvalidJsonReturnsError(t *testing.
 }
 
 func TestStudioProjectReaderAddToIgnoredFilesInvalidIgnoredFilesReturnsError(t *testing.T) {
-	path := writeFile(t, `
+	path := test.CreateFileWithContent(t, `
 {
   "name": "My Process",
   "projectId": "5fe987d1-7495-4dc7-bc4c-feaf08600b95",
@@ -262,7 +264,7 @@ func TestStudioProjectReaderAddToIgnoredFilesInvalidIgnoredFilesReturnsError(t *
 }
 
 func TestStudioProjectReaderAddToIgnoredFilesFilePatternExistsNoOp(t *testing.T) {
-	path := writeFile(t, `
+	path := test.CreateFileWithContent(t, `
 {
   "name": "My Process",
   "projectId": "5fe987d1-7495-4dc7-bc4c-feaf08600b95",

--- a/test/autocomplete_enable_test.go
+++ b/test/autocomplete_enable_test.go
@@ -19,7 +19,7 @@ func TestEnableAutocompleteInvalidShellShowsError(t *testing.T) {
 }
 
 func TestEnableAutocompletePowershellShowsSuccessOutput(t *testing.T) {
-	profilePath := createFile(t)
+	profilePath := CreateFile(t)
 
 	context := NewContextBuilder().
 		WithDefinition("myservice", "").
@@ -38,7 +38,7 @@ Successfully enabled command completion! Restart your shell for the changes to t
 }
 
 func TestEnableAutocompletePowershellCreatesProfileFile(t *testing.T) {
-	profilePath := createFile(t)
+	profilePath := CreateFile(t)
 
 	context := NewContextBuilder().
 		WithDefinition("myservice", "").
@@ -66,8 +66,7 @@ Register-ArgumentCompleter -Native -CommandName uipath -ScriptBlock $uipath_auto
 }
 
 func TestEnableAutocompletePowershellUpdatesExistingProfileFile(t *testing.T) {
-	profilePath := createFile(t)
-	writeFile(t, profilePath, []byte("existing content\nshould not change"))
+	profilePath := CreateFileWithContent(t, "existing content\nshould not change")
 
 	context := NewContextBuilder().
 		WithDefinition("myservice", "").
@@ -96,7 +95,6 @@ Register-ArgumentCompleter -Native -CommandName uipath -ScriptBlock $uipath_auto
 }
 
 func TestEnableAutocompletePowershellNoChangesIfEnabledAlready(t *testing.T) {
-	profilePath := createFile(t)
 	initialContent := `
 $uipath_auto_complete = {
     param($wordToComplete, $commandAst, $cursorPosition)
@@ -107,7 +105,7 @@ $uipath_auto_complete = {
 }
 Register-ArgumentCompleter -Native -CommandName uipath -ScriptBlock $uipath_auto_complete
 `
-	writeFile(t, profilePath, []byte(initialContent))
+	profilePath := CreateFileWithContent(t, initialContent)
 
 	context := NewContextBuilder().
 		WithDefinition("myservice", "").
@@ -122,7 +120,6 @@ Register-ArgumentCompleter -Native -CommandName uipath -ScriptBlock $uipath_auto
 }
 
 func TestEnableAutocompletePowershellShowsAlreadyEnabledOutput(t *testing.T) {
-	profilePath := createFile(t)
 	initialContent := `
 $uipath_auto_complete = {
     param($wordToComplete, $commandAst, $cursorPosition)
@@ -133,7 +130,7 @@ $uipath_auto_complete = {
 }
 Register-ArgumentCompleter -Native -CommandName uipath -ScriptBlock $uipath_auto_complete
 `
-	writeFile(t, profilePath, []byte(initialContent))
+	profilePath := CreateFileWithContent(t, initialContent)
 
 	context := NewContextBuilder().
 		WithDefinition("myservice", "").
@@ -152,7 +149,7 @@ Command completion is already enabled.
 }
 
 func TestEnableAutocompleteBashShowsSuccessOutput(t *testing.T) {
-	profilePath := createFile(t)
+	profilePath := CreateFile(t)
 
 	context := NewContextBuilder().
 		WithDefinition("myservice", "").
@@ -171,7 +168,7 @@ Successfully enabled command completion! Restart your shell for the changes to t
 }
 
 func TestEnableAutocompleteBashCreatesProfileFile(t *testing.T) {
-	profilePath := createFile(t)
+	profilePath := CreateFile(t)
 
 	context := NewContextBuilder().
 		WithDefinition("myservice", "").
@@ -198,8 +195,7 @@ complete -f -F _uipath_auto_complete uipath
 }
 
 func TestEnableAutocompleteBashUpdatesExistingProfileFile(t *testing.T) {
-	profilePath := createFile(t)
-	writeFile(t, profilePath, []byte("\nexisting content\nshould not change\n"))
+	profilePath := CreateFileWithContent(t, "\nexisting content\nshould not change\n")
 
 	context := NewContextBuilder().
 		WithDefinition("myservice", "").
@@ -229,7 +225,6 @@ complete -f -F _uipath_auto_complete uipath
 }
 
 func TestEnableAutocompleteBashNoChangesIfEnabledAlready(t *testing.T) {
-	profilePath := createFile(t)
 	initialContent := `
 function _uipath_auto_complete()
 {
@@ -241,7 +236,7 @@ function _uipath_auto_complete()
 }
 complete -f -F _uipath_auto_complete uipath
 `
-	writeFile(t, profilePath, []byte(initialContent))
+	profilePath := CreateFileWithContent(t, initialContent)
 
 	context := NewContextBuilder().
 		WithDefinition("myservice", "").
@@ -256,7 +251,6 @@ complete -f -F _uipath_auto_complete uipath
 }
 
 func TestEnableAutocompleteBashShowsAlreadyEnabledOutput(t *testing.T) {
-	profilePath := createFile(t)
 	initialContent := `
 function _uipath_auto_complete()
 {
@@ -268,7 +262,7 @@ function _uipath_auto_complete()
 }
 complete -f -F _uipath_auto_complete uipath
 `
-	writeFile(t, profilePath, []byte(initialContent))
+	profilePath := CreateFileWithContent(t, initialContent)
 
 	context := NewContextBuilder().
 		WithDefinition("myservice", "").

--- a/test/config_set_test.go
+++ b/test/config_set_test.go
@@ -18,7 +18,7 @@ func TestConfigSetUnknownKey(t *testing.T) {
 }
 
 func TestConfigSetCreatesNewProfile(t *testing.T) {
-	configFile := createFile(t)
+	configFile := CreateFile(t)
 	existingConfig := `profiles:
 - name: default
   organization: initial-org
@@ -46,7 +46,7 @@ func TestConfigSetCreatesNewProfile(t *testing.T) {
 }
 
 func TestConfigSetUpdatesExistingProfile(t *testing.T) {
-	configFile := createFile(t)
+	configFile := CreateFile(t)
 	existingConfig := `profiles:
 - name: existing
   organization: initial-org
@@ -72,7 +72,7 @@ func TestConfigSetUpdatesExistingProfile(t *testing.T) {
 }
 
 func TestConfigSetOrganization(t *testing.T) {
-	configFile := createFile(t)
+	configFile := CreateFile(t)
 	context := NewContextBuilder().
 		WithConfigFile(configFile).
 		Build()
@@ -93,7 +93,7 @@ func TestConfigSetOrganization(t *testing.T) {
 }
 
 func TestConfigSetTenant(t *testing.T) {
-	configFile := createFile(t)
+	configFile := CreateFile(t)
 	context := NewContextBuilder().
 		WithConfigFile(configFile).
 		Build()
@@ -114,7 +114,7 @@ func TestConfigSetTenant(t *testing.T) {
 }
 
 func TestConfigSetUri(t *testing.T) {
-	configFile := createFile(t)
+	configFile := CreateFile(t)
 	context := NewContextBuilder().
 		WithConfigFile(configFile).
 		Build()
@@ -146,7 +146,7 @@ func TestConfigInvalidUri(t *testing.T) {
 }
 
 func TestConfigSetInsecure(t *testing.T) {
-	configFile := createFile(t)
+	configFile := CreateFile(t)
 	context := NewContextBuilder().
 		WithConfigFile(configFile).
 		Build()
@@ -167,7 +167,7 @@ func TestConfigSetInsecure(t *testing.T) {
 }
 
 func TestConfigSetDebug(t *testing.T) {
-	configFile := createFile(t)
+	configFile := CreateFile(t)
 	context := NewContextBuilder().
 		WithConfigFile(configFile).
 		Build()
@@ -210,7 +210,7 @@ func TestConfigInvalidDebug(t *testing.T) {
 }
 
 func TestConfigSetHeader(t *testing.T) {
-	configFile := createFile(t)
+	configFile := CreateFile(t)
 	context := NewContextBuilder().
 		WithConfigFile(configFile).
 		Build()
@@ -232,7 +232,7 @@ func TestConfigSetHeader(t *testing.T) {
 }
 
 func TestConfigSetParameter(t *testing.T) {
-	configFile := createFile(t)
+	configFile := CreateFile(t)
 	context := NewContextBuilder().
 		WithConfigFile(configFile).
 		Build()
@@ -254,7 +254,7 @@ func TestConfigSetParameter(t *testing.T) {
 }
 
 func TestConfigSetAuthGrantType(t *testing.T) {
-	configFile := createFile(t)
+	configFile := CreateFile(t)
 	context := NewContextBuilder().
 		WithConfigFile(configFile).
 		Build()
@@ -276,7 +276,7 @@ func TestConfigSetAuthGrantType(t *testing.T) {
 }
 
 func TestConfigSetAuthScopes(t *testing.T) {
-	configFile := createFile(t)
+	configFile := CreateFile(t)
 	context := NewContextBuilder().
 		WithConfigFile(configFile).
 		Build()
@@ -298,7 +298,7 @@ func TestConfigSetAuthScopes(t *testing.T) {
 }
 
 func TestConfigSetAuthProperties(t *testing.T) {
-	configFile := createFile(t)
+	configFile := CreateFile(t)
 	context := NewContextBuilder().
 		WithConfigFile(configFile).
 		Build()
@@ -321,7 +321,7 @@ func TestConfigSetAuthProperties(t *testing.T) {
 }
 
 func TestConfigSetServiceVersion(t *testing.T) {
-	configFile := createFile(t)
+	configFile := CreateFile(t)
 	context := NewContextBuilder().
 		WithConfigFile(configFile).
 		Build()

--- a/test/config_update_test.go
+++ b/test/config_update_test.go
@@ -30,7 +30,7 @@ func TestConfigCommandDescriptionIsShown(t *testing.T) {
 }
 
 func TestConfiguresCredentialsAuth(t *testing.T) {
-	configFile := createFile(t)
+	configFile := CreateFile(t)
 
 	stdIn := bytes.Buffer{}
 	stdIn.Write([]byte("my-org\nmy-tenant\nclient-id\nclient-secret\n"))
@@ -59,7 +59,7 @@ func TestConfiguresCredentialsAuth(t *testing.T) {
 }
 
 func TestConfiguresLoginAuth(t *testing.T) {
-	configFile := createFile(t)
+	configFile := CreateFile(t)
 
 	stdIn := bytes.Buffer{}
 	stdIn.Write([]byte("my-org\nmy-tenant\nffe5141f-60fc-4fb9-8717-3969f303aedf\nhttp://localhost:27100\nOR.Users\n"))
@@ -89,7 +89,7 @@ func TestConfiguresLoginAuth(t *testing.T) {
 }
 
 func TestConfiguresPatAuth(t *testing.T) {
-	configFile := createFile(t)
+	configFile := CreateFile(t)
 
 	stdIn := bytes.Buffer{}
 	stdIn.Write([]byte("my-org\nmy-tenant\nrt_mypersonalaccesstoken\n"))
@@ -117,7 +117,7 @@ func TestConfiguresPatAuth(t *testing.T) {
 }
 
 func TestConfiguresPatAuthDoesNotChangeExistingConfigValues(t *testing.T) {
-	configFile := createFile(t)
+	configFile := CreateFile(t)
 	config := `
 profiles:
 - name: default
@@ -154,7 +154,7 @@ profiles:
 }
 
 func TestReconfiguresPatAuth(t *testing.T) {
-	configFile := createFile(t)
+	configFile := CreateFile(t)
 	config := `
 profiles:
 - name: default
@@ -191,7 +191,7 @@ profiles:
 }
 
 func TestReconfiguresPatAuthPartially(t *testing.T) {
-	configFile := createFile(t)
+	configFile := CreateFile(t)
 	config := `
 profiles:
 - name: default
@@ -228,7 +228,7 @@ profiles:
 }
 
 func TestConfiguresNewProfile(t *testing.T) {
-	configFile := createFile(t)
+	configFile := CreateFile(t)
 	config := `
 profiles:
 - name: default
@@ -266,7 +266,7 @@ profiles:
 }
 
 func TestReconfiguresExistingProfile(t *testing.T) {
-	configFile := createFile(t)
+	configFile := CreateFile(t)
 	config := `
 profiles:
 - name: default
@@ -322,7 +322,7 @@ func TestCredentialsAuthOutputNotSet(t *testing.T) {
 }
 
 func TestCredentialsAuthMasksSecrets(t *testing.T) {
-	configFile := createFile(t)
+	configFile := CreateFile(t)
 	config := `
 profiles:
 - name: default
@@ -350,7 +350,7 @@ profiles:
 }
 
 func TestCredentialsAuthMasksShortSecretsCompletely(t *testing.T) {
-	configFile := createFile(t)
+	configFile := CreateFile(t)
 	config := `
 profiles:
 - name: default
@@ -378,7 +378,7 @@ profiles:
 }
 
 func TestPatAuthMasksSecrets(t *testing.T) {
-	configFile := createFile(t)
+	configFile := CreateFile(t)
 	config := `
 profiles:
 - name: default
@@ -405,7 +405,7 @@ profiles:
 }
 
 func TestLoginAuthMasksSecrets(t *testing.T) {
-	configFile := createFile(t)
+	configFile := CreateFile(t)
 	config := `
 profiles:
 - name: default
@@ -434,7 +434,7 @@ profiles:
 }
 
 func TestConfigureMultiAuthCredentialsAuth(t *testing.T) {
-	configFile := createFile(t)
+	configFile := CreateFile(t)
 
 	stdIn := bytes.Buffer{}
 	stdIn.Write([]byte("my-org\nmy-tenant\n1\nclient-id\nclient-secret\n"))
@@ -463,7 +463,7 @@ func TestConfigureMultiAuthCredentialsAuth(t *testing.T) {
 }
 
 func TestConfigureMultiAuthLoginAuth(t *testing.T) {
-	configFile := createFile(t)
+	configFile := CreateFile(t)
 
 	stdIn := bytes.Buffer{}
 	stdIn.Write([]byte("my-org\nmy-tenant\n2\nffe5141f-60fc-4fb9-8717-3969f303aedf\nhttp://localhost:27100\nOR.Users\n"))
@@ -493,7 +493,7 @@ func TestConfigureMultiAuthLoginAuth(t *testing.T) {
 }
 
 func TestConfigureMultiAuthPatAuth(t *testing.T) {
-	configFile := createFile(t)
+	configFile := CreateFile(t)
 
 	stdIn := bytes.Buffer{}
 	stdIn.Write([]byte("my-org\nmy-tenant\n3\nrt_mypersonalaccesstoken\n"))
@@ -521,7 +521,7 @@ func TestConfigureMultiAuthPatAuth(t *testing.T) {
 }
 
 func TestConfigureMultiAuthShowsExistingCredentialsAuth(t *testing.T) {
-	configFile := createFile(t)
+	configFile := CreateFile(t)
 	config := `
 profiles:
 - name: default
@@ -548,7 +548,7 @@ profiles:
 }
 
 func TestConfigureMultiAuthShowsExistingLoginAuth(t *testing.T) {
-	configFile := createFile(t)
+	configFile := CreateFile(t)
 	config := `
 profiles:
 - name: default
@@ -576,7 +576,7 @@ profiles:
 }
 
 func TestConfigureMultiAuthShowsExistingPatAuth(t *testing.T) {
-	configFile := createFile(t)
+	configFile := CreateFile(t)
 	config := `
 profiles:
 - name: default
@@ -602,7 +602,7 @@ profiles:
 }
 
 func TestConfigureMultiAuthShowsNoAuthSet(t *testing.T) {
-	configFile := createFile(t)
+	configFile := CreateFile(t)
 	config := `
 profiles:
 - name: default
@@ -626,7 +626,7 @@ profiles:
 }
 
 func TestConfigureMultiAuthModifiesExistingPatAuth(t *testing.T) {
-	configFile := createFile(t)
+	configFile := CreateFile(t)
 	existingConfig := `
 profiles:
 - name: default
@@ -663,7 +663,7 @@ profiles:
 }
 
 func TestConfigureMultiAuthModifiesExistingCredentialsAuth(t *testing.T) {
-	configFile := createFile(t)
+	configFile := CreateFile(t)
 	existingConfig := `
 profiles:
 - name: default
@@ -702,7 +702,7 @@ profiles:
 }
 
 func TestConfigureMultiAuthModifiesExistingLoginAuth(t *testing.T) {
-	configFile := createFile(t)
+	configFile := CreateFile(t)
 	existingConfig := `
 profiles:
 - name: default

--- a/test/execution_test.go
+++ b/test/execution_test.go
@@ -950,8 +950,7 @@ paths:
 		WithDefinition("myservice", definition).
 		Build()
 
-	path := createFile(t)
-	writeFile(t, path, []byte("hello-world"))
+	path := CreateFileWithContent(t, "hello-world")
 	result := RunCli([]string{"myservice", "post-validate", "--file", path}, context)
 
 	contentType := result.RequestHeader["content-type"]
@@ -993,8 +992,7 @@ paths:
 		WithDefinition("myservice", definition).
 		Build()
 
-	path := createFile(t)
-	writeFile(t, path, []byte("hello-world"))
+	path := CreateFileWithContent(t, "hello-world")
 	result := RunCli([]string{"myservice", "post-validate", "--file", path}, context)
 
 	expected := fmt.Sprintf(`Content-Disposition: form-data; name="File"; filename="%s"`, filepath.Base(path))
@@ -1022,8 +1020,7 @@ paths:
 		WithResponse(200, "{}").
 		WithDefinition("myservice", definition).
 		Build()
-	path := createFile(t)
-	writeFile(t, path, []byte("hello-world"))
+	path := CreateFileWithContent(t, "hello-world")
 	result := RunCli([]string{"myservice", "post-validate", "--file", path}, context)
 
 	expected := `Content-Disposition: form-data; name="file"; filename="` + filepath.Base(path) + `"`
@@ -1060,8 +1057,8 @@ paths:
 		WithDefinition("myservice", definition).
 		Build()
 
-	path := createFile(t)
-	writeFile(t, path, make([]byte, 10*1024*1024))
+	path := CreateFileWithBinaryContent(t, make([]byte, 10*1024*1024))
+
 	result := RunCli([]string{"myservice", "post-validate", "--file", path}, context)
 
 	if len(result.RequestBody) < 10*1024*1024 {
@@ -1279,8 +1276,7 @@ paths:
 		WithResponse(200, "").
 		Build()
 
-	path := createFile(t)
-	writeFile(t, path, []byte("hello-world"))
+	path := CreateFileWithContent(t, "hello-world")
 	result := RunCli([]string{"myservice", "upload", "--file", path}, context)
 
 	contentType := result.RequestHeader["content-type"]
@@ -1316,8 +1312,11 @@ paths:
 		Build()
 
 	currentPath, _ := os.Getwd()
-	path := createFileInFolder(t, filepath.Join(currentPath, "tmp"))
-	writeFile(t, path, []byte("hello-world"))
+	path := CreateFileInDirectory(t, filepath.Join(currentPath, "tmp"))
+	err := os.WriteFile(path, []byte("hello-world"), 0600)
+	if err != nil {
+		t.Fatalf("Error writing file '%s': %v", path, err)
+	}
 
 	relativePath, _ := filepath.Rel(currentPath, path)
 	result := RunCli([]string{"myservice", "upload", "--file", relativePath}, context)

--- a/test/project_builder.go
+++ b/test/project_builder.go
@@ -1,0 +1,1022 @@
+package test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+const ProjectJsonTemplate = `
+{
+  "name": "%s",
+  "projectId": "%s",
+  "description": "Blank Process",
+  "main": "Main.xaml",
+  "dependencies": {
+    "UiPath.System.Activities": "[24.10.3]",
+    "UiPath.Testing.Activities": "[24.10.0]",
+    "UiPath.UIAutomation.Activities": "[24.10.0]"
+  },
+  "webServices": [],
+  "entitiesStores": [],
+  "schemaVersion": "4.0",
+  "studioVersion": "24.10.1.0",
+  "projectVersion": "1.0.0",
+  "runtimeOptions": {
+    "autoDispose": false,
+    "netFrameworkLazyLoading": false,
+    "isPausable": true,
+    "isAttended": false,
+    "requiresUserInteraction": false,
+    "supportsPersistence": false,
+    "workflowSerialization": "DataContract",
+    "excludedLoggedData": [
+      "Private:*",
+      "*password*"
+    ],
+    "executionType": "Workflow",
+    "readyForPiP": false,
+    "startsInPiP": false,
+    "mustRestoreAllDependencies": true,
+    "pipType": "ChildSession",
+    "robotVersion": "25.0.0"
+  },
+  "designOptions": {
+    "projectProfile": "Developement",
+    "outputType": "Process",
+    "libraryOptions": {
+      "includeOriginalXaml": false,
+      "privateWorkflows": []
+    },
+    "processOptions": {
+      "ignoredFiles": [
+        "MyProcess.*.nupkg"
+      ]
+    },
+    "fileInfoCollection": [],
+    "saveToCloud": false
+  },
+  "expressionLanguage": "CSharp",
+  "entryPoints": [
+    {
+      "filePath": "Main.xaml",
+      "uniqueId": "ac610120-f85b-4ed4-a014-05dca3380186",
+      "input": [],
+      "output": []
+    }
+  ],
+  "isTemplate": false,
+  "templateProjectData": {},
+  "publishData": {},
+  "targetFramework": "%s"
+}
+`
+
+const MainXaml = `
+<Activity mc:Ignorable="sap sap2010" x:Class="Main" sap2010:ExpressionActivityEditor.ExpressionActivityEditor="C#" sap:VirtualizedContainerService.HintSize="1088.8,636.8" sap2010:WorkflowViewState.IdRef="ActivityBuilder_1" xmlns="http://schemas.microsoft.com/netfx/2009/xaml/activities" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" xmlns:sap="http://schemas.microsoft.com/netfx/2009/xaml/activities/presentation" xmlns:sap2010="http://schemas.microsoft.com/netfx/2010/xaml/activities/presentation" xmlns:scg="clr-namespace:System.Collections.Generic;assembly=System.Private.CoreLib" xmlns:sco="clr-namespace:System.Collections.ObjectModel;assembly=System.Private.CoreLib" xmlns:ui="http://schemas.uipath.com/workflow/activities" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+  <TextExpression.NamespacesForImplementation>
+    <sco:Collection x:TypeArguments="x:String">
+      <x:String>System.Activities</x:String>
+      <x:String>System.Activities.Statements</x:String>
+      <x:String>System.Activities.Expressions</x:String>
+      <x:String>System.Activities.Validation</x:String>
+      <x:String>System.Activities.XamlIntegration</x:String>
+      <x:String>Microsoft.VisualBasic</x:String>
+      <x:String>Microsoft.VisualBasic.Activities</x:String>
+      <x:String>System</x:String>
+      <x:String>System.Collections</x:String>
+      <x:String>System.Collections.Generic</x:String>
+      <x:String>System.Collections.ObjectModel</x:String>
+      <x:String>System.Data</x:String>
+      <x:String>System.Diagnostics</x:String>
+      <x:String>System.Drawing</x:String>
+      <x:String>System.IO</x:String>
+      <x:String>System.Linq</x:String>
+      <x:String>System.Net.Mail</x:String>
+      <x:String>System.Xml</x:String>
+      <x:String>System.Text</x:String>
+      <x:String>System.Xml.Linq</x:String>
+      <x:String>UiPath.Core</x:String>
+      <x:String>UiPath.Core.Activities</x:String>
+      <x:String>System.Windows.Markup</x:String>
+      <x:String>GlobalVariablesNamespace</x:String>
+      <x:String>GlobalConstantsNamespace</x:String>
+      <x:String>System.Linq.Expressions</x:String>
+      <x:String>System.Runtime.Serialization</x:String>
+    </sco:Collection>
+  </TextExpression.NamespacesForImplementation>
+  <TextExpression.ReferencesForImplementation>
+    <sco:Collection x:TypeArguments="AssemblyReference">
+      <AssemblyReference>Microsoft.CSharp</AssemblyReference>
+      <AssemblyReference>Microsoft.VisualBasic</AssemblyReference>
+      <AssemblyReference>mscorlib</AssemblyReference>
+      <AssemblyReference>System</AssemblyReference>
+      <AssemblyReference>System.Activities</AssemblyReference>
+      <AssemblyReference>System.ComponentModel.TypeConverter</AssemblyReference>
+      <AssemblyReference>System.Core</AssemblyReference>
+      <AssemblyReference>System.Data</AssemblyReference>
+      <AssemblyReference>System.Data.Common</AssemblyReference>
+      <AssemblyReference>System.Data.DataSetExtensions</AssemblyReference>
+      <AssemblyReference>System.Drawing</AssemblyReference>
+      <AssemblyReference>System.Drawing.Common</AssemblyReference>
+      <AssemblyReference>System.Drawing.Primitives</AssemblyReference>
+      <AssemblyReference>System.Linq</AssemblyReference>
+      <AssemblyReference>System.Net.Mail</AssemblyReference>
+      <AssemblyReference>System.ObjectModel</AssemblyReference>
+      <AssemblyReference>System.Private.CoreLib</AssemblyReference>
+      <AssemblyReference>System.Runtime.Serialization</AssemblyReference>
+      <AssemblyReference>System.ServiceModel</AssemblyReference>
+      <AssemblyReference>System.ServiceModel.Activities</AssemblyReference>
+      <AssemblyReference>System.Xaml</AssemblyReference>
+      <AssemblyReference>System.Xml</AssemblyReference>
+      <AssemblyReference>System.Xml.Linq</AssemblyReference>
+      <AssemblyReference>UiPath.System.Activities</AssemblyReference>
+      <AssemblyReference>UiPath.UiAutomation.Activities</AssemblyReference>
+      <AssemblyReference>UiPath.Studio.Constants</AssemblyReference>
+      <AssemblyReference>System.Console</AssemblyReference>
+      <AssemblyReference>System.Security.Permissions</AssemblyReference>
+      <AssemblyReference>System.Configuration.ConfigurationManager</AssemblyReference>
+      <AssemblyReference>System.ComponentModel</AssemblyReference>
+      <AssemblyReference>System.Memory</AssemblyReference>
+      <AssemblyReference>System.Private.Uri</AssemblyReference>
+      <AssemblyReference>System.Linq.Expressions</AssemblyReference>
+      <AssemblyReference>System.Runtime.Serialization.Formatters</AssemblyReference>
+      <AssemblyReference>System.Private.DataContractSerialization</AssemblyReference>
+      <AssemblyReference>System.Runtime.Serialization.Primitives</AssemblyReference>
+    </sco:Collection>
+  </TextExpression.ReferencesForImplementation>
+  <Sequence DisplayName="Main Sequence" sap:VirtualizedContainerService.HintSize="416,254.4" sap2010:WorkflowViewState.IdRef="Sequence_1">
+    <sap:WorkflowViewStateService.ViewState>
+      <scg:Dictionary x:TypeArguments="x:String, x:Object">
+        <x:Boolean x:Key="IsExpanded">True</x:Boolean>
+      </scg:Dictionary>
+    </sap:WorkflowViewStateService.ViewState>
+    <ui:LogMessage DisplayName="Log Message" sap:VirtualizedContainerService.HintSize="353.6,165.6" sap2010:WorkflowViewState.IdRef="LogMessage_1">
+      <ui:LogMessage.Message>
+        <InArgument x:TypeArguments="x:Object">
+          <CSharpValue x:TypeArguments="x:Object">"Hello World"</CSharpValue>
+        </InArgument>
+      </ui:LogMessage.Message>
+    </ui:LogMessage>
+  </Sequence>
+</Activity>
+`
+
+const DefaultGovernanceFile = `
+{
+  "product-name": "Development",
+  "policy-name": "Modern Policy - Development",
+  "data": {
+    "core-allow-edit": true,
+    "experimental-features-dictionary": {},
+    "telemetry-redirection-options": {
+      "instrumentation-keys": ""
+    },
+    "publish-source-control-info": null,
+    "enforce-checkin-before-publish": false,
+    "enforce-checkin-before-publish-allow-edit": true,
+    "enforce-repositories-config-allow-edit": true,
+    "enforce-repositories-config": {
+      "enforce-repositories-config-allow-save-local": null,
+      "enforce-repositories-config-allow-edit-repositories": null,
+      "enforce-repositories-config-repositories": [
+        {
+          "enforce-repositories-config-repository-default-folder": null,
+          "enforce-repositories-config-repository-name": null,
+          "enforce-repositories-config-repository-url": null,
+          "enforce-repositories-config-repository-source-control-type": "Git"
+        }
+      ]
+    },
+    "compiler-optimizations": false,
+    "compiler-optimizations-allow-edit": true,
+    "hide-starting-screen": false,
+    "feedback-enabled": true,
+    "require-user-publish-permitted-consecutive-runs": "",
+    "require-user-publish-dialog-message": null,
+    "require-user-publish-log-to-queue-queue-name": null,
+    "require-user-publish-log-to-queue-queue-folder": null,
+    "template-feeds": [
+      {
+        "template-feed-name": "GettingStarted",
+        "template-feed-is-enabled": true
+      },
+      {
+        "template-feed-name": "Official",
+        "template-feed-is-enabled": true
+      },
+      {
+        "template-feed-name": "Marketplace",
+        "template-feed-is-enabled": true
+      }
+    ],
+    "user-add-feeds": false,
+    "user-enable-feeds": false,
+    "append-orchestrator-feeds": true,
+    "preview-packages-enabled": null,
+    "preview-packages-enabled-allow-edit": true,
+    "default-package-source": [
+      {
+        "default-package-source-name": "nuget.org",
+        "default-package-source-source": "https://api.nuget.org/v3/index.json",
+        "is-enabled-default-package-source": true
+      }
+    ],
+    "send-ui-descriptors": false,
+    "send-ui-descriptors-allow-edit": false,
+    "create-docked-annotations": true,
+    "create-docked-annotations-allow-edit": true,
+    "enforce-analyzer-before-run": false,
+    "enforce-analyzer-before-run-allow-edit": true,
+    "use-smart-file-paths": true,
+    "use-smart-file-paths-allow-edit": true,
+    "enable-activity-online-recommendations": true,
+    "enable-activity-online-recommendations-allow-edit": true,
+    "enable-discovered-activities": true,
+    "enable-discovered-activities-allow-edit": true,
+    "enforce-release-notes": false,
+    "display-legacy-framework-deprecation": true,
+    "enforce-analyzer-before-publish": false,
+    "enforce-analyzer-before-publish-allow-edit": true,
+    "publish-applications-metadata": true,
+    "enforce-analyzer-before-push": false,
+    "enforce-analyzer-before-push-allow-edit": true,
+    "is-collapsed-view-slim": true,
+    "is-collapsed-view-slim-allow-edit": true,
+    "analyze-rpa-xamls-only": false,
+    "analyze-rpa-xamls-only-allow-edit": true,
+    "object-repository-enforced": false,
+    "object-repository-enforced-allow-edit": true,
+    "default-project-language": "VisualBasic",
+    "default-project-language-allow-edit": true,
+    "default-project-framework": "Modern",
+    "default-project-framework-allow-edit": true,
+    "allowed-project-frameworks": {
+      "Classic": false,
+      "Modern": true,
+      "CrossPlatform": true
+    },
+    "additional-analyzer-rule-path": null,
+    "additional-analyzer-rule-path-allow-edit": true,
+    "project-path": null,
+    "project-path-allow-edit": true,
+    "publish-process-url": null,
+    "publish-process-url-allow-edit": true,
+    "publish-library-url": null,
+    "publish-library-url-allow-edit": true,
+    "publish-templates-url": null,
+    "publish-templates-url-allow-edit": true,
+    "export-analyzer-results": false,
+    "export-analyzer-results-allow-edit": true,
+    "use-connection-service": false,
+    "use-connection-service-allow-edit": true,
+    "default-pip-type": "ChildSession",
+    "default-pip-type-allow-edit": true,
+    "show-data-manager-only": false,
+    "show-data-manager-only-allow-edit": true,
+    "show-properties-inline": false,
+    "show-properties-inline-allow-edit": true,
+    "allowed-publish-feeds": {
+      "Custom": true,
+      "PersonalWorkspace": true,
+      "TenantPackages": true,
+      "FolderPackages": true,
+      "HostLibraries": true,
+      "TenantLibraries": true,
+      "Local": true
+    },
+    "auto-generate-activity-outputs": true,
+    "auto-generate-activity-outputs-allow-edit": true,
+    "separate-runtime-dependencies": true,
+    "separate-runtime-dependencies-allow-edit": true,
+    "include-sources": true,
+    "include-sources-allow-edit": true,
+    "save-to-cloud-by-default": null,
+    "save-to-cloud-by-default-allow-edit": true,
+    "enable-generative-ai": false,
+    "activities-manager-allow-show-developer": true,
+    "activities-manager-hidden-activities": [],
+    "analyzer-allow-edit": false,
+    "referenced-rules-config-file": null,
+    "embedded-rules-config-rules": [
+      {
+        "code-embedded-rules-config-rules": "ST-ANA-006",
+        "is-enabled-embedded-rules-config-rules": true,
+        "default-action": "Error",
+        "parameters-embedded-rules-config-rules": []
+      },
+      {
+        "code-embedded-rules-config-rules": "ST-ANA-005",
+        "is-enabled-embedded-rules-config-rules": true,
+        "default-action": "Error",
+        "parameters-embedded-rules-config-rules": []
+      },
+      {
+        "code-embedded-rules-config-rules": "ST-USG-034",
+        "is-enabled-embedded-rules-config-rules": true,
+        "default-action": "Warning",
+        "parameters-embedded-rules-config-rules": []
+      },
+      {
+        "code-embedded-rules-config-rules": "ST-USG-032",
+        "is-enabled-embedded-rules-config-rules": true,
+        "default-action": "Error",
+        "parameters-embedded-rules-config-rules": [
+          {
+            "key-embedded-rules-config-rules": "RequiredTags",
+            "value-use-default-value-rules": true
+          }
+        ]
+      },
+      {
+        "code-embedded-rules-config-rules": "ST-USG-027",
+        "is-enabled-embedded-rules-config-rules": true,
+        "default-action": "Error",
+        "parameters-embedded-rules-config-rules": [
+          {
+            "key-embedded-rules-config-rules": "RequiredPackages",
+            "value-use-default-value-rules": true
+          }
+        ]
+      },
+      {
+        "code-embedded-rules-config-rules": "ST-USG-014",
+        "is-enabled-embedded-rules-config-rules": true,
+        "default-action": "Error",
+        "parameters-embedded-rules-config-rules": [
+          {
+            "key-embedded-rules-config-rules": "ProhibitedPackages",
+            "value-use-default-value-rules": true
+          },
+          {
+            "key-embedded-rules-config-rules": "AllowedPackages",
+            "value-use-default-value-rules": true
+          }
+        ]
+      },
+      {
+        "code-embedded-rules-config-rules": "TA-DBP-003",
+        "is-enabled-embedded-rules-config-rules": true,
+        "default-action": "Info",
+        "parameters-embedded-rules-config-rules": []
+      },
+      {
+        "code-embedded-rules-config-rules": "ST-SEC-008",
+        "is-enabled-embedded-rules-config-rules": true,
+        "default-action": "Error",
+        "parameters-embedded-rules-config-rules": [
+          {
+            "key-embedded-rules-config-rules": "VariableDepthUsage",
+            "value-use-default-value-rules": true
+          }
+        ]
+      },
+      {
+        "code-embedded-rules-config-rules": "ST-SEC-007",
+        "is-enabled-embedded-rules-config-rules": true,
+        "default-action": "Error",
+        "parameters-embedded-rules-config-rules": []
+      },
+      {
+        "code-embedded-rules-config-rules": "ST-SEC-009",
+        "is-enabled-embedded-rules-config-rules": true,
+        "default-action": "Error",
+        "parameters-embedded-rules-config-rules": [
+          {
+            "key-embedded-rules-config-rules": "Excluded",
+            "value-use-default-value-rules": true
+          }
+        ]
+      },
+      {
+        "code-embedded-rules-config-rules": "ST-PRR-004",
+        "is-enabled-embedded-rules-config-rules": true,
+        "default-action": "Warning",
+        "parameters-embedded-rules-config-rules": []
+      },
+      {
+        "code-embedded-rules-config-rules": "ST-USG-028",
+        "is-enabled-embedded-rules-config-rules": true,
+        "default-action": "Error",
+        "parameters-embedded-rules-config-rules": []
+      },
+      {
+        "code-embedded-rules-config-rules": "ST-USG-026",
+        "is-enabled-embedded-rules-config-rules": true,
+        "default-action": "Warning",
+        "parameters-embedded-rules-config-rules": [
+          {
+            "key-embedded-rules-config-rules": "ProhibitedActivities",
+            "value-use-default-value-rules": true
+          },
+          {
+            "key-embedded-rules-config-rules": "AllowedActivities",
+            "value-use-default-value-rules": true
+          }
+        ]
+      },
+      {
+        "code-embedded-rules-config-rules": "ST-USG-009",
+        "is-enabled-embedded-rules-config-rules": true,
+        "default-action": "Warning",
+        "parameters-embedded-rules-config-rules": []
+      },
+      {
+        "code-embedded-rules-config-rules": "ST-MRD-009",
+        "is-enabled-embedded-rules-config-rules": true,
+        "default-action": "Warning",
+        "parameters-embedded-rules-config-rules": [
+          {
+            "key-embedded-rules-config-rules": "Threshold",
+            "value-use-default-value-rules": true
+          }
+        ]
+      },
+      {
+        "code-embedded-rules-config-rules": "ST-MRD-011",
+        "is-enabled-embedded-rules-config-rules": true,
+        "default-action": "Warning",
+        "parameters-embedded-rules-config-rules": []
+      },
+      {
+        "code-embedded-rules-config-rules": "ST-MRD-005",
+        "is-enabled-embedded-rules-config-rules": true,
+        "default-action": "Warning",
+        "parameters-embedded-rules-config-rules": []
+      },
+      {
+        "code-embedded-rules-config-rules": "ST-MRD-008",
+        "is-enabled-embedded-rules-config-rules": true,
+        "default-action": "Warning",
+        "parameters-embedded-rules-config-rules": []
+      },
+      {
+        "code-embedded-rules-config-rules": "ST-MRD-004",
+        "is-enabled-embedded-rules-config-rules": true,
+        "default-action": "Warning",
+        "parameters-embedded-rules-config-rules": []
+      },
+      {
+        "code-embedded-rules-config-rules": "ST-MRD-007",
+        "is-enabled-embedded-rules-config-rules": true,
+        "default-action": "Warning",
+        "parameters-embedded-rules-config-rules": [
+          {
+            "key-embedded-rules-config-rules": "Threshold",
+            "value-use-default-value-rules": true
+          }
+        ]
+      },
+      {
+        "code-embedded-rules-config-rules": "ST-DBP-026",
+        "is-enabled-embedded-rules-config-rules": true,
+        "default-action": "Error",
+        "parameters-embedded-rules-config-rules": []
+      },
+      {
+        "code-embedded-rules-config-rules": "ST-DBP-024",
+        "is-enabled-embedded-rules-config-rules": true,
+        "default-action": "Error",
+        "parameters-embedded-rules-config-rules": []
+      },
+      {
+        "code-embedded-rules-config-rules": "ST-DBP-028",
+        "is-enabled-embedded-rules-config-rules": true,
+        "default-action": "Error",
+        "parameters-embedded-rules-config-rules": []
+      },
+      {
+        "code-embedded-rules-config-rules": "ST-DBP-025",
+        "is-enabled-embedded-rules-config-rules": true,
+        "default-action": "Error",
+        "parameters-embedded-rules-config-rules": []
+      },
+      {
+        "code-embedded-rules-config-rules": "ST-DBP-023",
+        "is-enabled-embedded-rules-config-rules": true,
+        "default-action": "Warning",
+        "parameters-embedded-rules-config-rules": []
+      },
+      {
+        "code-embedded-rules-config-rules": "ST-DBP-007",
+        "is-enabled-embedded-rules-config-rules": true,
+        "default-action": "Warning",
+        "parameters-embedded-rules-config-rules": [
+          {
+            "key-embedded-rules-config-rules": "LayersCount",
+            "value-use-default-value-rules": true
+          }
+        ]
+      },
+      {
+        "code-embedded-rules-config-rules": "ST-DBP-002",
+        "is-enabled-embedded-rules-config-rules": true,
+        "default-action": "Error",
+        "parameters-embedded-rules-config-rules": [
+          {
+            "key-embedded-rules-config-rules": "ArgumentsCount",
+            "value-use-default-value-rules": true
+          }
+        ]
+      },
+      {
+        "code-embedded-rules-config-rules": "ST-NMG-016",
+        "is-enabled-embedded-rules-config-rules": true,
+        "default-action": "Warning",
+        "parameters-embedded-rules-config-rules": [
+          {
+            "key-embedded-rules-config-rules": "Length",
+            "value-use-default-value-rules": true
+          }
+        ]
+      },
+      {
+        "code-embedded-rules-config-rules": "ST-NMG-006",
+        "is-enabled-embedded-rules-config-rules": true,
+        "default-action": "Warning",
+        "parameters-embedded-rules-config-rules": []
+      },
+      {
+        "code-embedded-rules-config-rules": "ST-NMG-012",
+        "is-enabled-embedded-rules-config-rules": false,
+        "default-action": "Warning",
+        "parameters-embedded-rules-config-rules": []
+      },
+      {
+        "code-embedded-rules-config-rules": "ST-NMG-011",
+        "is-enabled-embedded-rules-config-rules": true,
+        "default-action": "Warning",
+        "parameters-embedded-rules-config-rules": []
+      },
+      {
+        "code-embedded-rules-config-rules": "ST-NMG-002",
+        "is-enabled-embedded-rules-config-rules": true,
+        "default-action": "Warning",
+        "parameters-embedded-rules-config-rules": [
+          {
+            "key-embedded-rules-config-rules": "InRegex",
+            "value-use-default-value-rules": true
+          },
+          {
+            "key-embedded-rules-config-rules": "OutRegex",
+            "value-use-default-value-rules": true
+          },
+          {
+            "key-embedded-rules-config-rules": "InOutRegex",
+            "value-use-default-value-rules": true
+          }
+        ]
+      },
+      {
+        "code-embedded-rules-config-rules": "ST-NMG-005",
+        "is-enabled-embedded-rules-config-rules": true,
+        "default-action": "Warning",
+        "parameters-embedded-rules-config-rules": []
+      },
+      {
+        "code-embedded-rules-config-rules": "ST-NMG-004",
+        "is-enabled-embedded-rules-config-rules": true,
+        "default-action": "Warning",
+        "parameters-embedded-rules-config-rules": [
+          {
+            "key-embedded-rules-config-rules": "Threshold",
+            "value-use-default-value-rules": true
+          }
+        ]
+      },
+      {
+        "code-embedded-rules-config-rules": "ST-DBP-027",
+        "is-enabled-embedded-rules-config-rules": true,
+        "default-action": "Warning",
+        "parameters-embedded-rules-config-rules": []
+      },
+      {
+        "code-embedded-rules-config-rules": "ST-USG-020",
+        "is-enabled-embedded-rules-config-rules": true,
+        "default-action": "Warning",
+        "parameters-embedded-rules-config-rules": []
+      },
+      {
+        "code-embedded-rules-config-rules": "TA-DBP-007",
+        "is-enabled-embedded-rules-config-rules": true,
+        "default-action": "Warning",
+        "parameters-embedded-rules-config-rules": [
+          {
+            "key-embedded-rules-config-rules": "BranchesMaxCount",
+            "value-use-default-value-rules": true
+          }
+        ]
+      },
+      {
+        "code-embedded-rules-config-rules": "TA-DBP-006",
+        "is-enabled-embedded-rules-config-rules": true,
+        "default-action": "Warning",
+        "parameters-embedded-rules-config-rules": [
+          {
+            "key-embedded-rules-config-rules": "ActivitiesMaxCount",
+            "value-use-default-value-rules": true
+          }
+        ]
+      },
+      {
+        "code-embedded-rules-config-rules": "TA-NMG-002",
+        "is-enabled-embedded-rules-config-rules": true,
+        "default-action": "Warning",
+        "parameters-embedded-rules-config-rules": [
+          {
+            "key-embedded-rules-config-rules": "RegEx",
+            "value-use-default-value-rules": true
+          }
+        ]
+      },
+      {
+        "code-embedded-rules-config-rules": "TA-DBP-001",
+        "is-enabled-embedded-rules-config-rules": true,
+        "default-action": "Warning",
+        "parameters-embedded-rules-config-rules": [
+          {
+            "key-embedded-rules-config-rules": "VerificationsMinCount",
+            "value-use-default-value-rules": true
+          },
+          {
+            "key-embedded-rules-config-rules": "VerificationsMaxCount",
+            "value-use-default-value-rules": true
+          }
+        ]
+      },
+      {
+        "code-embedded-rules-config-rules": "TA-NMG-001",
+        "is-enabled-embedded-rules-config-rules": true,
+        "default-action": "Warning",
+        "parameters-embedded-rules-config-rules": []
+      },
+      {
+        "code-embedded-rules-config-rules": "ST-USG-010",
+        "is-enabled-embedded-rules-config-rules": true,
+        "default-action": "Warning",
+        "parameters-embedded-rules-config-rules": []
+      },
+      {
+        "code-embedded-rules-config-rules": "TA-DBP-004",
+        "is-enabled-embedded-rules-config-rules": true,
+        "default-action": "Warning",
+        "parameters-embedded-rules-config-rules": []
+      },
+      {
+        "code-embedded-rules-config-rules": "TA-DBP-002",
+        "is-enabled-embedded-rules-config-rules": true,
+        "default-action": "Warning",
+        "parameters-embedded-rules-config-rules": []
+      },
+      {
+        "code-embedded-rules-config-rules": "UI-PST-001",
+        "is-enabled-embedded-rules-config-rules": false,
+        "default-action": "Warning",
+        "parameters-embedded-rules-config-rules": [
+          {
+            "key-embedded-rules-config-rules": "logLevel",
+            "value-use-default-value-rules": true
+          }
+        ]
+      },
+      {
+        "code-embedded-rules-config-rules": "UI-ANA-016",
+        "is-enabled-embedded-rules-config-rules": true,
+        "default-action": "Info",
+        "parameters-embedded-rules-config-rules": []
+      },
+      {
+        "code-embedded-rules-config-rules": "UI-ANA-017",
+        "is-enabled-embedded-rules-config-rules": true,
+        "default-action": "Info",
+        "parameters-embedded-rules-config-rules": []
+      },
+      {
+        "code-embedded-rules-config-rules": "ST-MRD-017",
+        "is-enabled-embedded-rules-config-rules": true,
+        "default-action": "Warning",
+        "parameters-embedded-rules-config-rules": []
+      },
+      {
+        "code-embedded-rules-config-rules": "ST-REL-006",
+        "is-enabled-embedded-rules-config-rules": true,
+        "default-action": "Warning",
+        "parameters-embedded-rules-config-rules": []
+      },
+      {
+        "code-embedded-rules-config-rules": "ST-USG-005",
+        "is-enabled-embedded-rules-config-rules": true,
+        "default-action": "Warning",
+        "parameters-embedded-rules-config-rules": [
+          {
+            "key-embedded-rules-config-rules": "IncludeActivities",
+            "value-use-default-value-rules": true
+          },
+          {
+            "key-embedded-rules-config-rules": "ExcludeActivities",
+            "value-use-default-value-rules": true
+          },
+          {
+            "key-embedded-rules-config-rules": "IncludeProperties",
+            "value-use-default-value-rules": true
+          },
+          {
+            "key-embedded-rules-config-rules": "ExcludeProperties",
+            "value-use-default-value-rules": true
+          }
+        ]
+      },
+      {
+        "code-embedded-rules-config-rules": "ST-MRD-002",
+        "is-enabled-embedded-rules-config-rules": true,
+        "default-action": "Warning",
+        "parameters-embedded-rules-config-rules": []
+      },
+      {
+        "code-embedded-rules-config-rules": "ST-DBP-020",
+        "is-enabled-embedded-rules-config-rules": false,
+        "default-action": "Warning",
+        "parameters-embedded-rules-config-rules": [
+          {
+            "key-embedded-rules-config-rules": "Excluded",
+            "value-use-default-value-rules": true
+          }
+        ]
+      },
+      {
+        "code-embedded-rules-config-rules": "ST-DBP-003",
+        "is-enabled-embedded-rules-config-rules": true,
+        "default-action": "Error",
+        "parameters-embedded-rules-config-rules": []
+      },
+      {
+        "code-embedded-rules-config-rules": "ST-NMG-009",
+        "is-enabled-embedded-rules-config-rules": true,
+        "default-action": "Warning",
+        "parameters-embedded-rules-config-rules": []
+      },
+      {
+        "code-embedded-rules-config-rules": "ST-NMG-008",
+        "is-enabled-embedded-rules-config-rules": true,
+        "default-action": "Warning",
+        "parameters-embedded-rules-config-rules": [
+          {
+            "key-embedded-rules-config-rules": "Length",
+            "value-use-default-value-rules": true
+          }
+        ]
+      },
+      {
+        "code-embedded-rules-config-rules": "ST-NMG-001",
+        "is-enabled-embedded-rules-config-rules": true,
+        "default-action": "Warning",
+        "parameters-embedded-rules-config-rules": [
+          {
+            "key-embedded-rules-config-rules": "Regex",
+            "value-use-default-value-rules": true
+          }
+        ]
+      },
+      {
+        "code-embedded-rules-config-rules": "SY-USG-013",
+        "is-enabled-embedded-rules-config-rules": true,
+        "default-action": "Error",
+        "parameters-embedded-rules-config-rules": []
+      },
+      {
+        "code-embedded-rules-config-rules": "UI-USG-011",
+        "is-enabled-embedded-rules-config-rules": true,
+        "default-action": "Warning",
+        "parameters-embedded-rules-config-rules": [
+          {
+            "key-embedded-rules-config-rules": "nonAllowedAttributes",
+            "value-use-default-value-rules": true
+          }
+        ]
+      },
+      {
+        "code-embedded-rules-config-rules": "UX-SEC-010",
+        "is-enabled-embedded-rules-config-rules": true,
+        "default-action": "Warning",
+        "parameters-embedded-rules-config-rules": [
+          {
+            "key-embedded-rules-config-rules": "blacklistApps",
+            "value-use-default-value-rules": true
+          },
+          {
+            "key-embedded-rules-config-rules": "whitelistApps",
+            "value-use-default-value-rules": true
+          },
+          {
+            "key-embedded-rules-config-rules": "blacklistUrls",
+            "value-use-default-value-rules": true
+          },
+          {
+            "key-embedded-rules-config-rules": "whitelistUrls",
+            "value-use-default-value-rules": true
+          }
+        ]
+      },
+      {
+        "code-embedded-rules-config-rules": "UI-SEC-004",
+        "is-enabled-embedded-rules-config-rules": true,
+        "default-action": "Warning",
+        "parameters-embedded-rules-config-rules": []
+      },
+      {
+        "code-embedded-rules-config-rules": "UI-REL-001",
+        "is-enabled-embedded-rules-config-rules": true,
+        "default-action": "Error",
+        "parameters-embedded-rules-config-rules": [
+          {
+            "key-embedded-rules-config-rules": "idxValue",
+            "value-use-default-value-rules": true
+          }
+        ]
+      },
+      {
+        "code-embedded-rules-config-rules": "UI-PRR-004",
+        "is-enabled-embedded-rules-config-rules": true,
+        "default-action": "Warning",
+        "parameters-embedded-rules-config-rules": []
+      },
+      {
+        "code-embedded-rules-config-rules": "UX-DBP-029",
+        "is-enabled-embedded-rules-config-rules": true,
+        "default-action": "Warning",
+        "parameters-embedded-rules-config-rules": []
+      },
+      {
+        "code-embedded-rules-config-rules": "UI-DBP-030",
+        "is-enabled-embedded-rules-config-rules": false,
+        "default-action": "Error",
+        "parameters-embedded-rules-config-rules": []
+      },
+      {
+        "code-embedded-rules-config-rules": "UI-DBP-013",
+        "is-enabled-embedded-rules-config-rules": true,
+        "default-action": "Warning",
+        "parameters-embedded-rules-config-rules": []
+      },
+      {
+        "code-embedded-rules-config-rules": "UI-ANA-018",
+        "is-enabled-embedded-rules-config-rules": true,
+        "default-action": "Info",
+        "parameters-embedded-rules-config-rules": []
+      },
+      {
+        "code-embedded-rules-config-rules": "MA-DBP-028",
+        "is-enabled-embedded-rules-config-rules": true,
+        "default-action": "Warning",
+        "parameters-embedded-rules-config-rules": []
+      },
+      {
+        "code-embedded-rules-config-rules": "UI-SEC-010",
+        "is-enabled-embedded-rules-config-rules": true,
+        "default-action": "Warning",
+        "parameters-embedded-rules-config-rules": [
+          {
+            "key-embedded-rules-config-rules": "blacklistApps",
+            "value-use-default-value-rules": true
+          },
+          {
+            "key-embedded-rules-config-rules": "whitelistApps",
+            "value-use-default-value-rules": true
+          },
+          {
+            "key-embedded-rules-config-rules": "blacklistUrls",
+            "value-use-default-value-rules": true
+          },
+          {
+            "key-embedded-rules-config-rules": "whitelistUrls",
+            "value-use-default-value-rules": true
+          }
+        ]
+      },
+      {
+        "code-embedded-rules-config-rules": "ST-DBP-021",
+        "is-enabled-embedded-rules-config-rules": true,
+        "default-action": "Warning",
+        "parameters-embedded-rules-config-rules": []
+      },
+      {
+        "code-embedded-rules-config-rules": "UI-PRR-003",
+        "is-enabled-embedded-rules-config-rules": true,
+        "default-action": "Warning",
+        "parameters-embedded-rules-config-rules": []
+      },
+      {
+        "code-embedded-rules-config-rules": "UI-PRR-002",
+        "is-enabled-embedded-rules-config-rules": true,
+        "default-action": "Warning",
+        "parameters-embedded-rules-config-rules": []
+      },
+      {
+        "code-embedded-rules-config-rules": "UI-PRR-001",
+        "is-enabled-embedded-rules-config-rules": true,
+        "default-action": "Warning",
+        "parameters-embedded-rules-config-rules": []
+      },
+      {
+        "code-embedded-rules-config-rules": "XL-DBP-027",
+        "is-enabled-embedded-rules-config-rules": true,
+        "default-action": "Warning",
+        "parameters-embedded-rules-config-rules": []
+      },
+      {
+        "code-embedded-rules-config-rules": "SY-USG-014",
+        "is-enabled-embedded-rules-config-rules": true,
+        "default-action": "Error",
+        "parameters-embedded-rules-config-rules": []
+      },
+      {
+        "code-embedded-rules-config-rules": "UI-DBP-006",
+        "is-enabled-embedded-rules-config-rules": true,
+        "default-action": "Error",
+        "parameters-embedded-rules-config-rules": []
+      },
+      {
+        "code-embedded-rules-config-rules": "TA-DBP-005",
+        "is-enabled-embedded-rules-config-rules": true,
+        "default-action": "Warning",
+        "parameters-embedded-rules-config-rules": []
+      }
+    ],
+    "embedded-rules-config-counter": [
+      {
+        "code-embedded-rules-config-counter": "ST-ANA-003",
+        "is-enabled-embedded-rules-config-counter": true,
+        "parameters-embedded-rules-config-counter": []
+      },
+      {
+        "code-embedded-rules-config-counter": "ST-ANA-009",
+        "is-enabled-embedded-rules-config-counter": true,
+        "parameters-embedded-rules-config-counter": []
+      }
+    ]
+  }
+}
+`
+
+type ProjectBuilder struct {
+	t                     *testing.T
+	projectName           string
+	projectId             string
+	targetFramework       string
+	defaultGovernanceFile string
+}
+
+func (b ProjectBuilder) buildProjectJson() string {
+	return fmt.Sprintf(ProjectJsonTemplate, b.projectName, b.projectId, b.targetFramework)
+}
+
+func (b *ProjectBuilder) WithProjectName(name string) *ProjectBuilder {
+	b.projectName = name
+	return b
+}
+
+func (b *ProjectBuilder) WithDefaultGovernanceFile() *ProjectBuilder {
+	b.defaultGovernanceFile = DefaultGovernanceFile
+	return b
+}
+
+func (b ProjectBuilder) writeFileContent(directory string, fileName string, content string) {
+	err := os.WriteFile(filepath.Join(directory, fileName), []byte(content), 0600)
+	if err != nil {
+		b.t.Fatal(err)
+	}
+}
+
+func (b ProjectBuilder) Build() string {
+	directory := CreateDirectory(b.t)
+
+	projectJson := b.buildProjectJson()
+	b.writeFileContent(directory, "project.json", projectJson)
+	b.writeFileContent(directory, "Main.xaml", MainXaml)
+	if b.defaultGovernanceFile != "" {
+		b.writeFileContent(directory, "uipath.policy.default.json", b.defaultGovernanceFile)
+	}
+
+	return directory
+}
+
+func NewCrossPlatformProject(t *testing.T) *ProjectBuilder {
+	return &ProjectBuilder{
+		t,
+		"MyProcess",
+		"9011ee47-8dd4-4726-8850-299bd6ef057c",
+		"Portable",
+		"",
+	}
+}
+
+func NewWindowsProject(t *testing.T) *ProjectBuilder {
+	return &ProjectBuilder{
+		t,
+		"MyWindowsProcess",
+		"94c4c9c1-68c3-45d4-be14-d4427f17eddd",
+		"Windows",
+		"",
+	}
+}

--- a/test/setup.go
+++ b/test/setup.go
@@ -247,11 +247,20 @@ func RunCli(args []string, context Context) Result {
 	}
 }
 
-func createFile(t *testing.T) string {
-	return createFileInFolder(t, "")
+func CreateDirectory(t *testing.T) string {
+	tmp, err := os.MkdirTemp("", "uipath-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.RemoveAll(tmp) })
+	return tmp
 }
 
-func createFileInFolder(t *testing.T, path string) string {
+func CreateFile(t *testing.T) string {
+	return CreateFileInDirectory(t, "")
+}
+
+func CreateFileInDirectory(t *testing.T, path string) string {
 	if path != "" {
 		err := os.MkdirAll(path, 0700)
 		if err != nil {
@@ -272,9 +281,15 @@ func createFileInFolder(t *testing.T, path string) string {
 	return tempFile.Name()
 }
 
-func writeFile(t *testing.T, name string, data []byte) {
-	err := os.WriteFile(name, data, 0600)
+func CreateFileWithContent(t *testing.T, data string) string {
+	return CreateFileWithBinaryContent(t, []byte(data))
+}
+
+func CreateFileWithBinaryContent(t *testing.T, data []byte) string {
+	path := CreateFile(t)
+	err := os.WriteFile(path, data, 0600)
 	if err != nil {
-		t.Fatalf("Error writing file '%s': %v", name, err)
+		t.Fatalf("Error writing file '%s': %v", path, err)
 	}
+	return path
 }


### PR DESCRIPTION
Added `ProjectBuilder` to generate new UiPath Studio projects on every test case execution so that tests do not share any state and UiPath Studio projects can be easily customized.

Moved file operation methods into `setup.go` and reduced duplication across plugin tests.