### PR TITLE
Add support for custom headers in plugins

### DIFF
--- a/auth/identity_client.go
+++ b/auth/identity_client.go
@@ -53,7 +53,7 @@ func (c identityClient) retrieveToken(baseUri url.URL, form url.Values, operatio
 	}
 	request := network.NewHttpPostRequest(uri.String(), nil, header, strings.NewReader(form.Encode()), -1)
 
-	clientSettings := network.NewHttpClientSettings(false, operationId, time.Duration(60)*time.Second, 3, insecure)
+	clientSettings := network.NewHttpClientSettings(false, operationId, map[string]string{}, time.Duration(60)*time.Second, 3, insecure)
 	client := network.NewHttpClient(nil, *clientSettings)
 	response, err := client.Send(request)
 	if err != nil {

--- a/commandline/command_builder.go
+++ b/commandline/command_builder.go
@@ -85,17 +85,7 @@ func (b CommandBuilder) createExecutionParameters(context *CommandExecContext, c
 			parameters = append(parameters, *parameter)
 		}
 	}
-	parameters = append(parameters, b.createExecutionParametersFromConfigMap(config.Header, parser.ParameterInHeader)...)
 	return parameters, nil
-}
-
-func (b CommandBuilder) createExecutionParametersFromConfigMap(params map[string]string, in string) executor.ExecutionParameters {
-	parameters := []executor.ExecutionParameter{}
-	for key, value := range params {
-		parameter := executor.NewExecutionParameter(key, value, in)
-		parameters = append(parameters, *parameter)
-	}
-	return parameters
 }
 
 func (b CommandBuilder) formatAllowedValues(values []interface{}) string {
@@ -204,10 +194,6 @@ func (b CommandBuilder) getValue(parameter parser.Parameter, context *CommandExe
 		return value
 	}
 	value = config.Parameter[parameter.Name]
-	if value != "" {
-		return value
-	}
-	value = config.Header[parameter.Name]
 	if value != "" {
 		return value
 	}
@@ -361,7 +347,7 @@ func (b CommandBuilder) createOperationCommand(operation parser.Operation) *Comm
 				*identityUri,
 				operation.Plugin,
 				debug,
-				*executor.NewExecutionSettings(operationId, timeout, maxAttempts, insecure),
+				*executor.NewExecutionSettings(operationId, config.Header, timeout, maxAttempts, insecure),
 			)
 
 			if wait != "" {

--- a/executor/execution_settings.go
+++ b/executor/execution_settings.go
@@ -7,6 +7,7 @@ import (
 // The ExecutionSettings provides global settings for executing commands.
 type ExecutionSettings struct {
 	OperationId string
+	Header      map[string]string
 	Timeout     time.Duration
 	MaxAttempts int
 	Insecure    bool
@@ -14,11 +15,13 @@ type ExecutionSettings struct {
 
 func NewExecutionSettings(
 	operationId string,
+	header map[string]string,
 	timeout time.Duration,
 	maxAttempts int,
 	insecure bool) *ExecutionSettings {
 	return &ExecutionSettings{
 		operationId,
+		header,
 		timeout,
 		maxAttempts,
 		insecure,

--- a/executor/http_executor.go
+++ b/executor/http_executor.go
@@ -273,6 +273,7 @@ func (e HttpExecutor) httpClientSettings(ctx ExecutionContext) network.HttpClien
 	return *network.NewHttpClientSettings(
 		ctx.Debug,
 		ctx.Settings.OperationId,
+		ctx.Settings.Header,
 		ctx.Settings.Timeout,
 		ctx.Settings.MaxAttempts,
 		ctx.Settings.Insecure)

--- a/executor/plugin_executor.go
+++ b/executor/plugin_executor.go
@@ -75,7 +75,7 @@ func (e PluginExecutor) Call(ctx ExecutionContext, writer output.OutputWriter, l
 		ctx.Input,
 		pluginParams,
 		ctx.Debug,
-		*plugin.NewExecutionSettings(ctx.Settings.OperationId, ctx.Settings.Timeout, ctx.Settings.MaxAttempts, ctx.Settings.Insecure))
+		*plugin.NewExecutionSettings(ctx.Settings.OperationId, ctx.Settings.Header, ctx.Settings.Timeout, ctx.Settings.MaxAttempts, ctx.Settings.Insecure))
 	return ctx.Plugin.Execute(*pluginContext, writer, logger)
 }
 

--- a/plugin/execution_settings.go
+++ b/plugin/execution_settings.go
@@ -7,6 +7,7 @@ import (
 // The ExecutionSettings provides global settings for executing commands.
 type ExecutionSettings struct {
 	OperationId string
+	Header      map[string]string
 	Timeout     time.Duration
 	MaxAttempts int
 	Insecure    bool
@@ -14,11 +15,13 @@ type ExecutionSettings struct {
 
 func NewExecutionSettings(
 	operationId string,
+	header map[string]string,
 	timeout time.Duration,
 	maxAttempts int,
 	insecure bool) *ExecutionSettings {
 	return &ExecutionSettings{
 		operationId,
+		header,
 		timeout,
 		maxAttempts,
 		insecure,

--- a/plugin/external_plugin.go
+++ b/plugin/external_plugin.go
@@ -92,7 +92,7 @@ func (p ExternalPlugin) download(name string, url string, destination string, pr
 	defer out.Close()
 
 	request := network.NewHttpGetRequest(url, nil, http.Header{})
-	clientSettings := network.NewHttpClientSettings(false, "", 0, 1, false)
+	clientSettings := network.NewHttpClientSettings(false, "", map[string]string{}, 0, 1, false)
 	client := network.NewHttpClient(nil, *clientSettings)
 	response, err := client.Send(request)
 	if err != nil {

--- a/plugin/orchestrator/download/download_command.go
+++ b/plugin/orchestrator/download/download_command.go
@@ -131,6 +131,7 @@ func (c DownloadCommand) httpClientSettings(ctx plugin.ExecutionContext) network
 	return *network.NewHttpClientSettings(
 		ctx.Debug,
 		ctx.Settings.OperationId,
+		ctx.Settings.Header,
 		ctx.Settings.Timeout,
 		ctx.Settings.MaxAttempts,
 		ctx.Settings.Insecure)

--- a/plugin/orchestrator/upload/upload_command.go
+++ b/plugin/orchestrator/upload/upload_command.go
@@ -180,6 +180,7 @@ func (c UploadCommand) httpClientSettings(ctx plugin.ExecutionContext) network.H
 	return *network.NewHttpClientSettings(
 		ctx.Debug,
 		ctx.Settings.OperationId,
+		ctx.Settings.Header,
 		ctx.Settings.Timeout,
 		ctx.Settings.MaxAttempts,
 		ctx.Settings.Insecure)

--- a/utils/api/du_client.go
+++ b/utils/api/du_client.go
@@ -144,6 +144,7 @@ func (c DuClient) httpClientSettings() network.HttpClientSettings {
 	return *network.NewHttpClientSettings(
 		c.debug,
 		c.settings.OperationId,
+		c.settings.Header,
 		c.settings.Timeout,
 		c.settings.MaxAttempts,
 		c.settings.Insecure)

--- a/utils/api/orchestrator_client.go
+++ b/utils/api/orchestrator_client.go
@@ -632,6 +632,7 @@ func (c OrchestratorClient) httpClientSettings() network.HttpClientSettings {
 	return *network.NewHttpClientSettings(
 		c.debug,
 		c.settings.OperationId,
+		c.settings.Header,
 		c.settings.Timeout,
 		c.settings.MaxAttempts,
 		c.settings.Insecure)

--- a/utils/network/http_client.go
+++ b/utils/network/http_client.go
@@ -98,6 +98,9 @@ func (c HttpClient) send(request *HttpRequest, ctx context.Context) (*HttpRespon
 			return
 		}
 		req.Header = request.Header
+		for k, v := range c.settings.Header {
+			req.Header.Set(k, v)
+		}
 		req.ContentLength = request.ContentLength
 
 		resp, err := client.Do(req)

--- a/utils/network/http_client_settings.go
+++ b/utils/network/http_client_settings.go
@@ -1,10 +1,13 @@
 package network
 
-import "time"
+import (
+	"time"
+)
 
 type HttpClientSettings struct {
 	Debug       bool
 	OperationId string
+	Header      map[string]string
 	Timeout     time.Duration
 	MaxAttempts int
 	Insecure    bool
@@ -13,12 +16,14 @@ type HttpClientSettings struct {
 func NewHttpClientSettings(
 	debug bool,
 	operationId string,
+	header map[string]string,
 	timeout time.Duration,
 	maxAttempts int,
 	insecure bool) *HttpClientSettings {
 	return &HttpClientSettings{
 		debug,
 		operationId,
+		header,
 		timeout,
 		maxAttempts,
 		insecure,


### PR DESCRIPTION
The custom config headers were only forwarded to the standard http executor but not to the plugins. Extended the execution settings to take the custom http headers from the config and set them on every outgoing request.