### PR TITLE
Add support for user login flow using confidential applications

### DIFF
--- a/auth/oauth_authenticator_config.go
+++ b/auth/oauth_authenticator_config.go
@@ -3,16 +3,18 @@ package auth
 import "net/url"
 
 type oauthAuthenticatorConfig struct {
-	ClientId    string
-	RedirectUrl url.URL
-	Scopes      string
-	IdentityUri url.URL
+	ClientId     string
+	ClientSecret string
+	RedirectUrl  url.URL
+	Scopes       string
+	IdentityUri  url.URL
 }
 
 func newOAuthAuthenticatorConfig(
 	clientId string,
+	clientSecret string,
 	redirectUrl url.URL,
 	scopes string,
 	identityUri url.URL) *oauthAuthenticatorConfig {
-	return &oauthAuthenticatorConfig{clientId, redirectUrl, scopes, identityUri}
+	return &oauthAuthenticatorConfig{clientId, clientSecret, redirectUrl, scopes, identityUri}
 }

--- a/auth/pat_authenticator.go
+++ b/auth/pat_authenticator.go
@@ -26,12 +26,13 @@ func (a PatAuthenticator) enabled(ctx AuthenticatorContext) bool {
 }
 
 func (a PatAuthenticator) getPat(ctx AuthenticatorContext) (string, error) {
-	return a.parseRequiredString(ctx.Config, "pat", os.Getenv(PatEnvVarName))
+	return a.parseRequiredString(ctx.Config, "pat", PatEnvVarName)
 }
 
-func (a PatAuthenticator) parseRequiredString(config map[string]interface{}, name string, override string) (string, error) {
-	if override != "" {
-		return override, nil
+func (a PatAuthenticator) parseRequiredString(config map[string]interface{}, name string, envVarName string) (string, error) {
+	envVarValue := os.Getenv(envVarName)
+	if envVarValue != "" {
+		return envVarValue, nil
 	}
 	value := config[name]
 	result, valid := value.(string)

--- a/auth/token_request.go
+++ b/auth/token_request.go
@@ -20,6 +20,6 @@ func newTokenRequest(baseUri url.URL, grantType string, scopes string, clientId 
 	return &tokenRequest{baseUri, grantType, scopes, clientId, clientSecret, "", "", "", properties, operationId, insecure}
 }
 
-func newAuthorizationCodeTokenRequest(baseUri url.URL, clientId string, code string, codeVerifier string, redirectUrl string, operationId string, insecure bool) *tokenRequest {
-	return &tokenRequest{baseUri, "authorization_code", "", clientId, "", code, codeVerifier, redirectUrl, map[string]string{}, operationId, insecure}
+func newAuthorizationCodeTokenRequest(baseUri url.URL, clientId string, clientSecret string, code string, codeVerifier string, redirectUrl string, operationId string, insecure bool) *tokenRequest {
+	return &tokenRequest{baseUri, "authorization_code", "", clientId, clientSecret, code, codeVerifier, redirectUrl, map[string]string{}, operationId, insecure}
 }

--- a/commandline/command_builder.go
+++ b/commandline/command_builder.go
@@ -570,7 +570,7 @@ func (b CommandBuilder) createConfigCommand() *CommandDefinition {
 	const flagNameAuth = "auth"
 
 	flags := NewFlagBuilder().
-		AddFlag(NewFlag(flagNameAuth, fmt.Sprintf("Authorization type: %s, %s, %s", CredentialsAuth, LoginAuth, PatAuth), FlagTypeString)).
+		AddFlag(NewFlag(flagNameAuth, fmt.Sprintf("Authorization type: %s, %s, %s", config.AuthTypeCredentials, config.AuthTypeLogin, config.AuthTypePat), FlagTypeString)).
 		AddFlag(NewFlag(FlagNameProfile, "Profile to configure", FlagTypeString).
 			WithEnvVarName("UIPATH_PROFILE").
 			WithDefaultValue(config.DefaultProfile)).

--- a/config/config_builder.go
+++ b/config/config_builder.go
@@ -1,0 +1,87 @@
+package config
+
+type ConfigBuilder struct {
+	Config Config
+
+	organization *string
+	tenant       *string
+
+	authType string
+
+	clientId     *string
+	clientSecret *string
+
+	redirectUri *string
+	scopes      *string
+
+	pat *string
+}
+
+func (b *ConfigBuilder) WithOrganization(organization *string) *ConfigBuilder {
+	b.organization = organization
+	return b
+}
+
+func (b *ConfigBuilder) WithTenant(tenant *string) *ConfigBuilder {
+	b.tenant = tenant
+	return b
+}
+
+func (b *ConfigBuilder) WithCredentials(clientId *string, clientSecret *string) *ConfigBuilder {
+	b.authType = AuthTypeCredentials
+	b.clientId = clientId
+	b.clientSecret = clientSecret
+	return b
+}
+
+func (b *ConfigBuilder) WithLogin(clientId *string, clientSecret *string, redirectUri *string, scopes *string) *ConfigBuilder {
+	b.authType = AuthTypeLogin
+	b.clientId = clientId
+	b.clientSecret = clientSecret
+	b.redirectUri = redirectUri
+	b.scopes = scopes
+	return b
+}
+
+func (b *ConfigBuilder) WithPat(pat *string) *ConfigBuilder {
+	b.authType = AuthTypePat
+	b.pat = pat
+	return b
+}
+
+func (b *ConfigBuilder) Build() (Config, bool) {
+	cfg := b.Config
+	authType := cfg.AuthType()
+
+	if b.organization != nil {
+		cfg.SetOrganization(*b.organization)
+	}
+	if b.tenant != nil {
+		cfg.SetTenant(*b.tenant)
+	}
+
+	switch b.authType {
+	case AuthTypeCredentials:
+		cfg.SetCredentialsAuth(b.clientId, b.clientSecret)
+	case AuthTypeLogin:
+		cfg.SetLoginAuth(b.clientId, b.clientSecret, b.redirectUri, b.scopes)
+	case AuthTypePat:
+		cfg.SetPatAuth(b.pat)
+	}
+
+	changed := b.organization != nil ||
+		b.tenant != nil ||
+		b.clientId != nil ||
+		b.clientSecret != nil ||
+		b.redirectUri != nil ||
+		b.scopes != nil ||
+		b.pat != nil ||
+		(b.authType != "" && b.authType != authType)
+	return cfg, changed
+}
+
+func NewConfigBuilder(cfg Config) *ConfigBuilder {
+	return &ConfigBuilder{
+		Config: cfg,
+	}
+}


### PR DESCRIPTION
- Added support for user login flows uing the browser with confidential apps.

- Parsing the clientSecret from the auth config and passing it in the `POST /connect/token` request

- Extended the `uipath config --auth login` command to, optionally, ask for client secret

- Created ConfigBuilder struct to better keep track of the inputted values of the user so that it is clear whether the user skipped over a value or entered a whitespace, for example.

- Added environment variable support for all basic auth values: `UIPATH_AUTH_GRANT_TYPE`: overrides the identity token request grant type (default client_credentials) `UIPATH_AUTH_SCOPES`: overrides the scopes `UIPATH_AUTH_REDIRECT_URI`: overrides the redirect uri for the OAuth flow

Example command:

```
uipath config --auth login

Enter organization [not set]: my-org
Enter tenant [not set]: my-tenant
Enter client id [not set]: 735db4d1-89d3-49c8-ad80-01c7ff871655
Enter client secret (only for confidential apps) [not set]: my-secret
Enter redirect uri [not set]: http://localhost:12700
Enter scopes [not set]: OR.Users
Successfully configured uipath CLI
```

Example config:

```
- name: default
  organization: my-org
  tenant: my-tenant
  auth:
    clientId: 735db4d1-89d3-49c8-ad80-01c7ff871655
    clientSecret: my-secret
    redirectUri: http://localhost:12700
    scopes: OR.Users
```

Implements https://github.com/UiPath/uipathcli/issues/192