### PR TITLE
Fix organization and tenant substitution in URLs

### DIFF
--- a/executor/http_executor.go
+++ b/executor/http_executor.go
@@ -123,7 +123,7 @@ func (e HttpExecutor) validateUri(uri string) (*url.URL, error) {
 }
 
 func (e HttpExecutor) formatUri(baseUri url.URL, route string, pathParameters []ExecutionParameter, queryParameters []ExecutionParameter) (*url.URL, error) {
-	uriBuilder := converter.NewUriBuilder(baseUri.String(), route)
+	uriBuilder := converter.NewUriBuilderFromUrl(baseUri, route)
 	for _, parameter := range pathParameters {
 		uriBuilder.FormatPath(parameter.Name, parameter.Value)
 	}

--- a/test/config_test.go
+++ b/test/config_test.go
@@ -81,6 +81,34 @@ paths:
 	}
 }
 
+func TestOrgTenantServerUrl(t *testing.T) {
+	config := `
+profiles:
+  - name: default
+    organization: my-org
+    tenant: my-tenant
+`
+	definition := `
+servers:
+  - url: https://cloud.uipath.com/{organization}/{tenant}/
+paths:
+  "/ping":
+    get:
+      operationId: ping
+`
+	context := NewContextBuilder().
+		WithDefinition("myservice", definition).
+		WithConfig(config).
+		WithResponse(http.StatusOK, "").
+		Build()
+
+	result := RunCli([]string{"myservice", "ping"}, context)
+
+	if result.RequestUrl != "/my-org/my-tenant/ping" {
+		t.Errorf("Did not set tenant from config, got: %v", result.RequestUrl)
+	}
+}
+
 func TestMissingTenantConfigShowsError(t *testing.T) {
 	config := `
 profiles:

--- a/utils/converter/uri_builder.go
+++ b/utils/converter/uri_builder.go
@@ -1,6 +1,9 @@
 package converter
 
 import (
+	"fmt"
+	"net/url"
+	"path"
 	"strings"
 )
 
@@ -47,5 +50,13 @@ func NewUriBuilder(baseUri string, route string) *UriBuilder {
 	if normalizedRoute != "" {
 		uri += "/" + normalizedRoute
 	}
+	return &UriBuilder{uri, NewStringConverter(), NewQueryStringBuilder()}
+}
+
+func NewUriBuilderFromUrl(baseUri url.URL, route string) *UriBuilder {
+	normalizedPath := strings.Trim(baseUri.Path, "/")
+	normalizedRoute := strings.Trim(route, "/")
+	path := path.Join(normalizedPath, normalizedRoute)
+	uri := fmt.Sprintf("%s://%s/%s", baseUri.Scheme, baseUri.Host, path)
 	return &UriBuilder{uri, NewStringConverter(), NewQueryStringBuilder()}
 }


### PR DESCRIPTION
The http executor has been converting the HTTP URLs to string which caused the URL to be escaped before replacing organization and tenant placeholders. Reverted the previous change in http executor and uri builder to construct the URL based on raw parts.

Fixes https://github.com/UiPath/uipathcli/issues/189