### PR TITLE
Move URI formatting logic from plugins into UriBuilder

### DIFF
--- a/commandline/command_builder.go
+++ b/commandline/command_builder.go
@@ -205,7 +205,7 @@ func (b CommandBuilder) getValue(parameter parser.Parameter, context *CommandExe
 		return value
 	}
 	if parameter.DefaultValue != nil {
-		return fmt.Sprintf("%v", parameter.DefaultValue)
+		return fmt.Sprint(parameter.DefaultValue)
 	}
 	return ""
 }
@@ -222,7 +222,7 @@ func (b CommandBuilder) validateArguments(context *CommandExecContext, parameter
 		if value != "" && len(parameter.AllowedValues) > 0 {
 			valid := false
 			for _, allowedValue := range parameter.AllowedValues {
-				if fmt.Sprintf("%v", allowedValue) == value {
+				if fmt.Sprint(allowedValue) == value {
 					valid = true
 					break
 				}

--- a/commandline/parameter_formatter.go
+++ b/commandline/parameter_formatter.go
@@ -99,7 +99,7 @@ func (f parameterFormatter) commaSeparatedValues(values []interface{}) string {
 	builder := strings.Builder{}
 	for _, value := range values {
 		f.writeSeparator(&builder, ", ")
-		builder.WriteString(fmt.Sprintf("%v", value))
+		builder.WriteString(fmt.Sprint(value))
 	}
 	return builder.String()
 }

--- a/config/config.go
+++ b/config/config.go
@@ -38,7 +38,7 @@ func (c *Config) ClientId() string {
 	if clientId == nil {
 		return ""
 	}
-	return fmt.Sprintf("%v", clientId)
+	return fmt.Sprint(clientId)
 }
 
 func (c *Config) ClientSecret() string {
@@ -46,7 +46,7 @@ func (c *Config) ClientSecret() string {
 	if clientSecret == nil {
 		return ""
 	}
-	return fmt.Sprintf("%v", clientSecret)
+	return fmt.Sprint(clientSecret)
 }
 
 func (c *Config) RedirectUri() string {
@@ -54,7 +54,7 @@ func (c *Config) RedirectUri() string {
 	if redirectUri == nil {
 		return ""
 	}
-	return fmt.Sprintf("%v", redirectUri)
+	return fmt.Sprint(redirectUri)
 }
 
 func (c *Config) Scopes() string {
@@ -62,7 +62,7 @@ func (c *Config) Scopes() string {
 	if scopes == nil {
 		return ""
 	}
-	return fmt.Sprintf("%v", scopes)
+	return fmt.Sprint(scopes)
 }
 
 func (c *Config) Pat() string {
@@ -70,7 +70,7 @@ func (c *Config) Pat() string {
 	if pat == nil {
 		return ""
 	}
-	return fmt.Sprintf("%v", pat)
+	return fmt.Sprint(pat)
 }
 
 func (c *Config) ConfigureOrgTenant(organization string, tenant string) bool {

--- a/config/config_provider.go
+++ b/config/config_provider.go
@@ -79,7 +79,7 @@ func (p *ConfigProvider) convertToConfig(profile profileYaml) Config {
 		Parameter:    profile.Parameter,
 		Header:       profile.Header,
 		Auth: AuthConfig{
-			Type:   fmt.Sprintf("%v", profile.Auth["type"]),
+			Type:   fmt.Sprint(profile.Auth["type"]),
 			Config: profile.Auth,
 		},
 		Insecure:       profile.Insecure,

--- a/executor/http_executor.go
+++ b/executor/http_executor.go
@@ -123,7 +123,7 @@ func (e HttpExecutor) validateUri(uri string) (*url.URL, error) {
 }
 
 func (e HttpExecutor) formatUri(baseUri url.URL, route string, pathParameters []ExecutionParameter, queryParameters []ExecutionParameter) (*url.URL, error) {
-	uriBuilder := converter.NewUriBuilderFromUrl(baseUri, route)
+	uriBuilder := converter.NewUriBuilder(baseUri, route)
 	for _, parameter := range pathParameters {
 		uriBuilder.FormatPath(parameter.Name, parameter.Value)
 	}

--- a/plugin/orchestrator/download/download_command.go
+++ b/plugin/orchestrator/download/download_command.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
-	"strings"
 
 	"github.com/UiPath/uipathcli/log"
 	"github.com/UiPath/uipathcli/output"
@@ -88,20 +86,8 @@ func (c DownloadCommand) getReadUrl(ctx plugin.ExecutionContext, logger log.Logg
 	bucketId := c.getIntParameter("key", ctx.Parameters)
 	path := c.getStringParameter("path", ctx.Parameters)
 
-	baseUri := c.formatUri(ctx.BaseUri, ctx.Organization, ctx.Tenant)
-	client := api.NewOrchestratorClient(baseUri, ctx.Auth.Token, ctx.Debug, ctx.Settings, logger)
+	client := api.NewOrchestratorClient(ctx.BaseUri, ctx.Organization, ctx.Tenant, ctx.Auth.Token, ctx.Debug, ctx.Settings, logger)
 	return client.GetReadUrl(folderId, bucketId, path)
-}
-
-func (c DownloadCommand) formatUri(baseUri url.URL, org string, tenant string) string {
-	path := baseUri.Path
-	if baseUri.Path == "" {
-		path = "/{organization}/{tenant}/orchestrator_"
-	}
-	path = strings.ReplaceAll(path, "{organization}", org)
-	path = strings.ReplaceAll(path, "{tenant}", tenant)
-	path = strings.TrimSuffix(path, "/")
-	return fmt.Sprintf("%s://%s%s", baseUri.Scheme, baseUri.Host, path)
 }
 
 func (c DownloadCommand) getStringParameter(name string, parameters []plugin.ExecutionParameter) string {

--- a/plugin/orchestrator/upload/upload_command.go
+++ b/plugin/orchestrator/upload/upload_command.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
-	"strings"
 
 	"github.com/UiPath/uipathcli/log"
 	"github.com/UiPath/uipathcli/output"
@@ -125,20 +123,8 @@ func (c UploadCommand) getWriteUrl(ctx plugin.ExecutionContext, logger log.Logge
 	bucketId := c.getIntParameter("key", ctx.Parameters)
 	path := c.getStringParameter("path", ctx.Parameters)
 
-	baseUri := c.formatUri(ctx.BaseUri, ctx.Organization, ctx.Tenant)
-	client := api.NewOrchestratorClient(baseUri, ctx.Auth.Token, ctx.Debug, ctx.Settings, logger)
+	client := api.NewOrchestratorClient(ctx.BaseUri, ctx.Organization, ctx.Tenant, ctx.Auth.Token, ctx.Debug, ctx.Settings, logger)
 	return client.GetWriteUrl(folderId, bucketId, path)
-}
-
-func (c UploadCommand) formatUri(baseUri url.URL, org string, tenant string) string {
-	path := baseUri.Path
-	if baseUri.Path == "" {
-		path = "/{organization}/{tenant}/orchestrator_"
-	}
-	path = strings.ReplaceAll(path, "{organization}", org)
-	path = strings.ReplaceAll(path, "{tenant}", tenant)
-	path = strings.TrimSuffix(path, "/")
-	return fmt.Sprintf("%s://%s%s", baseUri.Scheme, baseUri.Host, path)
 }
 
 func (c UploadCommand) getStringParameter(name string, parameters []plugin.ExecutionParameter) string {

--- a/plugin/studio/publish/package_publish_params.go
+++ b/plugin/studio/publish/package_publish_params.go
@@ -1,17 +1,23 @@
 package publish
 
-import "github.com/UiPath/uipathcli/plugin"
+import (
+	"net/url"
+
+	"github.com/UiPath/uipathcli/plugin"
+)
 
 type packagePublishParams struct {
-	Source      string
-	Folder      string
-	Name        string
-	Description string
-	Version     string
-	BaseUri     string
-	Auth        plugin.AuthResult
-	Debug       bool
-	Settings    plugin.ExecutionSettings
+	Source       string
+	Folder       string
+	Name         string
+	Description  string
+	Version      string
+	BaseUri      url.URL
+	Organization string
+	Tenant       string
+	Auth         plugin.AuthResult
+	Debug        bool
+	Settings     plugin.ExecutionSettings
 }
 
 func newPackagePublishParams(
@@ -20,9 +26,23 @@ func newPackagePublishParams(
 	name string,
 	description string,
 	version string,
-	baseUri string,
+	baseUri url.URL,
+	organization string,
+	tenant string,
 	auth plugin.AuthResult,
 	debug bool,
 	settings plugin.ExecutionSettings) *packagePublishParams {
-	return &packagePublishParams{source, folder, name, description, version, baseUri, auth, debug, settings}
+	return &packagePublishParams{
+		source,
+		folder,
+		name,
+		description,
+		version,
+		baseUri,
+		organization,
+		tenant,
+		auth,
+		debug,
+		settings,
+	}
 }

--- a/plugin/studio/testrun/junit_report_converter.go
+++ b/plugin/studio/testrun/junit_report_converter.go
@@ -9,7 +9,7 @@ import (
 )
 
 type jUnitReportConverter struct {
-	BaseUri string
+	client *api.OrchestratorClient
 }
 
 func (c jUnitReportConverter) Convert(status []testRunStatus) junitReport {
@@ -31,7 +31,7 @@ func (c jUnitReportConverter) convertTestSetExecution(status testRunStatus) juni
 		junitTestCases = append(junitTestCases, junitTestCase)
 	}
 
-	testSetExecutionUrl := c.BaseUri + fmt.Sprintf("/test/executions/%d?fid=%d", status.Execution.Id, status.FolderId)
+	testSetExecutionUrl := c.client.GetTestSetExecutionUrl(status.FolderId, status.Execution.Id)
 	durationMs := status.Execution.EndTime.Sub(status.Execution.StartTime).Milliseconds()
 	systemOut := fmt.Sprintf(`Test set execution %s took %dms.
 Test set execution url: %s
@@ -64,8 +64,8 @@ func (c jUnitReportConverter) convertTestCaseExecution(folderId int, testSetExec
 	if execution.DataVariationIdentifier != "" {
 		name = testCase.Name + "_" + execution.DataVariationIdentifier
 	}
-	testCaseExecutionUrl := c.BaseUri + fmt.Sprintf("/test/executions/%d?search=%s&fid=%d", testSetExecutionId, testCase.Name, folderId)
-	testCaseExecutionLogsUrl := c.BaseUri + fmt.Sprintf("/test/executions/%d/logs/%d?fid=%d", testSetExecutionId, execution.JobId, folderId)
+	testCaseExecutionUrl := c.client.GetTestCaseExecutionUrl(folderId, testSetExecutionId, testCase.Name)
+	testCaseExecutionLogsUrl := c.client.GetTestCaseExecutionLogsUrl(folderId, testSetExecutionId, execution.JobId)
 	durationMs := execution.EndTime.Sub(execution.StartTime).Milliseconds()
 	systemOut := fmt.Sprintf(`Test case %s (v%s) executed as job %d and took %dms.
 Test case logs url: %s
@@ -104,6 +104,6 @@ func (c jUnitReportConverter) findTestCase(testSet *api.TestSet, id int) api.Tes
 	return *api.NewTestCase(id, "", "")
 }
 
-func newJUnitReportConverter(baseUri string) *jUnitReportConverter {
-	return &jUnitReportConverter{baseUri}
+func newJUnitReportConverter(client *api.OrchestratorClient) *jUnitReportConverter {
+	return &jUnitReportConverter{client}
 }

--- a/plugin/studio/testrun/test_run_command_test.go
+++ b/plugin/studio/testrun/test_run_command_test.go
@@ -306,7 +306,7 @@ func TestRunGeneratesJUnitReport(t *testing.T) {
   <testsuite id="349001" name="Automated - MyLibrary - 1.0.195912597" time="8.996" package="MyTestPackage-1.2.3" tests="1" failures="0" errors="0" cancelled="0">
     <system-out>Test set execution Automated - MyLibrary - 1.0.195912597 took 8996ms.&#xA;Test set execution url: ` + result.BaseUrl + `/my-org/my-tenant/orchestrator_/test/executions/349001?fid=938064&#xA;</system-out>
     <testcase name="MyTestCase" time="8.996" status="Passed" classname="1.1.1">
-      <system-out>Test case MyTestCase (v) executed as job 0 and took 8996ms.&#xA;Test case logs url: ` + result.BaseUrl + `/my-org/my-tenant/orchestrator_/test/executions/349001/logs/0?fid=938064&#xA;Test case execution url: ` + result.BaseUrl + `/my-org/my-tenant/orchestrator_/test/executions/349001?search=MyTestCase&amp;fid=938064&#xA;Input arguments: &#xA;Output arguments: &#xA;</system-out>
+      <system-out>Test case MyTestCase (v) executed as job 0 and took 8996ms.&#xA;Test case logs url: ` + result.BaseUrl + `/my-org/my-tenant/orchestrator_/test/executions/349001/logs/0?fid=938064&#xA;Test case execution url: ` + result.BaseUrl + `/my-org/my-tenant/orchestrator_/test/executions/349001?fid=938064&amp;search=MyTestCase&#xA;Input arguments: &#xA;Output arguments: &#xA;</system-out>
     </testcase>
   </testsuite>
 </testsuites>`

--- a/utils/converter/query_string_builder.go
+++ b/utils/converter/query_string_builder.go
@@ -89,8 +89,8 @@ func (b *QueryStringBuilder) arrayToQueryString(key string, value []interface{})
 }
 
 func (b *QueryStringBuilder) toQueryString(key string, value interface{}) string {
-	stringValue := fmt.Sprintf("%v", value)
-	return fmt.Sprintf("%s=%v", key, url.QueryEscape(stringValue))
+	stringValue := fmt.Sprint(value)
+	return fmt.Sprintf("%s=%v", url.QueryEscape(key), url.QueryEscape(stringValue))
 }
 
 func NewQueryStringBuilder() *QueryStringBuilder {

--- a/utils/converter/string_converter.go
+++ b/utils/converter/string_converter.go
@@ -4,11 +4,12 @@ package converter
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 )
 
 // StringConverter converts interface{} values into a string.
-// Depending on the type of the parameter, the formatter converts the value to
+// Depending on the type of the parameter, it converts the value to
 // the proper format:
 // - Integers, Float, etc.. are simply converted to a string
 // - Arrays are formatted comma-separated
@@ -16,31 +17,60 @@ import (
 type StringConverter struct{}
 
 func (c StringConverter) ToString(value interface{}) string {
-	return c.formatParameter(value)
+	switch value := value.(type) {
+	case []int, []float64, []bool, []string:
+		array := c.ToStringArray(value)
+		return strings.Join(array, ",")
+	case int:
+		return strconv.Itoa(value)
+	case float64:
+		return strconv.FormatFloat(value, 'f', -1, 64)
+	case bool:
+		return strconv.FormatBool(value)
+	case string:
+		return value
+	default:
+		return fmt.Sprint(value)
+	}
 }
 
-func (c StringConverter) formatParameter(value interface{}) string {
+func (c StringConverter) ToStringArray(value interface{}) []string {
 	switch value := value.(type) {
 	case []int:
-		return c.arrayToCommaSeparatedString(value)
+		return c.intArrayToStringArray(value)
 	case []float64:
-		return c.arrayToCommaSeparatedString(value)
+		return c.floatArrayToStringArray(value)
 	case []bool:
-		return c.arrayToCommaSeparatedString(value)
+		return c.boolArrayToStringArray(value)
 	case []string:
-		return c.arrayToCommaSeparatedString(value)
+		return value
 	default:
-		return fmt.Sprintf("%v", value)
+		return strings.Fields(fmt.Sprint(value))
 	}
 }
 
-func (c StringConverter) arrayToCommaSeparatedString(array interface{}) string {
-	switch value := array.(type) {
-	case []string:
-		return strings.Join(value, ",")
-	default:
-		return strings.Trim(strings.Join(strings.Fields(fmt.Sprint(value)), ","), "[]")
+func (c StringConverter) intArrayToStringArray(array []int) []string {
+	result := make([]string, len(array))
+	for i, value := range array {
+		result[i] = strconv.Itoa(value)
 	}
+	return result
+}
+
+func (c StringConverter) floatArrayToStringArray(array []float64) []string {
+	result := make([]string, len(array))
+	for i, value := range array {
+		result[i] = strconv.FormatFloat(value, 'f', -1, 64)
+	}
+	return result
+}
+
+func (c StringConverter) boolArrayToStringArray(array []bool) []string {
+	result := make([]string, len(array))
+	for i, value := range array {
+		result[i] = strconv.FormatBool(value)
+	}
+	return result
 }
 
 func NewStringConverter() *StringConverter {


### PR DESCRIPTION
Each plugin has been doing some custom formatting of the URI and replacing organization and tenant. Moved all the logic for URI handling in the API clients which use the `uri_builder.go`.

Changed all the code which uses the baseUri to make use of url.URL instead of strings which allowed removing the `NewUriBuilder` method which used to convert the baseUri string.

Noticed that the UriBuilder does not espace all URI parts properly. Added escaping for path and query string keys.

Added more tests to validate the url formatting to avoid similar issues like https://github.com/UiPath/uipathcli/issues/189.