### PR TITLE
Support authenticated library feeds when analyzing projects

### DIFF
--- a/plugin/studio/analyze/package_analyze_params.go
+++ b/plugin/studio/analyze/package_analyze_params.go
@@ -1,0 +1,43 @@
+package analyze
+
+import (
+	"net/url"
+
+	"github.com/UiPath/uipathcli/auth"
+)
+
+type packageAnalyzeParams struct {
+	Organization          string
+	Tenant                string
+	BaseUri               url.URL
+	AuthToken             *auth.AuthToken
+	IdentityUri           url.URL
+	Source                string
+	StopOnRuleViolation   bool
+	TreatWarningsAsErrors bool
+	GovernanceFile        string
+}
+
+func newPackageAnalyzeParams(
+	organization string,
+	tenant string,
+	baseUri url.URL,
+	authToken *auth.AuthToken,
+	identityUri url.URL,
+	source string,
+	stopOnRuleViolation bool,
+	treatWarningsAsErrors bool,
+	governanceFile string,
+) *packageAnalyzeParams {
+	return &packageAnalyzeParams{
+		organization,
+		tenant,
+		baseUri,
+		authToken,
+		identityUri,
+		source,
+		stopOnRuleViolation,
+		treatWarningsAsErrors,
+		governanceFile,
+	}
+}


### PR DESCRIPTION
Use the provided auth token from the configured identity client to authenticate with the connected Orchestrator when analyzing projects so that package dependencies can be retrieved from authenticated feeds.

Extended the `uipath studio package analyze` command to use the existing auth token for authentication with the Orchestrator feeds.