### PR TITLE
Extend plugin paramters to support default value and allowed values

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -172,9 +172,11 @@ func (c CreateCommand) Execute(ctx plugin.ExecutionContext, writer output.Output
 func (c CreateCommand) Command() plugin.Command {
   return *plugin.NewCommand("myservice").
       WithOperation("create-product", "Create product", "Creates a new product in the store").
-      WithParameter("id", plugin.ParameterTypeInteger, "The product id", true).
-      WithParameter("name", plugin.ParameterTypeString, "The product name", true).
-      WithParameter("description", plugin.ParameterTypeString, "The product description", false)
+      WithParameter(plugin.NewParameter("id", plugin.ParameterTypeInteger, "The product id").
+          WithRequired(true)).
+      WithParameter(plugin.NewParameter("name", plugin.ParameterTypeString, "The product name").
+          WithRequired(true)).
+      WithParameter(plugin.NewParameter("description", plugin.ParameterTypeString, "The product description"))
 }
 ```
 

--- a/commandline/command_builder.go
+++ b/commandline/command_builder.go
@@ -112,7 +112,8 @@ func (b CommandBuilder) createFlags(parameters []parser.Parameter) []*FlagDefini
 		if parameter.IsArray() {
 			flagType = FlagTypeStringArray
 		}
-		flag := NewFlag(parameter.Name, formatter.Description(), flagType)
+		flag := NewFlag(parameter.Name, formatter.Description(), flagType).
+			WithHidden(parameter.Hidden)
 		flags = append(flags, flag)
 	}
 	return flags

--- a/commandline/definition_provider.go
+++ b/commandline/definition_provider.go
@@ -145,8 +145,9 @@ func (p DefinitionProvider) convertToParameters(parameters []plugin.CommandParam
 			parser.ParameterInCustom,
 			p.Name,
 			p.Required,
-			nil,
-			nil,
+			p.DefaultValue,
+			p.AllowedValues,
+			p.Hidden,
 			[]parser.Parameter{})
 		result = append(result, parameter)
 	}

--- a/commandline/show_command_handler.go
+++ b/commandline/show_command_handler.go
@@ -114,7 +114,9 @@ func (h showCommandHandler) convertFlagsToCommandParameters(flags []*FlagDefinit
 func (h showCommandHandler) convertParametersToCommandParameters(parameters []parser.Parameter) []parameterJson {
 	result := []parameterJson{}
 	for _, p := range parameters {
-		result = append(result, h.convertParameterToCommandParameter(p))
+		if !p.Hidden {
+			result = append(result, h.convertParameterToCommandParameter(p))
+		}
 	}
 	return result
 }

--- a/commandline/type_converter_test.go
+++ b/commandline/type_converter_test.go
@@ -225,5 +225,5 @@ func getArrayValue(result interface{}, key string, index int) interface{} {
 }
 
 func newParameter(name string, t string, parameters []parser.Parameter) parser.Parameter {
-	return *parser.NewParameter(name, t, "", "", name, false, nil, []interface{}{}, parameters)
+	return *parser.NewParameter(name, t, "", "", name, false, nil, []interface{}{}, false, parameters)
 }

--- a/parser/openapi_parser.go
+++ b/parser/openapi_parser.go
@@ -180,7 +180,7 @@ func (p OpenApiParser) parseSchema(fieldName string, schemaRef *openapi3.SchemaR
 		propertiesSchemas := p.getPropertiesSchemas(schemaRef.Value)
 		parameters = p.parseSchemas(propertiesSchemas, in, schemaRef.Value.Required, visitedSchemas)
 	}
-	return NewParameter(name, _type, description, in, fieldName, required, defaultValue, allowedValues, parameters)
+	return NewParameter(name, _type, description, in, fieldName, required, defaultValue, allowedValues, false, parameters)
 }
 
 func (p OpenApiParser) parseSchemas(schemas openapi3.Schemas, in string, requiredFieldnames []string, visitedSchemas map[*openapi3.SchemaRef]bool) []Parameter {
@@ -298,7 +298,7 @@ func (p OpenApiParser) parseParameter(param openapi3.Parameter) Parameter {
 		propertiesSchemas := p.getPropertiesSchemas(param.Schema.Value)
 		parameters = p.parseSchemas(propertiesSchemas, param.In, param.Schema.Value.Required, map[*openapi3.SchemaRef]bool{})
 	}
-	return *NewParameter(name, _type, param.Description, param.In, fieldName, required, defaultValue, allowedValues, parameters)
+	return *NewParameter(name, _type, param.Description, param.In, fieldName, required, defaultValue, allowedValues, false, parameters)
 }
 
 func (p OpenApiParser) parseParameters(params openapi3.Parameters) []Parameter {

--- a/parser/parameter.go
+++ b/parser/parameter.go
@@ -10,6 +10,7 @@ type Parameter struct {
 	Required      bool
 	DefaultValue  interface{}
 	AllowedValues []interface{}
+	Hidden        bool
 	Parameters    []Parameter
 }
 
@@ -44,6 +45,6 @@ func (p Parameter) IsArray() bool {
 		p.Type == ParameterTypeStringArray
 }
 
-func NewParameter(name string, t string, description string, in string, fieldName string, required bool, defaultValue interface{}, allowedValues []interface{}, parameters []Parameter) *Parameter {
-	return &Parameter{name, t, description, in, fieldName, required, defaultValue, allowedValues, parameters}
+func NewParameter(name string, t string, description string, in string, fieldName string, required bool, defaultValue interface{}, allowedValues []interface{}, hidden bool, parameters []Parameter) *Parameter {
+	return &Parameter{name, t, description, in, fieldName, required, defaultValue, allowedValues, hidden, parameters}
 }

--- a/plugin/command.go
+++ b/plugin/command.go
@@ -14,7 +14,7 @@ type Command struct {
 }
 
 func (c *Command) WithCategory(name string, summary string, description string) *Command {
-	c.Category = NewCommandCategory(name, summary, description)
+	c.Category = NewCategory(name, summary, description)
 	return c
 }
 
@@ -25,8 +25,7 @@ func (c *Command) WithOperation(name string, summary string, description string)
 	return c
 }
 
-func (c *Command) WithParameter(name string, type_ string, description string, required bool) *Command {
-	parameter := NewCommandParameter(name, type_, description, required)
+func (c *Command) WithParameter(parameter *CommandParameter) *Command {
 	c.Parameters = append(c.Parameters, *parameter)
 	return c
 }

--- a/plugin/command_category.go
+++ b/plugin/command_category.go
@@ -10,6 +10,6 @@ type CommandCategory struct {
 	Description string
 }
 
-func NewCommandCategory(name string, summary string, description string) *CommandCategory {
+func NewCategory(name string, summary string, description string) *CommandCategory {
 	return &CommandCategory{name, summary, description}
 }

--- a/plugin/command_parameter.go
+++ b/plugin/command_parameter.go
@@ -16,12 +16,35 @@ const (
 
 // CommandParameter defines the parameters the plugin command supports.
 type CommandParameter struct {
-	Name        string
-	Type        string
-	Description string
-	Required    bool
+	Name          string
+	Type          string
+	Description   string
+	Required      bool
+	DefaultValue  interface{}
+	AllowedValues []interface{}
+	Hidden        bool
 }
 
-func NewCommandParameter(name string, type_ string, description string, required bool) *CommandParameter {
-	return &CommandParameter{name, type_, description, required}
+func (p *CommandParameter) WithRequired(required bool) *CommandParameter {
+	p.Required = required
+	return p
+}
+
+func (p *CommandParameter) WithDefaultValue(value interface{}) *CommandParameter {
+	p.DefaultValue = value
+	return p
+}
+
+func (p *CommandParameter) WithAllowedValues(values []interface{}) *CommandParameter {
+	p.AllowedValues = values
+	return p
+}
+
+func (p *CommandParameter) WithHidden(hidden bool) *CommandParameter {
+	p.Hidden = hidden
+	return p
+}
+
+func NewParameter(name string, type_ string, description string) *CommandParameter {
+	return &CommandParameter{name, type_, description, false, nil, nil, false}
 }

--- a/plugin/orchestrator/download/download_command.go
+++ b/plugin/orchestrator/download/download_command.go
@@ -26,9 +26,12 @@ func (c DownloadCommand) Command() plugin.Command {
 	return *plugin.NewCommand("orchestrator").
 		WithCategory("buckets", "Orchestrator Buckets", "Buckets provide a per-folder storage solution for RPA developers to leverage in creating automation projects.").
 		WithOperation("download", "Download file", "Downloads the file with the given path from the bucket").
-		WithParameter("folder-id", plugin.ParameterTypeInteger, "Folder/OrganizationUnit Id", true).
-		WithParameter("key", plugin.ParameterTypeInteger, "The Bucket Id", true).
-		WithParameter("path", plugin.ParameterTypeString, "The BlobFile full path", true)
+		WithParameter(plugin.NewParameter("folder-id", plugin.ParameterTypeInteger, "Folder/OrganizationUnit Id").
+			WithRequired(true)).
+		WithParameter(plugin.NewParameter("key", plugin.ParameterTypeInteger, "The Bucket Id").
+			WithRequired(true)).
+		WithParameter(plugin.NewParameter("path", plugin.ParameterTypeString, "The BlobFile full path").
+			WithRequired(true))
 }
 
 func (c DownloadCommand) Execute(ctx plugin.ExecutionContext, writer output.OutputWriter, logger log.Logger) error {

--- a/plugin/orchestrator/upload/upload_command.go
+++ b/plugin/orchestrator/upload/upload_command.go
@@ -27,10 +27,14 @@ func (c UploadCommand) Command() plugin.Command {
 	return *plugin.NewCommand("orchestrator").
 		WithCategory("buckets", "Orchestrator Buckets", "Buckets provide a per-folder storage solution for RPA developers to leverage in creating automation projects.").
 		WithOperation("upload", "Upload file", "Uploads the provided file to the bucket").
-		WithParameter("folder-id", plugin.ParameterTypeInteger, "Folder/OrganizationUnit Id", true).
-		WithParameter("key", plugin.ParameterTypeInteger, "The Bucket Id", true).
-		WithParameter("path", plugin.ParameterTypeString, "The BlobFile full path", true).
-		WithParameter("file", plugin.ParameterTypeBinary, "The file to upload", true)
+		WithParameter(plugin.NewParameter("folder-id", plugin.ParameterTypeInteger, "Folder/OrganizationUnit Id").
+			WithRequired(true)).
+		WithParameter(plugin.NewParameter("key", plugin.ParameterTypeInteger, "The Bucket Id").
+			WithRequired(true)).
+		WithParameter(plugin.NewParameter("path", plugin.ParameterTypeString, "The BlobFile full path").
+			WithRequired(true)).
+		WithParameter(plugin.NewParameter("file", plugin.ParameterTypeBinary, "The file to upload").
+			WithRequired(true))
 }
 
 func (c UploadCommand) Execute(ctx plugin.ExecutionContext, writer output.OutputWriter, logger log.Logger) error {

--- a/plugin/studio/pack/package_pack_command_test.go
+++ b/plugin/studio/pack/package_pack_command_test.go
@@ -36,8 +36,9 @@ func TestPackInvalidOutputTypeShowsValidationError(t *testing.T) {
 	destination := t.TempDir()
 	result := test.RunCli([]string{"studio", "package", "pack", "--source", source, "--destination", destination, "--output-type", "unknown"}, context)
 
-	if !strings.Contains(result.StdErr, "Invalid output type 'unknown', allowed values: Process, Library, Tests, Objects") {
-		t.Errorf("Expected stderr to show output type is invalid, but got: %v", result.StdErr)
+	expected := "Argument value 'unknown' for --output-type is invalid, allowed values: Process, Library, Tests, Objects"
+	if !strings.Contains(result.StdErr, expected) {
+		t.Errorf("Expected stderr to show output type is invalid, got: %v", result.StdErr)
 	}
 }
 

--- a/plugin/studio/publish/package_publish_command.go
+++ b/plugin/studio/publish/package_publish_command.go
@@ -27,8 +27,10 @@ func (c PackagePublishCommand) Command() plugin.Command {
 	return *plugin.NewCommand("studio").
 		WithCategory("package", "Package", "UiPath Studio package-related actions").
 		WithOperation("publish", "Publish Package", "Publishes the package to orchestrator").
-		WithParameter("source", plugin.ParameterTypeString, "Path to package (default: .)", false).
-		WithParameter("folder-id", plugin.ParameterTypeInteger, "Folder/OrganizationUnit Id", false)
+		WithParameter(plugin.NewParameter("source", plugin.ParameterTypeString, "Path to package").
+			WithRequired(true).
+			WithDefaultValue(".")).
+		WithParameter(plugin.NewParameter("folder-id", plugin.ParameterTypeInteger, "Folder/OrganizationUnit Id"))
 }
 
 func (c PackagePublishCommand) Execute(ctx plugin.ExecutionContext, writer output.OutputWriter, logger log.Logger) error {
@@ -97,7 +99,7 @@ func (c PackagePublishCommand) publish(params packagePublishParams, logger log.L
 }
 
 func (c PackagePublishCommand) getSource(ctx plugin.ExecutionContext) (string, error) {
-	source := c.getParameter("source", ".", ctx.Parameters)
+	source := c.getStringParameter("source", ".", ctx.Parameters)
 	source, _ = filepath.Abs(source)
 	fileInfo, err := os.Stat(source)
 	if err != nil {
@@ -112,7 +114,7 @@ func (c PackagePublishCommand) getSource(ctx plugin.ExecutionContext) (string, e
 	return source, nil
 }
 
-func (c PackagePublishCommand) getParameter(name string, defaultValue string, parameters []plugin.ExecutionParameter) string {
+func (c PackagePublishCommand) getStringParameter(name string, defaultValue string, parameters []plugin.ExecutionParameter) string {
 	result := defaultValue
 	for _, p := range parameters {
 		if p.Name == name {

--- a/plugin/studio/publish/package_publish_command_test.go
+++ b/plugin/studio/publish/package_publish_command_test.go
@@ -217,6 +217,8 @@ func TestPublishWithDebugFlagOutputsRequestData(t *testing.T) {
 		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Folders", http.StatusOK, `{"value":[{"Id":938064,"FullyQualifiedName":"Shared"}]}`).
 		WithUrlResponse("/my-org/my-tenant/orchestrator_/api/PackageFeeds/GetFolderFeed?folderId=938064", http.StatusOK, `null`).
 		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Processes/UiPath.Server.Configuration.OData.UploadPackage", http.StatusOK, `{}`).
+		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Releases?$filter=ProcessKey%20eq%20'MyProcess'", http.StatusOK, `{"value":[]}`).
+		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Releases", http.StatusCreated, `{"name":"MyProcess","processKey":"MyProcess","processVersion":"1.0.195912597"}`).
 		WithCommandPlugin(NewPackagePublishCommand()).
 		Build()
 

--- a/plugin/studio/restore/package_restore_command.go
+++ b/plugin/studio/restore/package_restore_command.go
@@ -26,8 +26,12 @@ func (c PackageRestoreCommand) Command() plugin.Command {
 	return *plugin.NewCommand("studio").
 		WithCategory("package", "Package", "UiPath Studio package-related actions").
 		WithOperation("restore", "Package Project", "Restores the packages of the project").
-		WithParameter("source", plugin.ParameterTypeString, "Path to a project.json file or a folder containing project.json file (default: .)", false).
-		WithParameter("destination", plugin.ParameterTypeString, "The output folder (default ./packages)", false)
+		WithParameter(plugin.NewParameter("source", plugin.ParameterTypeString, "Path to a project.json file or a folder containing project.json file").
+			WithRequired(true).
+			WithDefaultValue(".")).
+		WithParameter(plugin.NewParameter("destination", plugin.ParameterTypeString, "The output folder").
+			WithRequired(true).
+			WithDefaultValue("./packages"))
 }
 
 func (c PackageRestoreCommand) Execute(ctx plugin.ExecutionContext, writer output.OutputWriter, logger log.Logger) error {
@@ -145,7 +149,7 @@ func (c PackageRestoreCommand) newProgressBar(logger log.Logger) chan struct{} {
 }
 
 func (c PackageRestoreCommand) getSource(ctx plugin.ExecutionContext) (string, error) {
-	source := c.getParameter("source", ".", ctx.Parameters)
+	source := c.getStringParameter("source", ".", ctx.Parameters)
 	source, _ = filepath.Abs(source)
 	fileInfo, err := os.Stat(source)
 	if err != nil {
@@ -158,12 +162,12 @@ func (c PackageRestoreCommand) getSource(ctx plugin.ExecutionContext) (string, e
 }
 
 func (c PackageRestoreCommand) getDestination(ctx plugin.ExecutionContext) string {
-	destination := c.getParameter("destination", "./packages/", ctx.Parameters)
+	destination := c.getStringParameter("destination", "./packages/", ctx.Parameters)
 	destination, _ = filepath.Abs(destination)
 	return destination
 }
 
-func (c PackageRestoreCommand) getParameter(name string, defaultValue string, parameters []plugin.ExecutionParameter) string {
+func (c PackageRestoreCommand) getStringParameter(name string, defaultValue string, parameters []plugin.ExecutionParameter) string {
 	result := defaultValue
 	for _, p := range parameters {
 		if p.Name == name {


### PR DESCRIPTION
The core command executor already supports default values and a list of allowed values for parameters. Extended the plugin parameters to support these features as well to reduce custom handling in the plugins themselves.

Changed the plugin command to use builder pattern for more complex parameter configurations.

Example:

```
*plugin.NewCommand("myplugin").
  WithOperation("get", "Get Data", "Gets data from the API").
  WithParameter(plugin.NewParameter("filter", plugin.ParameterTypeString, "This is a filter").
    WithDefaultValue("all").
    WithAllowedValues([]interface{}{"all", "default", "none"}))
```