### PR TITLE
Pass identity url when authenticating with external libraries

### DIFF
--- a/executor/plugin_executor.go
+++ b/executor/plugin_executor.go
@@ -71,6 +71,7 @@ func (e PluginExecutor) Call(ctx ExecutionContext, writer output.OutputWriter, l
 		ctx.Tenant,
 		ctx.BaseUri,
 		pluginAuth,
+		ctx.IdentityUri,
 		ctx.Input,
 		pluginParams,
 		ctx.Debug,

--- a/plugin/execution_context.go
+++ b/plugin/execution_context.go
@@ -12,6 +12,7 @@ type ExecutionContext struct {
 	Tenant       string
 	BaseUri      url.URL
 	Auth         AuthResult
+	IdentityUri  url.URL
 	Input        stream.Stream
 	Parameters   []ExecutionParameter
 	Debug        bool
@@ -23,9 +24,21 @@ func NewExecutionContext(
 	tenant string,
 	baseUri url.URL,
 	auth AuthResult,
+	identityUri url.URL,
 	input stream.Stream,
 	parameters []ExecutionParameter,
 	debug bool,
-	settings ExecutionSettings) *ExecutionContext {
-	return &ExecutionContext{organization, tenant, baseUri, auth, input, parameters, debug, settings}
+	settings ExecutionSettings,
+) *ExecutionContext {
+	return &ExecutionContext{
+		organization,
+		tenant,
+		baseUri,
+		auth,
+		identityUri,
+		input,
+		parameters,
+		debug,
+		settings,
+	}
 }

--- a/plugin/studio/package_pack_command.go
+++ b/plugin/studio/package_pack_command.go
@@ -58,6 +58,7 @@ func (c PackagePackCommand) Execute(ctx plugin.ExecutionContext, writer output.O
 		ctx.Tenant,
 		ctx.BaseUri,
 		ctx.Auth.Token,
+		ctx.IdentityUri,
 		source,
 		destination,
 		packageVersion,
@@ -152,6 +153,7 @@ func (c PackagePackCommand) preparePackArguments(params packagePackParams) []str
 		args = append(args, "--releaseNotes", params.ReleaseNotes)
 	}
 	if params.AuthToken != nil && params.Organization != "" {
+		args = append(args, "--libraryIdentityUrl", params.IdentityUri.String())
 		args = append(args, "--libraryOrchestratorUrl", params.BaseUri.String())
 		args = append(args, "--libraryOrchestratorAuthToken", params.AuthToken.Value)
 		args = append(args, "--libraryOrchestratorAccountName", params.Organization)

--- a/plugin/studio/package_pack_params.go
+++ b/plugin/studio/package_pack_params.go
@@ -11,6 +11,7 @@ type packagePackParams struct {
 	Tenant         string
 	BaseUri        url.URL
 	AuthToken      *auth.AuthToken
+	IdentityUri    url.URL
 	Source         string
 	Destination    string
 	PackageVersion string
@@ -25,12 +26,27 @@ func newPackagePackParams(
 	tenant string,
 	baseUri url.URL,
 	authToken *auth.AuthToken,
+	identityUri url.URL,
 	source string,
 	destination string,
 	packageVersion string,
 	autoVersion bool,
 	outputType string,
 	splitOutput bool,
-	releaseNotes string) *packagePackParams {
-	return &packagePackParams{organization, tenant, baseUri, authToken, source, destination, packageVersion, autoVersion, outputType, splitOutput, releaseNotes}
+	releaseNotes string,
+) *packagePackParams {
+	return &packagePackParams{
+		organization,
+		tenant,
+		baseUri,
+		authToken,
+		identityUri,
+		source,
+		destination,
+		packageVersion,
+		autoVersion,
+		outputType,
+		splitOutput,
+		releaseNotes,
+	}
 }

--- a/plugin/studio/package_restore_command.go
+++ b/plugin/studio/package_restore_command.go
@@ -41,6 +41,7 @@ func (c PackageRestoreCommand) Execute(ctx plugin.ExecutionContext, writer outpu
 		ctx.Tenant,
 		ctx.BaseUri,
 		ctx.Auth.Token,
+		ctx.IdentityUri,
 		source,
 		destination)
 
@@ -107,6 +108,7 @@ func (c PackageRestoreCommand) prepareRestoreArguments(params packageRestorePara
 	source, _ := strings.CutSuffix(params.Source, defaultProjectJson)
 	args := []string{"package", "restore", source, "--restoreFolder", params.Destination}
 	if params.AuthToken != nil && params.Organization != "" {
+		args = append(args, "--libraryIdentityUrl", params.IdentityUri.String())
 		args = append(args, "--libraryOrchestratorUrl", params.BaseUri.String())
 		args = append(args, "--libraryOrchestratorAuthToken", params.AuthToken.Value)
 		args = append(args, "--libraryOrchestratorAccountName", params.Organization)

--- a/plugin/studio/package_restore_params.go
+++ b/plugin/studio/package_restore_params.go
@@ -11,6 +11,7 @@ type packageRestoreParams struct {
 	Tenant       string
 	BaseUri      url.URL
 	AuthToken    *auth.AuthToken
+	IdentityUri  url.URL
 	Source       string
 	Destination  string
 }
@@ -20,7 +21,17 @@ func newPackageRestoreParams(
 	tenant string,
 	baseUri url.URL,
 	authToken *auth.AuthToken,
+	identityUri url.URL,
 	source string,
-	destination string) *packageRestoreParams {
-	return &packageRestoreParams{organization, tenant, baseUri, authToken, source, destination}
+	destination string,
+) *packageRestoreParams {
+	return &packageRestoreParams{
+		organization,
+		tenant,
+		baseUri,
+		authToken,
+		identityUri,
+		source,
+		destination,
+	}
 }

--- a/plugin/studio/studio_plugin_test.go
+++ b/plugin/studio/studio_plugin_test.go
@@ -213,10 +213,15 @@ profiles:
 	source := test.NewCrossPlatformProject(t).
 		Build()
 	destination := test.CreateDirectory(t)
-	test.RunCli([]string{"studio", "package", "pack", "--source", source, "--destination", destination}, context)
+	result := test.RunCli([]string{"studio", "package", "pack", "--source", source, "--destination", destination}, context)
+
+	identityUrl := getArgumentValue(commandArgs, "--libraryIdentityUrl")
+	if identityUrl != result.BaseUrl+"/identity_" {
+		t.Errorf("Expected identity url as argument, but got: %v", commandArgs)
+	}
 
 	orchestratorUrl := getArgumentValue(commandArgs, "--libraryOrchestratorUrl")
-	if !strings.HasPrefix(orchestratorUrl, "http") {
+	if orchestratorUrl != result.BaseUrl {
 		t.Errorf("Expected orchestrator url as argument, but got: %v", commandArgs)
 	}
 
@@ -260,10 +265,15 @@ profiles:
 	source := test.NewCrossPlatformProject(t).
 		Build()
 	destination := test.CreateDirectory(t)
-	test.RunCli([]string{"studio", "package", "pack", "--source", source, "--destination", destination}, context)
+	result := test.RunCli([]string{"studio", "package", "pack", "--source", source, "--destination", destination}, context)
+
+	identityUrl := getArgumentValue(commandArgs, "--libraryIdentityUrl")
+	if identityUrl != result.BaseUrl+"/identity_" {
+		t.Errorf("Expected identity url as argument, but got: %v", commandArgs)
+	}
 
 	orchestratorUrl := getArgumentValue(commandArgs, "--libraryOrchestratorUrl")
-	if !strings.HasPrefix(orchestratorUrl, "http") {
+	if orchestratorUrl != result.BaseUrl {
 		t.Errorf("Expected orchestrator url as argument, but got: %v", commandArgs)
 	}
 
@@ -1522,10 +1532,15 @@ profiles:
 
 	source := test.NewCrossPlatformProject(t).
 		Build()
-	test.RunCli([]string{"studio", "test", "run", "--source", source}, context)
+	result := test.RunCli([]string{"studio", "test", "run", "--source", source}, context)
+
+	identityUrl := getArgumentValue(commandArgs, "--libraryIdentityUrl")
+	if identityUrl != result.BaseUrl+"/identity_" {
+		t.Errorf("Expected identity url as argument, but got: %v", commandArgs)
+	}
 
 	orchestratorUrl := getArgumentValue(commandArgs, "--libraryOrchestratorUrl")
-	if !strings.HasPrefix(orchestratorUrl, "http") {
+	if orchestratorUrl != result.BaseUrl {
 		t.Errorf("Expected orchestrator url as argument, but got: %v", commandArgs)
 	}
 
@@ -1782,10 +1797,15 @@ profiles:
 	source := test.NewCrossPlatformProject(t).
 		Build()
 	destination := test.CreateDirectory(t)
-	test.RunCli([]string{"studio", "package", "restore", "--source", source, "--destination", destination}, context)
+	result := test.RunCli([]string{"studio", "package", "restore", "--source", source, "--destination", destination}, context)
+
+	identityUrl := getArgumentValue(commandArgs, "--libraryIdentityUrl")
+	if identityUrl != result.BaseUrl+"/identity_" {
+		t.Errorf("Expected identity url as argument, but got: %v", commandArgs)
+	}
 
 	orchestratorUrl := getArgumentValue(commandArgs, "--libraryOrchestratorUrl")
-	if !strings.HasPrefix(orchestratorUrl, "http") {
+	if orchestratorUrl != result.BaseUrl {
 		t.Errorf("Expected orchestrator url as argument, but got: %v", commandArgs)
 	}
 

--- a/plugin/studio/test_run_command.go
+++ b/plugin/studio/test_run_command.go
@@ -199,6 +199,7 @@ func (c TestRunCommand) execute(params testRunParams, ctx plugin.ExecutionContex
 		ctx.Tenant,
 		ctx.BaseUri,
 		ctx.Auth.Token,
+		ctx.IdentityUri,
 		params.Source,
 		params.Destination,
 		"",
@@ -303,6 +304,7 @@ func (c TestRunCommand) preparePackArguments(params packagePackParams) []string 
 		args = append(args, "--releaseNotes", params.ReleaseNotes)
 	}
 	if params.AuthToken != nil && params.Organization != "" {
+		args = append(args, "--libraryIdentityUrl", params.IdentityUri.String())
 		args = append(args, "--libraryOrchestratorUrl", params.BaseUri.String())
 		args = append(args, "--libraryOrchestratorAuthToken", params.AuthToken.Value)
 		args = append(args, "--libraryOrchestratorAccountName", params.Organization)


### PR DESCRIPTION
Passing the correct identity url when authenticating with an authenticated feed in UiPath Orchestrator.