### PR TITLE
Extend test run command to specify custom UiPath Orchestrator folders

### DIFF
--- a/plugin/studio/testrun/test_run_params.go
+++ b/plugin/studio/testrun/test_run_params.go
@@ -15,6 +15,7 @@ type testRunParams struct {
 	Destination     string
 	Timeout         time.Duration
 	AttachRobotLogs bool
+	FolderId        int
 }
 
 func newTestRunParams(
@@ -24,6 +25,17 @@ func newTestRunParams(
 	source string,
 	destination string,
 	timeout time.Duration,
-	attachRobotLogs bool) *testRunParams {
-	return &testRunParams{executionId, uipcli, logger, source, destination, timeout, attachRobotLogs}
+	attachRobotLogs bool,
+	folderId int,
+) *testRunParams {
+	return &testRunParams{
+		executionId,
+		uipcli,
+		logger,
+		source,
+		destination,
+		timeout,
+		attachRobotLogs,
+		folderId,
+	}
 }


### PR DESCRIPTION
Added new parameter `--folder-id` to the test run command so that users can choose the UiPath Orchestrator folder for running the tests in.