### PR TITLE
Extend studio commands to support Orchestrator folder names

### DIFF
--- a/auth/oauth_authenticator_test.go
+++ b/auth/oauth_authenticator_test.go
@@ -55,7 +55,7 @@ func TestOAuthAuthenticatorInvalidConfig(t *testing.T) {
 
 func TestOAuthFlowIdentityFails(t *testing.T) {
 	identityServerFake := identityServerFake{
-		ResponseStatus: 400,
+		ResponseStatus: http.StatusBadRequest,
 		ResponseBody:   "Invalid token request",
 	}
 	identityBaseUrl := identityServerFake.Start(t)
@@ -72,7 +72,7 @@ func TestOAuthFlowIdentityFails(t *testing.T) {
 
 func TestOAuthFlowSuccessful(t *testing.T) {
 	identityServerFake := identityServerFake{
-		ResponseStatus: 200,
+		ResponseStatus: http.StatusOK,
 		ResponseBody:   `{"access_token": "my-access-token", "expires_in": 3600, "token_type": "Bearer", "scope": "OR.Users"}`,
 	}
 	identityBaseUrl := identityServerFake.Start(t)
@@ -95,7 +95,7 @@ func TestOAuthFlowSuccessful(t *testing.T) {
 
 func TestOAuthFlowIsCached(t *testing.T) {
 	identityServerFake := identityServerFake{
-		ResponseStatus: 200,
+		ResponseStatus: http.StatusOK,
 		ResponseBody:   `{"access_token": "my-access-token", "expires_in": 3600, "token_type": "Bearer", "scope": "OR.Users"}`,
 	}
 	identityBaseUrl := identityServerFake.Start(t)
@@ -121,7 +121,7 @@ func TestOAuthFlowIsCached(t *testing.T) {
 
 func TestProvidesCorrectPkceCodes(t *testing.T) {
 	identityFake := identityServerFake{
-		ResponseStatus: 200,
+		ResponseStatus: http.StatusOK,
 		ResponseBody:   `{"access_token": "my-access-token", "expires_in": 3600, "token_type": "Bearer", "scope": "OR.Users"}`,
 	}
 	identityUrl := identityFake.Start(t)
@@ -139,7 +139,7 @@ func TestProvidesCorrectPkceCodes(t *testing.T) {
 
 func TestShowsSuccessfullyLoggedInPage(t *testing.T) {
 	identityServerFake := identityServerFake{
-		ResponseStatus: 200,
+		ResponseStatus: http.StatusOK,
 		ResponseBody:   `{"access_token": "my-access-token", "expires_in": 3600, "token_type": "Bearer", "scope": "OR.Users"}`,
 	}
 	identityBaseUrl := identityServerFake.Start(t)

--- a/executor/http_executor.go
+++ b/executor/http_executor.go
@@ -123,7 +123,7 @@ func (e HttpExecutor) validateUri(uri string) (*url.URL, error) {
 }
 
 func (e HttpExecutor) formatUri(baseUri url.URL, route string, pathParameters []ExecutionParameter, queryParameters []ExecutionParameter) (*url.URL, error) {
-	uriBuilder := converter.NewUriBuilder(baseUri, route)
+	uriBuilder := converter.NewUriBuilder(baseUri.String(), route)
 	for _, parameter := range pathParameters {
 		uriBuilder.FormatPath(parameter.Name, parameter.Value)
 	}

--- a/log/debug_logger_test.go
+++ b/log/debug_logger_test.go
@@ -2,6 +2,7 @@ package log
 
 import (
 	"bytes"
+	"net/http"
 	"testing"
 )
 
@@ -46,7 +47,7 @@ func TestLogResponseDisplaysResponseDetails(t *testing.T) {
 	header := map[string][]string{
 		"x-request-id": {"my-request-id"},
 	}
-	logger.LogResponse(*NewResponseInfo(200, "200 OK", "HTTP/1.1", header, body))
+	logger.LogResponse(*NewResponseInfo(http.StatusOK, "200 OK", "HTTP/1.1", header, body))
 
 	expectedOutput := `HTTP/1.1 200 OK
 x-request-id: my-request-id

--- a/output/json_output_writer_test.go
+++ b/output/json_output_writer_test.go
@@ -2,6 +2,7 @@ package output
 
 import (
 	"bytes"
+	"net/http"
 	"testing"
 )
 
@@ -9,7 +10,7 @@ func TestJsonWriterOutputsErrorStatusWhenResponseIsFailure(t *testing.T) {
 	var output bytes.Buffer
 	writer := NewJsonOutputWriter(&output, NewDefaultTransformer())
 
-	err := writer.WriteResponse(*NewResponseInfo(400, "400 BadRequest", "HTTP/1.1", map[string][]string{}, bytes.NewReader([]byte{})))
+	err := writer.WriteResponse(*NewResponseInfo(http.StatusBadRequest, "400 BadRequest", "HTTP/1.1", map[string][]string{}, bytes.NewReader([]byte{})))
 
 	if err != nil {
 		t.Errorf("Writing response failed: %v", err)
@@ -23,7 +24,7 @@ func TestJsonWriterOutputsResponseBody(t *testing.T) {
 	output := bytes.NewBufferString(`{"hello":"world"}`)
 	writer := NewJsonOutputWriter(output, NewDefaultTransformer())
 
-	err := writer.WriteResponse(*NewResponseInfo(200, "200 OK", "HTTP/1.1", map[string][]string{}, output))
+	err := writer.WriteResponse(*NewResponseInfo(http.StatusOK, "200 OK", "HTTP/1.1", map[string][]string{}, output))
 
 	if err != nil {
 		t.Errorf("Writing response failed: %v", err)
@@ -40,7 +41,7 @@ func TestJsonWriterOutputsPlainBodyOnJsonParsingError(t *testing.T) {
 	output := bytes.NewBufferString(`{invalid}`)
 	writer := NewJsonOutputWriter(output, NewDefaultTransformer())
 
-	err := writer.WriteResponse(*NewResponseInfo(200, "200 OK", "HTTP/1.1", map[string][]string{}, output))
+	err := writer.WriteResponse(*NewResponseInfo(http.StatusOK, "200 OK", "HTTP/1.1", map[string][]string{}, output))
 
 	if err != nil {
 		t.Errorf("Writing response failed: %v", err)

--- a/output/text_output_writer_test.go
+++ b/output/text_output_writer_test.go
@@ -2,6 +2,7 @@ package output
 
 import (
 	"bytes"
+	"net/http"
 	"testing"
 )
 
@@ -9,7 +10,7 @@ func TestTextWriterOutputsErrorStatusWhenResponseIsFailure(t *testing.T) {
 	var output bytes.Buffer
 	writer := NewTextOutputWriter(&output, NewDefaultTransformer())
 
-	err := writer.WriteResponse(*NewResponseInfo(400, "400 BadRequest", "HTTP/1.1", map[string][]string{}, bytes.NewReader([]byte{})))
+	err := writer.WriteResponse(*NewResponseInfo(http.StatusBadRequest, "400 BadRequest", "HTTP/1.1", map[string][]string{}, bytes.NewReader([]byte{})))
 
 	if err != nil {
 		t.Errorf("Writing response failed: %v", err)
@@ -23,7 +24,7 @@ func TestTextWriterOutputsResponseBody(t *testing.T) {
 	output := bytes.NewBufferString(`{"hello":"world"}`)
 	writer := NewTextOutputWriter(output, NewDefaultTransformer())
 
-	err := writer.WriteResponse(*NewResponseInfo(200, "200 OK", "HTTP/1.1", map[string][]string{}, output))
+	err := writer.WriteResponse(*NewResponseInfo(http.StatusOK, "200 OK", "HTTP/1.1", map[string][]string{}, output))
 
 	if err != nil {
 		t.Errorf("Writing response failed: %v", err)
@@ -37,7 +38,7 @@ func TestTextWriterOutputsResponseBodySortedByKeys(t *testing.T) {
 	output := bytes.NewBufferString(`{"b":"world","a":"hello"}`)
 	writer := NewTextOutputWriter(output, NewDefaultTransformer())
 
-	err := writer.WriteResponse(*NewResponseInfo(200, "200 OK", "HTTP/1.1", map[string][]string{}, output))
+	err := writer.WriteResponse(*NewResponseInfo(http.StatusOK, "200 OK", "HTTP/1.1", map[string][]string{}, output))
 
 	if err != nil {
 		t.Errorf("Writing response failed: %v", err)
@@ -51,7 +52,7 @@ func TestTextWriterOutputsResponseBodyArray(t *testing.T) {
 	output := bytes.NewBufferString(`["hello","world"]`)
 	writer := NewTextOutputWriter(output, NewDefaultTransformer())
 
-	err := writer.WriteResponse(*NewResponseInfo(200, "200 OK", "HTTP/1.1", map[string][]string{}, output))
+	err := writer.WriteResponse(*NewResponseInfo(http.StatusOK, "200 OK", "HTTP/1.1", map[string][]string{}, output))
 
 	if err != nil {
 		t.Errorf("Writing response failed: %v", err)
@@ -65,7 +66,7 @@ func TestTextWriterOutputsResponseBodyObjectArray(t *testing.T) {
 	output := bytes.NewBufferString(`[{"a":"hello"},{"a":"world"}]`)
 	writer := NewTextOutputWriter(output, NewDefaultTransformer())
 
-	err := writer.WriteResponse(*NewResponseInfo(200, "200 OK", "HTTP/1.1", map[string][]string{}, output))
+	err := writer.WriteResponse(*NewResponseInfo(http.StatusOK, "200 OK", "HTTP/1.1", map[string][]string{}, output))
 
 	if err != nil {
 		t.Errorf("Writing response failed: %v", err)
@@ -79,7 +80,7 @@ func TestTextWriterOutputsResponseBodyObjectArrayDifferentKeys(t *testing.T) {
 	output := bytes.NewBufferString(`[{"b":"foo","a":"hello"},{"b":"bar"}]`)
 	writer := NewTextOutputWriter(output, NewDefaultTransformer())
 
-	err := writer.WriteResponse(*NewResponseInfo(200, "200 OK", "HTTP/1.1", map[string][]string{}, output))
+	err := writer.WriteResponse(*NewResponseInfo(http.StatusOK, "200 OK", "HTTP/1.1", map[string][]string{}, output))
 
 	if err != nil {
 		t.Errorf("Writing response failed: %v", err)
@@ -93,7 +94,7 @@ func TestTextWriterOutputsPlainBodyOnJsonParsingError(t *testing.T) {
 	output := bytes.NewBufferString(`{invalid}`)
 	writer := NewTextOutputWriter(output, NewDefaultTransformer())
 
-	err := writer.WriteResponse(*NewResponseInfo(200, "200 OK", "HTTP/1.1", map[string][]string{}, output))
+	err := writer.WriteResponse(*NewResponseInfo(http.StatusOK, "200 OK", "HTTP/1.1", map[string][]string{}, output))
 
 	if err != nil {
 		t.Errorf("Writing response failed: %v", err)

--- a/plugin/digitizer/digitize_command.go
+++ b/plugin/digitizer/digitize_command.go
@@ -3,6 +3,7 @@ package digitzer
 import (
 	"errors"
 	"fmt"
+	"net/http"
 	"net/url"
 	"strings"
 	"time"
@@ -82,7 +83,7 @@ func (c DigitizeCommand) waitForDigitization(documentId string, ctx plugin.Execu
 		return false, nil
 	}
 
-	err = writer.WriteResponse(*output.NewResponseInfo(200, "200 OK", "HTTP/1.1", map[string][]string{}, strings.NewReader(result)))
+	err = writer.WriteResponse(*output.NewResponseInfo(http.StatusOK, "200 OK", "HTTP/1.1", map[string][]string{}, strings.NewReader(result)))
 	return true, err
 }
 

--- a/plugin/digitizer/digitize_command_test.go
+++ b/plugin/digitizer/digitize_command_test.go
@@ -147,7 +147,7 @@ paths:
 		WithConfig(config).
 		WithCommandPlugin(NewDigitizeCommand()).
 		WithResponse(http.StatusAccepted, `{"documentId":"04908673-2b65-4647-8ab3-dde8a3aa7885"}`).
-		WithUrlResponse("/my-org/my-tenant/du_/api/framework/projects/1234/digitization/result/04908673-2b65-4647-8ab3-dde8a3aa7885?api-version=1", 400, `validation error`).
+		WithUrlResponse("/my-org/my-tenant/du_/api/framework/projects/1234/digitization/result/04908673-2b65-4647-8ab3-dde8a3aa7885?api-version=1", http.StatusBadRequest, `validation error`).
 		Build()
 
 	result := test.RunCli([]string{"du", "digitization", "digitize", "--project-id", "1234", "--file", path}, context)
@@ -188,7 +188,7 @@ paths:
 		WithConfig(config).
 		WithCommandPlugin(NewDigitizeCommand()).
 		WithResponse(http.StatusAccepted, `{"documentId":"648ea1c2-7dbe-42a8-b112-6474d07e61c1"}`).
-		WithUrlResponse("/my-org/my-tenant/du_/api/framework/projects/00000000-0000-0000-0000-000000000000/digitization/result/648ea1c2-7dbe-42a8-b112-6474d07e61c1?api-version=1", 200, `{"status":"Done"}`).
+		WithUrlResponse("/my-org/my-tenant/du_/api/framework/projects/00000000-0000-0000-0000-000000000000/digitization/result/648ea1c2-7dbe-42a8-b112-6474d07e61c1?api-version=1", http.StatusOK, `{"status":"Done"}`).
 		Build()
 
 	result := test.RunCli([]string{"du", "digitization", "digitize", "--file", path}, context)
@@ -233,7 +233,7 @@ paths:
 		WithConfig(config).
 		WithCommandPlugin(NewDigitizeCommand()).
 		WithResponse(http.StatusAccepted, `{"documentId":"eb80e441-05de-4a13-9aaa-f65b1babba05"}`).
-		WithUrlResponse("/my-org/my-tenant/du_/api/framework/projects/1234/digitization/result/eb80e441-05de-4a13-9aaa-f65b1babba05?api-version=1", 200, `{"status":"Done"}`).
+		WithUrlResponse("/my-org/my-tenant/du_/api/framework/projects/1234/digitization/result/eb80e441-05de-4a13-9aaa-f65b1babba05?api-version=1", http.StatusOK, `{"status":"Done"}`).
 		Build()
 
 	result := test.RunCli([]string{"du", "digitization", "digitize", "--project-id", "1234", "--file", path}, context)
@@ -268,7 +268,7 @@ paths:
 		WithConfig(config).
 		WithCommandPlugin(NewDigitizeCommand()).
 		WithResponse(http.StatusAccepted, `{"documentId":"eb80e441-05de-4a13-9aaa-f65b1babba05"}`).
-		WithUrlResponse("/my-org/my-tenant/du_/api/framework/projects/1234/digitization/result/eb80e441-05de-4a13-9aaa-f65b1babba05?api-version=1", 200, `{"pages":[],"status":"Done"}`).
+		WithUrlResponse("/my-org/my-tenant/du_/api/framework/projects/1234/digitization/result/eb80e441-05de-4a13-9aaa-f65b1babba05?api-version=1", http.StatusOK, `{"pages":[],"status":"Done"}`).
 		Build()
 
 	result := test.RunCli([]string{"du", "digitization", "digitize", "--project-id", "1234", "--file", path, "--debug"}, context)
@@ -310,7 +310,7 @@ paths:
 		WithCommandPlugin(NewDigitizeCommand()).
 		WithStdIn(stdIn).
 		WithResponse(http.StatusAccepted, `{"documentId":"eb80e441-05de-4a13-9aaa-f65b1babba05"}`).
-		WithUrlResponse("/my-org/my-tenant/du_/api/framework/projects/1234/digitization/result/eb80e441-05de-4a13-9aaa-f65b1babba05?api-version=1", 200, `{"status":"Done"}`).
+		WithUrlResponse("/my-org/my-tenant/du_/api/framework/projects/1234/digitization/result/eb80e441-05de-4a13-9aaa-f65b1babba05?api-version=1", http.StatusOK, `{"status":"Done"}`).
 		Build()
 
 	result := test.RunCli([]string{"du", "digitization", "digitize", "--project-id", "1234", "--content-type", "application/pdf", "--file", "-"}, context)
@@ -355,7 +355,7 @@ paths:
 		WithConfig(config).
 		WithCommandPlugin(NewDigitizeCommand()).
 		WithResponse(http.StatusAccepted, `{"documentId":"eb80e441-05de-4a13-9aaa-f65b1babba05"}`).
-		WithUrlResponse("/my-org/my-tenant/du_/api/framework/projects/1234/digitization/result/eb80e441-05de-4a13-9aaa-f65b1babba05?api-version=1", 200, `{"status":"Done"}`).
+		WithUrlResponse("/my-org/my-tenant/du_/api/framework/projects/1234/digitization/result/eb80e441-05de-4a13-9aaa-f65b1babba05?api-version=1", http.StatusOK, `{"status":"Done"}`).
 		Build()
 
 	result := test.RunCli([]string{"du", "digitization", "digitize", "--project-id", "1234", "--file", path}, context)
@@ -402,7 +402,7 @@ paths:
 		WithConfig(config).
 		WithCommandPlugin(NewDigitizeCommand()).
 		WithResponse(http.StatusAccepted, `{"documentId":"eb80e441-05de-4a13-9aaa-f65b1babba05"}`).
-		WithUrlResponse("/my-org/my-tenant/du_/api/framework/projects/1234/digitization/result/eb80e441-05de-4a13-9aaa-f65b1babba05?api-version=1", 200, `{"status":"Done"}`).
+		WithUrlResponse("/my-org/my-tenant/du_/api/framework/projects/1234/digitization/result/eb80e441-05de-4a13-9aaa-f65b1babba05?api-version=1", http.StatusOK, `{"status":"Done"}`).
 		Build()
 
 	result := test.RunCli([]string{"du", "digitization", "digitize", "--project-id", "1234", "--file", path}, context)

--- a/plugin/studio/analyze/package_analyze_command.go
+++ b/plugin/studio/analyze/package_analyze_command.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"math"
 	"math/big"
+	"net/http"
 	"os"
 	"path/filepath"
 	"time"
@@ -74,7 +75,7 @@ func (c PackageAnalyzeCommand) Execute(ctx plugin.ExecutionContext, writer outpu
 	if err != nil {
 		return fmt.Errorf("analyze command failed: %w", err)
 	}
-	err = writer.WriteResponse(*output.NewResponseInfo(200, "200 OK", "HTTP/1.1", map[string][]string{}, bytes.NewReader(json)))
+	err = writer.WriteResponse(*output.NewResponseInfo(http.StatusOK, "200 OK", "HTTP/1.1", map[string][]string{}, bytes.NewReader(json)))
 	if err != nil {
 		return err
 	}

--- a/plugin/studio/pack/package_pack_command.go
+++ b/plugin/studio/pack/package_pack_command.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"os"
 	"path/filepath"
 	"time"
@@ -73,7 +74,7 @@ func (c PackagePackCommand) Execute(ctx plugin.ExecutionContext, writer output.O
 	if err != nil {
 		return fmt.Errorf("pack command failed: %w", err)
 	}
-	return writer.WriteResponse(*output.NewResponseInfo(200, "200 OK", "HTTP/1.1", map[string][]string{}, bytes.NewReader(json)))
+	return writer.WriteResponse(*output.NewResponseInfo(http.StatusOK, "200 OK", "HTTP/1.1", map[string][]string{}, bytes.NewReader(json)))
 }
 
 func (c PackagePackCommand) execute(params packagePackParams, debug bool, logger log.Logger) (*packagePackResult, error) {

--- a/plugin/studio/publish/package_publish_command_test.go
+++ b/plugin/studio/publish/package_publish_command_test.go
@@ -72,10 +72,10 @@ func TestPublishReturnsPackageMetadata(t *testing.T) {
 	nupkgPath := createDefaultNupkgArchive(t)
 	context := test.NewContextBuilder().
 		WithDefinition("studio", studio.StudioDefinition).
-		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Folders", http.StatusOK, `{"value":[{"Id":938064,"FullyQualifiedName":"Shared"}]}`).
+		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Folders?$filter=FullyQualifiedName eq 'Shared'", http.StatusOK, `{"value":[{"Id":938064,"FullyQualifiedName":"Shared"}]}`).
 		WithUrlResponse("/my-org/my-tenant/orchestrator_/api/PackageFeeds/GetFolderFeed?folderId=938064", http.StatusOK, `null`).
 		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Processes/UiPath.Server.Configuration.OData.UploadPackage", http.StatusOK, `{}`).
-		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Releases?$filter=ProcessKey%20eq%20'MyProcess'", http.StatusOK, `{"value":[]}`).
+		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Releases?$filter=ProcessKey eq 'MyProcess'", http.StatusOK, `{"value":[]}`).
 		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Releases", http.StatusCreated, `{"name":"MyProcess","processKey":"MyProcess","processVersion":"1.0.195912597"}`).
 		WithCommandPlugin(NewPackagePublishCommand()).
 		Build()
@@ -107,7 +107,7 @@ func TestPublishUploadsPackageToOrchestrator(t *testing.T) {
 	nupkgPath := createDefaultNupkgArchive(t)
 	context := test.NewContextBuilder().
 		WithDefinition("studio", studio.StudioDefinition).
-		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Folders", http.StatusOK, `{"value":[{"Id":938064,"FullyQualifiedName":"Shared"}]}`).
+		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Folders?$filter=FullyQualifiedName eq 'Shared'", http.StatusOK, `{"value":[{"Id":938064,"FullyQualifiedName":"Shared"}]}`).
 		WithUrlResponse("/my-org/my-tenant/orchestrator_/api/PackageFeeds/GetFolderFeed?folderId=938064", http.StatusOK, `null`).
 		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Processes/UiPath.Server.Configuration.OData.UploadPackage", http.StatusInternalServerError, `{}`).
 		WithCommandPlugin(NewPackagePublishCommand()).
@@ -163,10 +163,10 @@ func TestPublishUploadsLatestPackageFromDirectory(t *testing.T) {
 
 	context := test.NewContextBuilder().
 		WithDefinition("studio", studio.StudioDefinition).
-		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Folders", http.StatusOK, `{"value":[{"Id":938064,"FullyQualifiedName":"Shared"}]}`).
+		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Folders?$filter=FullyQualifiedName eq 'Shared'", http.StatusOK, `{"value":[{"Id":938064,"FullyQualifiedName":"Shared"}]}`).
 		WithUrlResponse("/my-org/my-tenant/orchestrator_/api/PackageFeeds/GetFolderFeed?folderId=938064", http.StatusOK, `null`).
 		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Processes/UiPath.Server.Configuration.OData.UploadPackage", http.StatusOK, `{}`).
-		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Releases?$filter=ProcessKey%20eq%20'MyProcess'", http.StatusOK, `{"value":[]}`).
+		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Releases?$filter=ProcessKey eq 'MyProcess'", http.StatusOK, `{"value":[]}`).
 		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Releases", http.StatusCreated, `{"name":"MyProcess","processKey":"MyProcess","processVersion":"1.0.195912597"}`).
 		WithCommandPlugin(NewPackagePublishCommand()).
 		Build()
@@ -195,10 +195,10 @@ func TestPublishLargeFile(t *testing.T) {
 	nupkgPath := createLargeNupkgArchive(t, size)
 	context := test.NewContextBuilder().
 		WithDefinition("studio", studio.StudioDefinition).
-		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Folders", http.StatusOK, `{"value":[{"Id":938064,"FullyQualifiedName":"Shared"}]}`).
+		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Folders?$filter=FullyQualifiedName eq 'Shared'", http.StatusOK, `{"value":[{"Id":938064,"FullyQualifiedName":"Shared"}]}`).
 		WithUrlResponse("/my-org/my-tenant/orchestrator_/api/PackageFeeds/GetFolderFeed?folderId=938064", http.StatusOK, `null`).
 		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Processes/UiPath.Server.Configuration.OData.UploadPackage", http.StatusOK, `{}`).
-		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Releases?$filter=ProcessKey%20eq%20'MyProcess'", http.StatusOK, `{"value":[]}`).
+		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Releases?$filter=ProcessKey eq 'MyProcess'", http.StatusOK, `{"value":[]}`).
 		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Releases", http.StatusCreated, `{"name":"MyProcess","processKey":"MyProcess","processVersion":"1.0.195912597"}`).
 		WithCommandPlugin(NewPackagePublishCommand()).
 		Build()
@@ -214,10 +214,10 @@ func TestPublishWithDebugFlagOutputsRequestData(t *testing.T) {
 	nupkgPath := createDefaultNupkgArchive(t)
 	context := test.NewContextBuilder().
 		WithDefinition("studio", studio.StudioDefinition).
-		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Folders", http.StatusOK, `{"value":[{"Id":938064,"FullyQualifiedName":"Shared"}]}`).
+		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Folders?$filter=FullyQualifiedName eq 'Shared'", http.StatusOK, `{"value":[{"Id":938064,"FullyQualifiedName":"Shared"}]}`).
 		WithUrlResponse("/my-org/my-tenant/orchestrator_/api/PackageFeeds/GetFolderFeed?folderId=938064", http.StatusOK, `null`).
 		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Processes/UiPath.Server.Configuration.OData.UploadPackage", http.StatusOK, `{}`).
-		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Releases?$filter=ProcessKey%20eq%20'MyProcess'", http.StatusOK, `{"value":[]}`).
+		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Releases?$filter=ProcessKey eq 'MyProcess'", http.StatusOK, `{"value":[]}`).
 		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Releases", http.StatusCreated, `{"name":"MyProcess","processKey":"MyProcess","processVersion":"1.0.195912597"}`).
 		WithCommandPlugin(NewPackagePublishCommand()).
 		Build()
@@ -233,7 +233,7 @@ func TestPublishPackageAlreadyExistsReturnsFailed(t *testing.T) {
 	nupkgPath := createNupkgArchive(t, *studio.NewNuspec("MyProcess", "My Process", "2.0.0"))
 	context := test.NewContextBuilder().
 		WithDefinition("studio", studio.StudioDefinition).
-		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Folders", http.StatusOK, `{"value":[{"Id":938064,"FullyQualifiedName":"Shared"}]}`).
+		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Folders?$filter=FullyQualifiedName eq 'Shared'", http.StatusOK, `{"value":[{"Id":938064,"FullyQualifiedName":"Shared"}]}`).
 		WithUrlResponse("/my-org/my-tenant/orchestrator_/api/PackageFeeds/GetFolderFeed?folderId=938064", http.StatusOK, `null`).
 		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Processes/UiPath.Server.Configuration.OData.UploadPackage", http.StatusConflict, `{}`).
 		WithCommandPlugin(NewPackagePublishCommand()).
@@ -283,12 +283,13 @@ func TestPublishUsesProvidedFolderId(t *testing.T) {
 	header := map[string]string{}
 	context := test.NewContextBuilder().
 		WithDefinition("studio", studio.StudioDefinition).
+		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Folders?$filter=FullyQualifiedName eq '12345' or Id eq 12345", http.StatusOK, `{"value":[{"Id":12345,"FullyQualifiedName":"MyFolder"}]}`).
 		WithUrlResponse("/my-org/my-tenant/orchestrator_/api/PackageFeeds/GetFolderFeed?folderId=12345", http.StatusOK, `null`).
 		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Processes/UiPath.Server.Configuration.OData.UploadPackage", http.StatusOK, `{}`).
-		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Releases?$filter=ProcessKey%20eq%20'MyProcess'", http.StatusOK, `{"value":[]}`).
+		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Releases?$filter=ProcessKey eq 'MyProcess'", http.StatusOK, `{"value":[]}`).
 		WithResponseHandler(func(request test.RequestData) test.ResponseData {
 			header = request.Header
-			return test.ResponseData{Status: 200, Body: ""}
+			return test.ResponseData{Status: http.StatusOK, Body: ""}
 		}).
 		WithCommandPlugin(NewPackagePublishCommand()).
 		Build()
@@ -301,17 +302,42 @@ func TestPublishUsesProvidedFolderId(t *testing.T) {
 	}
 }
 
+func TestPublishUsesProvidedFolder(t *testing.T) {
+	nupkgPath := createDefaultNupkgArchive(t)
+	header := map[string]string{}
+	context := test.NewContextBuilder().
+		WithDefinition("studio", studio.StudioDefinition).
+		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Folders?$filter=FullyQualifiedName eq 'MyFolder'", http.StatusOK, `{"value":[{"Id":12345,"FullyQualifiedName":"MyFolder"}]}`).
+		WithUrlResponse("/my-org/my-tenant/orchestrator_/api/PackageFeeds/GetFolderFeed?folderId=12345", http.StatusOK, `null`).
+		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Processes/UiPath.Server.Configuration.OData.UploadPackage", http.StatusOK, `{}`).
+		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Releases?$filter=ProcessKey eq 'MyProcess'", http.StatusOK, `{"value":[]}`).
+		WithResponseHandler(func(request test.RequestData) test.ResponseData {
+			header = request.Header
+			return test.ResponseData{Status: http.StatusOK, Body: ""}
+		}).
+		WithCommandPlugin(NewPackagePublishCommand()).
+		Build()
+
+	test.RunCli([]string{"studio", "package", "publish", "--organization", "my-org", "--tenant", "my-tenant", "--source", nupkgPath, "--folder", "MyFolder"}, context)
+
+	folderId := header["x-uipath-organizationunitid"]
+	if folderId != "12345" {
+		t.Errorf("Expected x-uipath-organizationunitid header from argument, but got: '%s'", folderId)
+	}
+}
+
 func TestPublishUsesFolderFeedWhenAvailable(t *testing.T) {
 	nupkgPath := createDefaultNupkgArchive(t)
 	header := map[string]string{}
 	context := test.NewContextBuilder().
 		WithDefinition("studio", studio.StudioDefinition).
+		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Folders?$filter=FullyQualifiedName eq '12345' or Id eq 12345", http.StatusOK, `{"value":[{"Id":12345,"FullyQualifiedName":"MyFolder"}]}`).
 		WithUrlResponse("/my-org/my-tenant/orchestrator_/api/PackageFeeds/GetFolderFeed?folderId=12345", http.StatusOK, `8e00fda5-6124-43ca-b8c8-5d812589e567`).
 		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Processes/UiPath.Server.Configuration.OData.UploadPackage?feedId=8e00fda5-6124-43ca-b8c8-5d812589e567", http.StatusOK, `{}`).
-		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Releases?$filter=ProcessKey%20eq%20'MyProcess'", http.StatusOK, `{"value":[]}`).
+		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Releases?$filter=ProcessKey eq 'MyProcess'", http.StatusOK, `{"value":[]}`).
 		WithResponseHandler(func(request test.RequestData) test.ResponseData {
 			header = request.Header
-			return test.ResponseData{Status: 200, Body: ""}
+			return test.ResponseData{Status: http.StatusOK, Body: ""}
 		}).
 		WithCommandPlugin(NewPackagePublishCommand()).
 		Build()

--- a/plugin/studio/publish/package_publish_params.go
+++ b/plugin/studio/publish/package_publish_params.go
@@ -4,7 +4,7 @@ import "github.com/UiPath/uipathcli/plugin"
 
 type packagePublishParams struct {
 	Source      string
-	FolderId    int
+	Folder      string
 	Name        string
 	Description string
 	Version     string
@@ -16,7 +16,7 @@ type packagePublishParams struct {
 
 func newPackagePublishParams(
 	source string,
-	folderId int,
+	folder string,
 	name string,
 	description string,
 	version string,
@@ -24,5 +24,5 @@ func newPackagePublishParams(
 	auth plugin.AuthResult,
 	debug bool,
 	settings plugin.ExecutionSettings) *packagePublishParams {
-	return &packagePublishParams{source, folderId, name, description, version, baseUri, auth, debug, settings}
+	return &packagePublishParams{source, folder, name, description, version, baseUri, auth, debug, settings}
 }

--- a/plugin/studio/restore/package_restore_command.go
+++ b/plugin/studio/restore/package_restore_command.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -59,7 +60,7 @@ func (c PackageRestoreCommand) Execute(ctx plugin.ExecutionContext, writer outpu
 	if err != nil {
 		return fmt.Errorf("restore command failed: %w", err)
 	}
-	return writer.WriteResponse(*output.NewResponseInfo(200, "200 OK", "HTTP/1.1", map[string][]string{}, bytes.NewReader(json)))
+	return writer.WriteResponse(*output.NewResponseInfo(http.StatusOK, "200 OK", "HTTP/1.1", map[string][]string{}, bytes.NewReader(json)))
 }
 
 func (c PackageRestoreCommand) execute(params packageRestoreParams, debug bool, logger log.Logger) (*packageRestoreResult, error) {

--- a/plugin/studio/testrun/test_run_command_test.go
+++ b/plugin/studio/testrun/test_run_command_test.go
@@ -30,10 +30,10 @@ func TestRunPassed(t *testing.T) {
 	context := test.NewContextBuilder().
 		WithDefinition("studio", studio.StudioDefinition).
 		WithCommandPlugin(NewTestRunCommand()).
-		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Folders", http.StatusOK, `{"value":[{"Id":938064,"FullyQualifiedName":"Shared"}]}`).
+		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Folders?$filter=FullyQualifiedName eq 'Shared'", http.StatusOK, `{"value":[{"Id":938064,"FullyQualifiedName":"Shared"}]}`).
 		WithUrlResponse("/my-org/my-tenant/orchestrator_/api/PackageFeeds/GetFolderFeed?folderId=938064", http.StatusOK, `null`).
 		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Processes/UiPath.Server.Configuration.OData.UploadPackage", http.StatusOK, `{}`).
-		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Releases?$filter=ProcessKey%20eq%20'MyProcess_Tests'", http.StatusOK, `{"value":[]}`).
+		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Releases?$filter=ProcessKey eq 'MyProcess_Tests'", http.StatusOK, `{"value":[]}`).
 		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Releases", http.StatusCreated, `{"name":"MyProcess_Tests","processKey":"MyProcess_Tests","processVersion":"1.0.195912597"}`).
 		WithUrlResponse("/my-org/my-tenant/orchestrator_/api/TestAutomation/CreateTestSetForReleaseVersion", http.StatusCreated, "25819").
 		WithUrlResponse("/my-org/my-tenant/orchestrator_/api/TestAutomation/StartTestSetExecution?testSetId=25819&triggerType=ExternalTool", http.StatusOK, "349562").
@@ -135,10 +135,10 @@ func TestRunFailed(t *testing.T) {
 	context := test.NewContextBuilder().
 		WithDefinition("studio", studio.StudioDefinition).
 		WithCommandPlugin(TestRunCommand{exec}).
-		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Folders", http.StatusOK, `{"value":[{"Id":938064,"FullyQualifiedName":"Shared"}]}`).
+		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Folders?$filter=FullyQualifiedName eq 'Shared'", http.StatusOK, `{"value":[{"Id":938064,"FullyQualifiedName":"Shared"}]}`).
 		WithUrlResponse("/my-org/my-tenant/orchestrator_/api/PackageFeeds/GetFolderFeed?folderId=938064", http.StatusOK, `null`).
 		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Processes/UiPath.Server.Configuration.OData.UploadPackage", http.StatusOK, `{}`).
-		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Releases?$filter=ProcessKey%20eq%20'MyLibrary'", http.StatusOK, `{"value":[]}`).
+		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Releases?$filter=ProcessKey eq 'MyLibrary'", http.StatusOK, `{"value":[]}`).
 		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Releases", http.StatusCreated, `{"name":"MyLibrary","processKey":"MyLibrary","processVersion":"1.0.195912597"}`).
 		WithUrlResponse("/my-org/my-tenant/orchestrator_/api/TestAutomation/CreateTestSetForReleaseVersion", http.StatusCreated, "29991").
 		WithUrlResponse("/my-org/my-tenant/orchestrator_/api/TestAutomation/StartTestSetExecution?testSetId=29991&triggerType=ExternalTool", http.StatusOK, "349001").
@@ -258,10 +258,10 @@ func TestRunGeneratesJUnitReport(t *testing.T) {
 	context := test.NewContextBuilder().
 		WithDefinition("studio", studio.StudioDefinition).
 		WithCommandPlugin(TestRunCommand{exec}).
-		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Folders", http.StatusOK, `{"value":[{"Id":938064,"FullyQualifiedName":"Shared"}]}`).
+		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Folders?$filter=FullyQualifiedName eq 'Shared'", http.StatusOK, `{"value":[{"Id":938064,"FullyQualifiedName":"Shared"}]}`).
 		WithUrlResponse("/my-org/my-tenant/orchestrator_/api/PackageFeeds/GetFolderFeed?folderId=938064", http.StatusOK, `null`).
 		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Processes/UiPath.Server.Configuration.OData.UploadPackage", http.StatusOK, `{}`).
-		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Releases?$filter=ProcessKey%20eq%20'MyLibrary'", http.StatusOK, `{"value":[{"id":12345,"name":"MyLibrary"}]}`).
+		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Releases?$filter=ProcessKey eq 'MyLibrary'", http.StatusOK, `{"value":[{"id":12345,"name":"MyLibrary"}]}`).
 		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Releases(12345)", http.StatusOK, `{"name":"MyLibrary","processKey":"MyLibrary","processVersion":"1.0.195912597"}`).
 		WithUrlResponse("/my-org/my-tenant/orchestrator_/api/TestAutomation/CreateTestSetForReleaseVersion", http.StatusCreated, "29991").
 		WithUrlResponse("/my-org/my-tenant/orchestrator_/api/TestAutomation/StartTestSetExecution?testSetId=29991&triggerType=ExternalTool", http.StatusOK, "349001").
@@ -323,10 +323,10 @@ func TestRunAttachesRobotLogs(t *testing.T) {
 	context := test.NewContextBuilder().
 		WithDefinition("studio", studio.StudioDefinition).
 		WithCommandPlugin(TestRunCommand{exec}).
-		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Folders", http.StatusOK, `{"value":[{"Id":938064,"FullyQualifiedName":"Shared"}]}`).
+		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Folders?$filter=FullyQualifiedName eq 'Shared'", http.StatusOK, `{"value":[{"Id":938064,"FullyQualifiedName":"Shared"}]}`).
 		WithUrlResponse("/my-org/my-tenant/orchestrator_/api/PackageFeeds/GetFolderFeed?folderId=938064", http.StatusOK, `null`).
 		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Processes/UiPath.Server.Configuration.OData.UploadPackage", http.StatusOK, `{}`).
-		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Releases?$filter=ProcessKey%20eq%20'MyLibrary'", http.StatusOK, `{"value":[{"id":12345,"name":"MyLibrary"}]}`).
+		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Releases?$filter=ProcessKey eq 'MyLibrary'", http.StatusOK, `{"value":[{"id":12345,"name":"MyLibrary"}]}`).
 		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Releases(12345)", http.StatusOK, `{"name":"MyLibrary","processKey":"MyLibrary","processVersion":"1.0.195912597"}`).
 		WithUrlResponse("/my-org/my-tenant/orchestrator_/api/TestAutomation/CreateTestSetForReleaseVersion", http.StatusCreated, "29991").
 		WithUrlResponse("/my-org/my-tenant/orchestrator_/api/TestAutomation/StartTestSetExecution?testSetId=29991&triggerType=ExternalTool", http.StatusOK, "349001").
@@ -344,7 +344,7 @@ func TestRunAttachesRobotLogs(t *testing.T) {
                  "VersionMask":"1.2.3"
                }]
              }`).
-		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/RobotLogs?$filter=JobKey%20eq%20b6dd3f45-03c6-46c2-98ad-95a05f59905d", http.StatusOK,
+		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/RobotLogs?$filter=JobKey eq b6dd3f45-03c6-46c2-98ad-95a05f59905d", http.StatusOK,
 			`{
                 "value":[{
                   "Level":"Info",
@@ -455,10 +455,10 @@ func TestRunUpdatesExistingRelease(t *testing.T) {
 	context := test.NewContextBuilder().
 		WithDefinition("studio", studio.StudioDefinition).
 		WithCommandPlugin(TestRunCommand{exec}).
-		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Folders", http.StatusOK, `{"value":[{"Id":938064,"FullyQualifiedName":"Shared"}]}`).
+		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Folders?$filter=FullyQualifiedName eq 'Shared'", http.StatusOK, `{"value":[{"Id":938064,"FullyQualifiedName":"Shared"}]}`).
 		WithUrlResponse("/my-org/my-tenant/orchestrator_/api/PackageFeeds/GetFolderFeed?folderId=938064", http.StatusOK, `null`).
 		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Processes/UiPath.Server.Configuration.OData.UploadPackage", http.StatusOK, `{}`).
-		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Releases?$filter=ProcessKey%20eq%20'MyLibrary'", http.StatusOK, `{"value":[{"id":12345,"name":"MyLibrary"}]}`).
+		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Releases?$filter=ProcessKey eq 'MyLibrary'", http.StatusOK, `{"value":[{"id":12345,"name":"MyLibrary"}]}`).
 		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Releases(12345)", http.StatusOK, `{"name":"MyLibrary","processKey":"MyLibrary","processVersion":"1.0.195912597"}`).
 		WithUrlResponse("/my-org/my-tenant/orchestrator_/api/TestAutomation/CreateTestSetForReleaseVersion", http.StatusCreated, "29991").
 		WithUrlResponse("/my-org/my-tenant/orchestrator_/api/TestAutomation/StartTestSetExecution?testSetId=29991&triggerType=ExternalTool", http.StatusOK, "349001").
@@ -546,10 +546,10 @@ func TestRunTimesOutWaitingForTestExecutionToFinish(t *testing.T) {
 	context := test.NewContextBuilder().
 		WithDefinition("studio", studio.StudioDefinition).
 		WithCommandPlugin(TestRunCommand{exec}).
-		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Folders", http.StatusOK, `{"value":[{"Id":938064,"FullyQualifiedName":"Shared"}]}`).
+		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Folders?$filter=FullyQualifiedName eq 'Shared'", http.StatusOK, `{"value":[{"Id":938064,"FullyQualifiedName":"Shared"}]}`).
 		WithUrlResponse("/my-org/my-tenant/orchestrator_/api/PackageFeeds/GetFolderFeed?folderId=938064", http.StatusOK, `null`).
 		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Processes/UiPath.Server.Configuration.OData.UploadPackage", http.StatusOK, `{}`).
-		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Releases?$filter=ProcessKey%20eq%20'MyLibrary'", http.StatusOK, `{"value":[]}`).
+		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Releases?$filter=ProcessKey eq 'MyLibrary'", http.StatusOK, `{"value":[]}`).
 		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Releases", http.StatusCreated, `{"name":"MyLibrary","processKey":"MyLibrary","processVersion":"1.0.195912597"}`).
 		WithUrlResponse("/my-org/my-tenant/orchestrator_/api/TestAutomation/CreateTestSetForReleaseVersion", http.StatusCreated, "29991").
 		WithUrlResponse("/my-org/my-tenant/orchestrator_/api/TestAutomation/StartTestSetExecution?testSetId=29991&triggerType=ExternalTool", http.StatusOK, "349001").
@@ -600,7 +600,7 @@ func TestRunFailsWithMissingFolder(t *testing.T) {
 	context := test.NewContextBuilder().
 		WithDefinition("studio", studio.StudioDefinition).
 		WithCommandPlugin(TestRunCommand{exec}).
-		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Folders", http.StatusOK, `{"value":[]}`).
+		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Folders?$filter=FullyQualifiedName eq 'Shared'", http.StatusOK, `{"value":[]}`).
 		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Processes/UiPath.Server.Configuration.OData.UploadPackage", http.StatusOK, `{}`).
 		Build()
 
@@ -608,7 +608,7 @@ func TestRunFailsWithMissingFolder(t *testing.T) {
 		Build()
 	result := test.RunCli([]string{"studio", "test", "run", "--source", source, "--timeout", "3", "--organization", "my-org", "--tenant", "my-tenant"}, context)
 
-	if result.Error == nil || result.Error.Error() != "Could not find 'Shared' orchestrator folder." {
+	if result.Error == nil || result.Error.Error() != "Could not find orchestrator folder 'Shared'" {
 		t.Errorf("Expected missing folder error, but got: %v", result.Error)
 	}
 }
@@ -621,10 +621,10 @@ func TestRunFailsWithServerErrorOnStartExecution(t *testing.T) {
 	context := test.NewContextBuilder().
 		WithDefinition("studio", studio.StudioDefinition).
 		WithCommandPlugin(TestRunCommand{exec}).
-		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Folders", http.StatusOK, `{"value":[{"Id":938064,"FullyQualifiedName":"Shared"}]}`).
+		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Folders?$filter=FullyQualifiedName eq 'Shared'", http.StatusOK, `{"value":[{"Id":938064,"FullyQualifiedName":"Shared"}]}`).
 		WithUrlResponse("/my-org/my-tenant/orchestrator_/api/PackageFeeds/GetFolderFeed?folderId=938064", http.StatusOK, `null`).
 		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Processes/UiPath.Server.Configuration.OData.UploadPackage", http.StatusOK, `{}`).
-		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Releases?$filter=ProcessKey%20eq%20'MyLibrary'", http.StatusOK, `{"value":[]}`).
+		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Releases?$filter=ProcessKey eq 'MyLibrary'", http.StatusOK, `{"value":[]}`).
 		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Releases", http.StatusCreated, `{"name":"MyLibrary","processKey":"MyLibrary","processVersion":"1.0.195912597"}`).
 		WithUrlResponse("/my-org/my-tenant/orchestrator_/api/TestAutomation/CreateTestSetForReleaseVersion", http.StatusCreated, "29991").
 		WithUrlResponse("/my-org/my-tenant/orchestrator_/api/TestAutomation/StartTestSetExecution?testSetId=29991&triggerType=ExternalTool", http.StatusInternalServerError, "{}").
@@ -647,10 +647,10 @@ func TestRunFailsWithServerErrorOnCreateTestSet(t *testing.T) {
 	context := test.NewContextBuilder().
 		WithDefinition("studio", studio.StudioDefinition).
 		WithCommandPlugin(TestRunCommand{exec}).
-		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Folders", http.StatusOK, `{"value":[{"Id":938064,"FullyQualifiedName":"Shared"}]}`).
+		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Folders?$filter=FullyQualifiedName eq 'Shared'", http.StatusOK, `{"value":[{"Id":938064,"FullyQualifiedName":"Shared"}]}`).
 		WithUrlResponse("/my-org/my-tenant/orchestrator_/api/PackageFeeds/GetFolderFeed?folderId=938064", http.StatusOK, `null`).
 		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Processes/UiPath.Server.Configuration.OData.UploadPackage", http.StatusOK, `{}`).
-		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Releases?$filter=ProcessKey%20eq%20'MyLibrary'", http.StatusOK, `{"value":[]}`).
+		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Releases?$filter=ProcessKey eq 'MyLibrary'", http.StatusOK, `{"value":[]}`).
 		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Releases", http.StatusCreated, `{"name":"MyLibrary","processKey":"MyLibrary","processVersion":"1.0.195912597"}`).
 		WithUrlResponse("/my-org/my-tenant/orchestrator_/api/TestAutomation/CreateTestSetForReleaseVersion", http.StatusInternalServerError, "{}").
 		Build()
@@ -672,10 +672,10 @@ func TestRunFailsWithInvalidJsonOnCreateRelease(t *testing.T) {
 	context := test.NewContextBuilder().
 		WithDefinition("studio", studio.StudioDefinition).
 		WithCommandPlugin(TestRunCommand{exec}).
-		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Folders", http.StatusOK, `{"value":[{"Id":938064,"FullyQualifiedName":"Shared"}]}`).
+		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Folders?$filter=FullyQualifiedName eq 'Shared'", http.StatusOK, `{"value":[{"Id":938064,"FullyQualifiedName":"Shared"}]}`).
 		WithUrlResponse("/my-org/my-tenant/orchestrator_/api/PackageFeeds/GetFolderFeed?folderId=938064", http.StatusOK, `null`).
 		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Processes/UiPath.Server.Configuration.OData.UploadPackage", http.StatusOK, `{}`).
-		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Releases?$filter=ProcessKey%20eq%20'MyLibrary'", http.StatusOK, `{"value":[]}`).
+		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Releases?$filter=ProcessKey eq 'MyLibrary'", http.StatusOK, `{"value":[]}`).
 		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Releases", http.StatusCreated, "invalid { json }").
 		Build()
 
@@ -696,10 +696,10 @@ func TestRunFailsWithBadRequestOnGetReleases(t *testing.T) {
 	context := test.NewContextBuilder().
 		WithDefinition("studio", studio.StudioDefinition).
 		WithCommandPlugin(TestRunCommand{exec}).
-		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Folders", http.StatusOK, `{"value":[{"Id":938064,"FullyQualifiedName":"Shared"}]}`).
+		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Folders?$filter=FullyQualifiedName eq 'Shared'", http.StatusOK, `{"value":[{"Id":938064,"FullyQualifiedName":"Shared"}]}`).
 		WithUrlResponse("/my-org/my-tenant/orchestrator_/api/PackageFeeds/GetFolderFeed?folderId=938064", http.StatusOK, `null`).
 		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Processes/UiPath.Server.Configuration.OData.UploadPackage", http.StatusOK, `{}`).
-		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Releases?$filter=ProcessKey%20eq%20'MyLibrary'", 400, `{"value":[]}`).
+		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Releases?$filter=ProcessKey eq 'MyLibrary'", http.StatusBadRequest, `{"value":[]}`).
 		Build()
 
 	source := test.NewCrossPlatformProject(t).
@@ -719,9 +719,9 @@ func TestRunFailsWithBadRequestOnUploadPackage(t *testing.T) {
 	context := test.NewContextBuilder().
 		WithDefinition("studio", studio.StudioDefinition).
 		WithCommandPlugin(TestRunCommand{exec}).
-		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Folders", http.StatusOK, `{"value":[{"Id":938064,"FullyQualifiedName":"Shared"}]}`).
+		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Folders?$filter=FullyQualifiedName eq 'Shared'", http.StatusOK, `{"value":[{"Id":938064,"FullyQualifiedName":"Shared"}]}`).
 		WithUrlResponse("/my-org/my-tenant/orchestrator_/api/PackageFeeds/GetFolderFeed?folderId=938064", http.StatusOK, `null`).
-		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Processes/UiPath.Server.Configuration.OData.UploadPackage", 400, `Bad Request`).
+		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Processes/UiPath.Server.Configuration.OData.UploadPackage", http.StatusBadRequest, `Bad Request`).
 		Build()
 
 	source := test.NewCrossPlatformProject(t).
@@ -741,7 +741,7 @@ func TestRunFailsWithBadRequestOnGetFolderFeed(t *testing.T) {
 	context := test.NewContextBuilder().
 		WithDefinition("studio", studio.StudioDefinition).
 		WithCommandPlugin(TestRunCommand{exec}).
-		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Folders", http.StatusOK, `{"value":[{"Id":938064,"FullyQualifiedName":"Shared"}]}`).
+		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Folders?$filter=FullyQualifiedName eq 'Shared'", http.StatusOK, `{"value":[{"Id":938064,"FullyQualifiedName":"Shared"}]}`).
 		WithUrlResponse("/my-org/my-tenant/orchestrator_/api/PackageFeeds/GetFolderFeed?folderId=938064", http.StatusBadRequest, `Bad Request`).
 		Build()
 
@@ -762,7 +762,7 @@ func TestRunFailsWithUnauthorizedOnGetFolders(t *testing.T) {
 	context := test.NewContextBuilder().
 		WithDefinition("studio", studio.StudioDefinition).
 		WithCommandPlugin(TestRunCommand{exec}).
-		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Folders", http.StatusUnauthorized, `{}`).
+		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Folders?$filter=FullyQualifiedName eq 'Shared'", http.StatusUnauthorized, `{}`).
 		Build()
 
 	source := test.NewCrossPlatformProject(t).
@@ -832,11 +832,11 @@ func TestRunParallelPassed(t *testing.T) {
 	context := test.NewContextBuilder().
 		WithDefinition("studio", studio.StudioDefinition).
 		WithCommandPlugin(NewTestRunCommand()).
-		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Folders", http.StatusOK, `{"value":[{"Id":938064,"FullyQualifiedName":"Shared"}]}`).
+		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Folders?$filter=FullyQualifiedName eq 'Shared'", http.StatusOK, `{"value":[{"Id":938064,"FullyQualifiedName":"Shared"}]}`).
 		WithUrlResponse("/my-org/my-tenant/orchestrator_/api/PackageFeeds/GetFolderFeed?folderId=938064", http.StatusOK, `null`).
 		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Processes/UiPath.Server.Configuration.OData.UploadPackage", http.StatusOK, `{}`).
-		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Releases?$filter=ProcessKey%20eq%20'MyFirstProcess_Tests'", http.StatusOK, `{"value":[{"id":10000,"name":"MyFirstProcess_Tests"}]}`).
-		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Releases?$filter=ProcessKey%20eq%20'MySecondProcess_Tests'", http.StatusOK, `{"value":[{"id":20000,"name":"MySecondProcess_Tests"}]}`).
+		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Releases?$filter=ProcessKey eq 'MyFirstProcess_Tests'", http.StatusOK, `{"value":[{"id":10000,"name":"MyFirstProcess_Tests"}]}`).
+		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Releases?$filter=ProcessKey eq 'MySecondProcess_Tests'", http.StatusOK, `{"value":[{"id":20000,"name":"MySecondProcess_Tests"}]}`).
 		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Releases(10000)", http.StatusOK, `{"name":"MyFirstProcess_Tests","processKey":"MyFirstProcess_Tests","processVersion":"1.0.0"}`).
 		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Releases(20000)", http.StatusOK, `{"name":"MySecondProcess_Tests","processKey":"MySecondProcess_Tests","processVersion":"2.0.0"}`).
 		WithResponseHandler(func(request test.RequestData) test.ResponseData {
@@ -1005,9 +1005,10 @@ func TestRunUsesProvidedFolderId(t *testing.T) {
 	context := test.NewContextBuilder().
 		WithDefinition("studio", studio.StudioDefinition).
 		WithCommandPlugin(TestRunCommand{exec}).
+		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Folders?$filter=FullyQualifiedName eq '12345' or Id eq 12345", http.StatusOK, `{"value":[{"Id":12345,"FullyQualifiedName":"MyFolder"}]}`).
 		WithUrlResponse("/my-org/my-tenant/orchestrator_/api/PackageFeeds/GetFolderFeed?folderId=12345", http.StatusOK, `null`).
 		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Processes/UiPath.Server.Configuration.OData.UploadPackage", http.StatusOK, `{}`).
-		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Releases?$filter=ProcessKey%20eq%20'MyProcess_Tests'", http.StatusOK, `{"value":[]}`).
+		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Releases?$filter=ProcessKey eq 'MyProcess_Tests'", http.StatusOK, `{"value":[]}`).
 		WithResponseHandler(func(request test.RequestData) test.ResponseData {
 			header = request.Header
 			return test.ResponseData{Status: http.StatusOK, Body: ""}
@@ -1024,6 +1025,35 @@ func TestRunUsesProvidedFolderId(t *testing.T) {
 	}
 }
 
+func TestRunUsesProvidedFolder(t *testing.T) {
+	exec := process.NewExecCustomProcess(0, "", "", func(name string, args []string) {
+		outputDirectory := test.GetArgumentValue(args, "--output")
+		writeNupkgArchive(t, filepath.Join(outputDirectory, "MyLibrary_Tests.nupkg"))
+	})
+	header := map[string]string{}
+	context := test.NewContextBuilder().
+		WithDefinition("studio", studio.StudioDefinition).
+		WithCommandPlugin(TestRunCommand{exec}).
+		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Folders?$filter=FullyQualifiedName eq 'MyFolder'", http.StatusOK, `{"value":[{"Id":12345,"FullyQualifiedName":"MyFolder"}]}`).
+		WithUrlResponse("/my-org/my-tenant/orchestrator_/api/PackageFeeds/GetFolderFeed?folderId=12345", http.StatusOK, `null`).
+		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Processes/UiPath.Server.Configuration.OData.UploadPackage", http.StatusOK, `{}`).
+		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Releases?$filter=ProcessKey eq 'MyProcess_Tests'", http.StatusOK, `{"value":[]}`).
+		WithResponseHandler(func(request test.RequestData) test.ResponseData {
+			header = request.Header
+			return test.ResponseData{Status: http.StatusOK, Body: ""}
+		}).
+		Build()
+
+	source := test.NewCrossPlatformProject(t).
+		Build()
+	test.RunCli([]string{"studio", "test", "run", "--source", source, "--organization", "my-org", "--tenant", "my-tenant", "--folder", "MyFolder"}, context)
+
+	folderId := header["x-uipath-organizationunitid"]
+	if folderId != "12345" {
+		t.Errorf("Expected x-uipath-organizationunitid header from argument, but got: '%s'", folderId)
+	}
+}
+
 func TestRunUsesFolderFeedWhenAvailable(t *testing.T) {
 	exec := process.NewExecCustomProcess(0, "", "", func(name string, args []string) {
 		outputDirectory := test.GetArgumentValue(args, "--output")
@@ -1033,9 +1063,10 @@ func TestRunUsesFolderFeedWhenAvailable(t *testing.T) {
 	context := test.NewContextBuilder().
 		WithDefinition("studio", studio.StudioDefinition).
 		WithCommandPlugin(TestRunCommand{exec}).
+		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Folders?$filter=FullyQualifiedName eq '12345' or Id eq 12345", http.StatusOK, `{"value":[{"Id":12345,"FullyQualifiedName":"MyFolder"}]}`).
 		WithUrlResponse("/my-org/my-tenant/orchestrator_/api/PackageFeeds/GetFolderFeed?folderId=12345", http.StatusOK, `8e00fda5-6124-43ca-b8c8-5d812589e567`).
 		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Processes/UiPath.Server.Configuration.OData.UploadPackage?feedId=8e00fda5-6124-43ca-b8c8-5d812589e567", http.StatusOK, `{}`).
-		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Releases?$filter=ProcessKey%20eq%20'MyProcess_Tests'", http.StatusOK, `{"value":[]}`).
+		WithUrlResponse("/my-org/my-tenant/orchestrator_/odata/Releases?$filter=ProcessKey eq 'MyProcess_Tests'", http.StatusOK, `{"value":[]}`).
 		WithResponseHandler(func(request test.RequestData) test.ResponseData {
 			header = request.Header
 			return test.ResponseData{Status: http.StatusOK, Body: ""}

--- a/plugin/studio/testrun/test_run_params.go
+++ b/plugin/studio/testrun/test_run_params.go
@@ -15,7 +15,7 @@ type testRunParams struct {
 	Destination     string
 	Timeout         time.Duration
 	AttachRobotLogs bool
-	FolderId        int
+	Folder          string
 }
 
 func newTestRunParams(
@@ -26,7 +26,7 @@ func newTestRunParams(
 	destination string,
 	timeout time.Duration,
 	attachRobotLogs bool,
-	folderId int,
+	folder string,
 ) *testRunParams {
 	return &testRunParams{
 		executionId,
@@ -36,6 +36,6 @@ func newTestRunParams(
 		destination,
 		timeout,
 		attachRobotLogs,
-		folderId,
+		folder,
 	}
 }

--- a/test/execution_test.go
+++ b/test/execution_test.go
@@ -1708,9 +1708,9 @@ paths:
 		WithResponseHandler(func(request RequestData) ResponseData {
 			callCount++
 			if callCount == 3 {
-				return ResponseData{Status: 200, Body: `{"hello":"world"}`}
+				return ResponseData{Status: http.StatusOK, Body: `{"hello":"world"}`}
 			}
-			return ResponseData{Status: 500, Body: "Internal Server Error"}
+			return ResponseData{Status: http.StatusInternalServerError, Body: "Internal Server Error"}
 		}).
 		Build()
 

--- a/test/plugin_test.go
+++ b/test/plugin_test.go
@@ -339,7 +339,7 @@ func (c SimplePluginCommand) Command() plugin.Command {
 
 func (c SimplePluginCommand) Execute(ctx plugin.ExecutionContext, writer output.OutputWriter, logger log.Logger) error {
 	logger.LogError("Simple plugin logging output")
-	return writer.WriteResponse(*output.NewResponseInfo(200, "200 OK", "https", map[string][]string{}, bytes.NewReader([]byte("Simple plugin output"))))
+	return writer.WriteResponse(*output.NewResponseInfo(http.StatusOK, "200 OK", "https", map[string][]string{}, bytes.NewReader([]byte("Simple plugin output"))))
 }
 
 type ContextPluginCommand struct {

--- a/test/setup.go
+++ b/test/setup.go
@@ -172,7 +172,12 @@ func RunCli(args []string, context Context) Result {
 				}
 			}
 
-			response, found := context.Responses[requestUrl]
+			decodedRequestUrl := r.URL.Path
+			query, _ := url.QueryUnescape(r.URL.RawQuery)
+			if query != "" {
+				decodedRequestUrl += "?" + query
+			}
+			response, found := context.Responses[decodedRequestUrl]
 			if !found {
 				response, found = context.Responses["*"]
 			}

--- a/test/wait_test.go
+++ b/test/wait_test.go
@@ -89,7 +89,7 @@ paths:
 		WithDefinition("myservice", definition).
 		WithResponseHandler(func(request RequestData) ResponseData {
 			callCount++
-			return ResponseData{Status: 200, Body: `{"version":` + strconv.Itoa(callCount) + `}`}
+			return ResponseData{Status: http.StatusOK, Body: `{"version":` + strconv.Itoa(callCount) + `}`}
 		}).
 		Build()
 
@@ -121,7 +121,7 @@ paths:
 		WithDefinition("myservice", definition).
 		WithResponseHandler(func(request RequestData) ResponseData {
 			callCount++
-			return ResponseData{Status: 200, Body: `{"version":` + strconv.Itoa(callCount) + `}`}
+			return ResponseData{Status: http.StatusOK, Body: `{"version":` + strconv.Itoa(callCount) + `}`}
 		}).
 		Build()
 

--- a/utils/api/du_client.go
+++ b/utils/api/du_client.go
@@ -12,6 +12,7 @@ import (
 	"github.com/UiPath/uipathcli/auth"
 	"github.com/UiPath/uipathcli/log"
 	"github.com/UiPath/uipathcli/plugin"
+	"github.com/UiPath/uipathcli/utils/converter"
 	"github.com/UiPath/uipathcli/utils/network"
 	"github.com/UiPath/uipathcli/utils/stream"
 	"github.com/UiPath/uipathcli/utils/visualization"
@@ -55,7 +56,10 @@ func (c DuClient) createStartDigitizationRequest(projectId string, file stream.S
 	formDataContentType := c.writeMultipartBody(bodyWriter, file, contentType, cancel)
 	uploadReader := c.progressReader("uploading...", "completing  ", bodyReader, streamSize, uploadBar)
 
-	uri := c.baseUri + fmt.Sprintf("/api/framework/projects/%s/digitization/start?api-version=1", projectId)
+	uri := converter.NewUriBuilder(c.baseUri, "/api/framework/projects/{ProjectId}/digitization/start").
+		FormatPath("ProjectId", projectId).
+		AddQueryString("api-version", "1").
+		Build()
 	header := http.Header{
 		"Content-Type": {formDataContentType},
 	}
@@ -89,7 +93,11 @@ func (c DuClient) GetDigitizationResult(projectId string, documentId string) (st
 }
 
 func (c DuClient) createDigitizeStatusRequest(projectId string, documentId string) *network.HttpRequest {
-	uri := c.baseUri + fmt.Sprintf("/api/framework/projects/%s/digitization/result/%s?api-version=1", projectId, documentId)
+	uri := converter.NewUriBuilder(c.baseUri, "/api/framework/projects/{ProjectId}/digitization/result/{DocumentId}").
+		FormatPath("ProjectId", projectId).
+		FormatPath("DocumentId", documentId).
+		AddQueryString("api-version", "1").
+		Build()
 	return network.NewHttpGetRequest(uri, c.toAuthorization(c.token), http.Header{})
 }
 

--- a/utils/converter/query_string_builder.go
+++ b/utils/converter/query_string_builder.go
@@ -19,13 +19,14 @@ type QueryStringBuilder struct {
 	querystring string
 }
 
-func (b *QueryStringBuilder) Add(name string, value interface{}) {
+func (b *QueryStringBuilder) Add(name string, value interface{}) *QueryStringBuilder {
 	param := b.formatQueryStringParam(name, value)
 	if b.querystring == "" {
 		b.querystring = param
 	} else {
 		b.querystring = b.querystring + "&" + param
 	}
+	return b
 }
 
 func (b *QueryStringBuilder) Build() string {

--- a/utils/converter/uri_builder.go
+++ b/utils/converter/uri_builder.go
@@ -1,9 +1,6 @@
 package converter
 
 import (
-	"fmt"
-	"net/url"
-	"path"
 	"strings"
 )
 
@@ -25,13 +22,15 @@ type UriBuilder struct {
 	queryStringBuilder *QueryStringBuilder
 }
 
-func (b *UriBuilder) FormatPath(name string, value interface{}) {
+func (b *UriBuilder) FormatPath(name string, value interface{}) *UriBuilder {
 	valueString := b.converter.ToString(value)
 	b.uri = strings.ReplaceAll(b.uri, "{"+name+"}", valueString)
+	return b
 }
 
-func (b *UriBuilder) AddQueryString(name string, value interface{}) {
+func (b *UriBuilder) AddQueryString(name string, value interface{}) *UriBuilder {
 	b.queryStringBuilder.Add(name, value)
+	return b
 }
 
 func (b *UriBuilder) Build() string {
@@ -42,10 +41,11 @@ func (b *UriBuilder) Build() string {
 	return b.uri + "?" + queryString
 }
 
-func NewUriBuilder(baseUri url.URL, route string) *UriBuilder {
-	normalizedPath := strings.Trim(baseUri.Path, "/")
+func NewUriBuilder(baseUri string, route string) *UriBuilder {
+	uri := strings.Trim(baseUri, "/")
 	normalizedRoute := strings.Trim(route, "/")
-	path := path.Join(normalizedPath, normalizedRoute)
-	uri := fmt.Sprintf("%s://%s/%s", baseUri.Scheme, baseUri.Host, path)
+	if normalizedRoute != "" {
+		uri += "/" + normalizedRoute
+	}
 	return &UriBuilder{uri, NewStringConverter(), NewQueryStringBuilder()}
 }

--- a/utils/converter/uri_builder_test.go
+++ b/utils/converter/uri_builder_test.go
@@ -1,12 +1,11 @@
 package converter
 
 import (
-	"net/url"
 	"testing"
 )
 
 func TestRemovesTrailingSlash(t *testing.T) {
-	builder := NewUriBuilder(toUrl("https://cloud.uipath.com/"), "/my-service")
+	builder := NewUriBuilder("https://cloud.uipath.com/", "/my-service")
 
 	uri := builder.Build()
 	if uri != "https://cloud.uipath.com/my-service" {
@@ -15,7 +14,7 @@ func TestRemovesTrailingSlash(t *testing.T) {
 }
 
 func TestAddsMissingSlashSeparator(t *testing.T) {
-	builder := NewUriBuilder(toUrl("https://cloud.uipath.com"), "my-service")
+	builder := NewUriBuilder("https://cloud.uipath.com", "my-service")
 
 	uri := builder.Build()
 	if uri != "https://cloud.uipath.com/my-service" {
@@ -24,7 +23,7 @@ func TestAddsMissingSlashSeparator(t *testing.T) {
 }
 
 func TestFormatPathReplacesPlaceholder(t *testing.T) {
-	builder := NewUriBuilder(toUrl("https://cloud.uipath.com"), "/{organization}/{tenant}/my-service")
+	builder := NewUriBuilder("https://cloud.uipath.com", "/{organization}/{tenant}/my-service")
 
 	builder.FormatPath("organization", "my-org")
 
@@ -35,7 +34,7 @@ func TestFormatPathReplacesPlaceholder(t *testing.T) {
 }
 
 func TestFormatPathReplacesMultiplePlaceholders(t *testing.T) {
-	builder := NewUriBuilder(toUrl("https://cloud.uipath.com"), "/{organization}/{tenant}/my-service")
+	builder := NewUriBuilder("https://cloud.uipath.com", "/{organization}/{tenant}/my-service")
 
 	builder.FormatPath("organization", "my-org")
 	builder.FormatPath("tenant", "my-tenant")
@@ -65,7 +64,7 @@ func TestFormatPathDataTypes(t *testing.T) {
 	})
 }
 func FormatPathDataTypes(t *testing.T, value interface{}, expected string) {
-	builder := NewUriBuilder(toUrl("https://cloud.uipath.com"), "/{param}")
+	builder := NewUriBuilder("https://cloud.uipath.com", "/{param}")
 
 	builder.FormatPath("param", value)
 
@@ -76,7 +75,7 @@ func FormatPathDataTypes(t *testing.T, value interface{}, expected string) {
 }
 
 func TestAddQueryString(t *testing.T) {
-	builder := NewUriBuilder(toUrl("https://cloud.uipath.com"), "/my-service")
+	builder := NewUriBuilder("https://cloud.uipath.com", "/my-service")
 
 	builder.AddQueryString("filter", "my-value")
 
@@ -87,7 +86,7 @@ func TestAddQueryString(t *testing.T) {
 }
 
 func TestAddMultipleQueryStringParameters(t *testing.T) {
-	builder := NewUriBuilder(toUrl("https://cloud.uipath.com"), "/my-service")
+	builder := NewUriBuilder("https://cloud.uipath.com", "/my-service")
 
 	builder.AddQueryString("skip", 1)
 	builder.AddQueryString("take", 5)
@@ -117,7 +116,7 @@ func TestQueryStringDataTypes(t *testing.T) {
 	})
 }
 func QueryStringDataTypes(t *testing.T, value interface{}, expected string) {
-	builder := NewUriBuilder(toUrl("https://cloud.uipath.com"), "/my-service")
+	builder := NewUriBuilder("https://cloud.uipath.com", "/my-service")
 
 	builder.AddQueryString("param", value)
 
@@ -125,9 +124,4 @@ func QueryStringDataTypes(t *testing.T, value interface{}, expected string) {
 	if uri != "https://cloud.uipath.com/my-service"+expected {
 		t.Errorf("Did not format data type for query string properly, got: %v", uri)
 	}
-}
-
-func toUrl(uri string) url.URL {
-	result, _ := url.Parse(uri)
-	return *result
 }


### PR DESCRIPTION
`--folder-id` parameter is still supported but now hidden. Users can use the `--folder` parameter to either specify a folder id or a folder name.

The test run and publish commands will retrieve the folder details and find the matching folder to retrieve the folder feed, store the process, test sets and other resources.

Implements https://github.com/UiPath/uipathcli/issues/184

Changes:

- Added method to orchestrator client for finding the folder based on a filter which can be either a folder id or name

- TestRunCommand and PublishCommand use now always try to find the Orchestrator folder first

- Refactored DU and orchestrator clients to use url builder which takes care of escaping path segments and query string values

- Changed the fake server for the tests to compare decoded URLs so that faking URLs can be specified without URL encoding and become more readable

- Replaced some magic numbers for http status codes with http.StatusX constants