### PR TITLE
Add support for refresh tokens

### DIFF
--- a/auth/authenticator_context.go
+++ b/auth/authenticator_context.go
@@ -1,6 +1,10 @@
 package auth
 
-import "net/url"
+import (
+	"net/url"
+
+	"github.com/UiPath/uipathcli/log"
+)
 
 // AuthenticatorContext provides information required for authenticating requests.
 type AuthenticatorContext struct {
@@ -9,7 +13,9 @@ type AuthenticatorContext struct {
 	IdentityUri url.URL
 	OperationId string
 	Insecure    bool
+	Debug       bool
 	Request     AuthenticatorRequest
+	Logger      log.Logger
 }
 
 func NewAuthenticatorContext(
@@ -18,6 +24,9 @@ func NewAuthenticatorContext(
 	identityUri url.URL,
 	operationId string,
 	insecure bool,
-	request AuthenticatorRequest) *AuthenticatorContext {
-	return &AuthenticatorContext{authType, config, identityUri, operationId, insecure, request}
+	debug bool,
+	request AuthenticatorRequest,
+	logger log.Logger,
+) *AuthenticatorContext {
+	return &AuthenticatorContext{authType, config, identityUri, operationId, insecure, debug, request, logger}
 }

--- a/auth/identity_client.go
+++ b/auth/identity_client.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -9,95 +10,107 @@ import (
 	"strings"
 	"time"
 
-	"github.com/UiPath/uipathcli/cache"
+	"github.com/UiPath/uipathcli/log"
 	"github.com/UiPath/uipathcli/utils/network"
 )
 
 type identityClient struct {
-	cache cache.Cache
+	logger log.Logger
 }
 
-const TokenRoute = "/connect/token"
+const tokenRoute = "/connect/token"
+const redactedMessage = "**redacted**"
 
 func (c identityClient) GetToken(tokenRequest tokenRequest) (*tokenResponse, error) {
-	form := url.Values{}
-	form.Add("grant_type", tokenRequest.GrantType)
-	form.Add("scope", tokenRequest.Scopes)
-	form.Add("client_id", tokenRequest.ClientId)
-	form.Add("client_secret", tokenRequest.ClientSecret)
-	form.Add("code", tokenRequest.Code)
-	form.Add("code_verifier", tokenRequest.CodeVerifier)
-	form.Add("redirect_uri", tokenRequest.RedirectUri)
-	for key, value := range tokenRequest.Properties {
-		form.Add(key, value)
+	request := tokenRequestForm{
+		GrantType:    tokenRequest.GrantType,
+		Scopes:       tokenRequest.Scopes,
+		ClientId:     tokenRequest.ClientId,
+		ClientSecret: tokenRequest.ClientSecret,
+		Code:         tokenRequest.Code,
+		CodeVerifier: tokenRequest.CodeVerifier,
+		RedirectUri:  tokenRequest.RedirectUri,
+		RefreshToken: tokenRequest.RefreshToken,
+		Properties:   tokenRequest.Properties,
 	}
-
-	cacheKey := c.cacheKey(tokenRequest)
-	token, expiresIn := c.cache.Get(cacheKey)
-	if token != "" {
-		return newTokenResponse(token, expiresIn), nil
-	}
-
-	response, err := c.retrieveToken(tokenRequest.BaseUri, form, tokenRequest.OperationId, tokenRequest.Insecure)
+	response, err := c.retrieveToken(tokenRequest.BaseUri, request, tokenRequest.Settings)
 	if err != nil {
 		return nil, err
 	}
-	c.cache.Set(cacheKey, response.AccessToken, response.ExpiresIn)
-	return response, nil
+
+	expiresAt := time.Now().UTC().Add(time.Duration(response.ExpiresIn) * time.Second)
+	return newTokenResponse(response.AccessToken, expiresAt, response.RefreshToken), nil
 }
 
-func (c identityClient) retrieveToken(baseUri url.URL, form url.Values, operationId string, insecure bool) (*tokenResponse, error) {
-	uri := baseUri.JoinPath(TokenRoute)
+func (c identityClient) retrieveToken(baseUri url.URL, form tokenRequestForm, settings network.HttpClientSettings) (*tokenResponseJson, error) {
+	uri := baseUri.JoinPath(tokenRoute)
 	header := http.Header{
 		"Content-Type": {"application/x-www-form-urlencoded"},
 	}
 	request := network.NewHttpPostRequest(uri.String(), nil, header, strings.NewReader(form.Encode()), -1)
+	c.logRequest(settings.Debug, request, strings.NewReader(form.Redacted()))
 
-	clientSettings := network.NewHttpClientSettings(false, operationId, map[string]string{}, time.Duration(60)*time.Second, 3, insecure)
-	client := network.NewHttpClient(nil, *clientSettings)
+	settingsNoDebug := c.networkSettingsNoDebug(settings)
+	client := network.NewHttpClient(nil, settingsNoDebug)
 	response, err := client.Send(request)
 	if err != nil {
 		return nil, err
 	}
 	defer func() { _ = response.Body.Close() }()
-	bytes, err := io.ReadAll(response.Body)
+	responseBody, err := io.ReadAll(response.Body)
 	if err != nil {
 		return nil, fmt.Errorf("Error reading response: %w", err)
 	}
 	if response.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("Token service returned status code '%d' and body '%s'", response.StatusCode, string(bytes))
+		c.logResponse(settings.Debug, response, bytes.NewReader(responseBody))
+		return nil, fmt.Errorf("Token service returned status code '%d' and body '%s'", response.StatusCode, string(responseBody))
 	}
 
-	var result tokenResponse
-	err = json.Unmarshal(bytes, &result)
+	var responseJson tokenResponseJson
+	err = json.Unmarshal(responseBody, &responseJson)
 	if err != nil {
+		c.logResponse(settings.Debug, response, bytes.NewReader(responseBody))
 		return nil, fmt.Errorf("Error parsing json response: %w", err)
 	}
-	return &result, nil
+	c.logResponseJson(settings.Debug, response, responseJson)
+	return &responseJson, nil
 }
 
-func (c identityClient) cacheKey(tokenRequest tokenRequest) string {
-	return fmt.Sprintf("token|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s",
-		tokenRequest.BaseUri.Scheme,
-		tokenRequest.BaseUri.Hostname(),
-		tokenRequest.GrantType,
-		tokenRequest.Scopes,
-		tokenRequest.ClientId,
-		tokenRequest.ClientSecret,
-		tokenRequest.Code,
-		tokenRequest.CodeVerifier,
-		tokenRequest.RedirectUri,
-		c.cacheKeyProperties(tokenRequest.Properties))
-}
-
-func (c identityClient) cacheKeyProperties(properties map[string]string) string {
-	values := []string{}
-	for key, value := range properties {
-		values = append(values, key+"="+value)
+func (c identityClient) logRequest(debug bool, request *network.HttpRequest, body io.Reader) {
+	if !debug {
+		return
 	}
-	return strings.Join(values, ",")
+	requestInfo := log.NewRequestInfo(request.Method, request.URL, request.Proto, request.Header, body)
+	c.logger.LogRequest(*requestInfo)
 }
 
-func newIdentityClient(cache cache.Cache) *identityClient {
-	return &identityClient{cache}
+func (c identityClient) logResponse(debug bool, response *network.HttpResponse, body io.Reader) {
+	if !debug {
+		return
+	}
+	responseInfo := log.NewResponseInfo(response.StatusCode, response.Status, response.Proto, response.Header, body)
+	c.logger.LogResponse(*responseInfo)
+}
+
+func (c identityClient) logResponseJson(debug bool, response *network.HttpResponse, body tokenResponseJson) {
+	if !debug {
+		return
+	}
+	data, _ := json.Marshal(body.Redacted())
+	c.logResponse(debug, response, bytes.NewReader(data))
+}
+
+func (c identityClient) networkSettingsNoDebug(settings network.HttpClientSettings) network.HttpClientSettings {
+	return *network.NewHttpClientSettings(
+		false,
+		settings.OperationId,
+		settings.Header,
+		settings.Timeout,
+		settings.MaxAttempts,
+		settings.Insecure,
+	)
+}
+
+func newIdentityClient(logger log.Logger) *identityClient {
+	return &identityClient{logger}
 }

--- a/auth/oauth_authenticator_config.go
+++ b/auth/oauth_authenticator_config.go
@@ -3,11 +3,12 @@ package auth
 import "net/url"
 
 type oauthAuthenticatorConfig struct {
-	ClientId     string
-	ClientSecret string
-	RedirectUrl  url.URL
-	Scopes       string
-	IdentityUri  url.URL
+	ClientId      string
+	ClientSecret  string
+	RedirectUrl   url.URL
+	Scopes        string
+	IdentityUri   url.URL
+	OfflineAccess bool
 }
 
 func newOAuthAuthenticatorConfig(
@@ -15,6 +16,8 @@ func newOAuthAuthenticatorConfig(
 	clientSecret string,
 	redirectUrl url.URL,
 	scopes string,
-	identityUri url.URL) *oauthAuthenticatorConfig {
-	return &oauthAuthenticatorConfig{clientId, clientSecret, redirectUrl, scopes, identityUri}
+	identityUri url.URL,
+	offlineAccess bool,
+) *oauthAuthenticatorConfig {
+	return &oauthAuthenticatorConfig{clientId, clientSecret, redirectUrl, scopes, identityUri, offlineAccess}
 }

--- a/auth/token_request.go
+++ b/auth/token_request.go
@@ -1,6 +1,10 @@
 package auth
 
-import "net/url"
+import (
+	"net/url"
+
+	"github.com/UiPath/uipathcli/utils/network"
+)
 
 type tokenRequest struct {
 	BaseUri      url.URL
@@ -12,14 +16,18 @@ type tokenRequest struct {
 	CodeVerifier string
 	RedirectUri  string
 	Properties   map[string]string
-	OperationId  string
-	Insecure     bool
+	RefreshToken string
+	Settings     network.HttpClientSettings
 }
 
-func newTokenRequest(baseUri url.URL, grantType string, scopes string, clientId string, clientSecret string, properties map[string]string, operationId string, insecure bool) *tokenRequest {
-	return &tokenRequest{baseUri, grantType, scopes, clientId, clientSecret, "", "", "", properties, operationId, insecure}
+func newTokenRequest(baseUri url.URL, grantType string, scopes string, clientId string, clientSecret string, properties map[string]string, settings network.HttpClientSettings) *tokenRequest {
+	return &tokenRequest{baseUri, grantType, scopes, clientId, clientSecret, "", "", "", properties, "", settings}
 }
 
-func newAuthorizationCodeTokenRequest(baseUri url.URL, clientId string, clientSecret string, code string, codeVerifier string, redirectUrl string, operationId string, insecure bool) *tokenRequest {
-	return &tokenRequest{baseUri, "authorization_code", "", clientId, clientSecret, code, codeVerifier, redirectUrl, map[string]string{}, operationId, insecure}
+func newAuthorizationCodeTokenRequest(baseUri url.URL, clientId string, clientSecret string, code string, codeVerifier string, redirectUrl string, settings network.HttpClientSettings) *tokenRequest {
+	return &tokenRequest{baseUri, "authorization_code", "", clientId, clientSecret, code, codeVerifier, redirectUrl, map[string]string{}, "", settings}
+}
+
+func newRefreshTokenRequest(baseUri url.URL, clientId string, clientSecret string, refreshToken string, settings network.HttpClientSettings) *tokenRequest {
+	return &tokenRequest{baseUri, "refresh_token", "", clientId, clientSecret, "", "", "", map[string]string{}, refreshToken, settings}
 }

--- a/auth/token_request_form.go
+++ b/auth/token_request_form.go
@@ -1,0 +1,78 @@
+package auth
+
+import "net/url"
+
+type tokenRequestForm struct {
+	GrantType    string
+	Scopes       string
+	ClientId     string
+	ClientSecret string
+	Code         string
+	CodeVerifier string
+	RedirectUri  string
+	Properties   map[string]string
+	RefreshToken string
+}
+
+func (r tokenRequestForm) Encode() string {
+	form := r.createForm(
+		r.GrantType,
+		r.Scopes,
+		r.ClientId,
+		r.ClientSecret,
+		r.Code,
+		r.CodeVerifier,
+		r.RedirectUri,
+		r.RefreshToken,
+		r.Properties,
+	)
+	return form.Encode()
+}
+
+func (r tokenRequestForm) Redacted() string {
+	form := r.createForm(
+		r.GrantType,
+		r.Scopes,
+		r.ClientId,
+		r.redact(r.ClientSecret),
+		r.Code,
+		r.CodeVerifier,
+		r.RedirectUri,
+		r.redact(r.RefreshToken),
+		r.Properties,
+	)
+	return form.Encode()
+}
+
+func (r tokenRequestForm) createForm(
+	grantType string,
+	scopes string,
+	clientId string,
+	clientSecret string,
+	code string,
+	codeVerifier string,
+	redirectUri string,
+	refreshToken string,
+	properties map[string]string,
+) url.Values {
+	form := url.Values{}
+	form.Add("grant_type", grantType)
+	form.Add("scope", scopes)
+	form.Add("client_id", clientId)
+	form.Add("client_secret", clientSecret)
+	form.Add("code", code)
+	form.Add("code_verifier", codeVerifier)
+	form.Add("redirect_uri", redirectUri)
+	form.Add("refresh_token", refreshToken)
+	for key, value := range properties {
+		form.Add(key, value)
+	}
+	return form
+}
+
+func (r tokenRequestForm) redact(value string) string {
+	if value == "" {
+		return ""
+	}
+	return redactedMessage
+}

--- a/auth/token_response.go
+++ b/auth/token_response.go
@@ -1,10 +1,13 @@
 package auth
 
+import "time"
+
 type tokenResponse struct {
-	AccessToken string  `json:"access_token"`
-	ExpiresIn   float32 `json:"expires_in"`
+	AccessToken  string
+	ExpiresAt    time.Time
+	RefreshToken *string
 }
 
-func newTokenResponse(accessToken string, expiresIn float32) *tokenResponse {
-	return &tokenResponse{accessToken, expiresIn}
+func newTokenResponse(accessToken string, expiresAt time.Time, refreshToken *string) *tokenResponse {
+	return &tokenResponse{accessToken, expiresAt, refreshToken}
 }

--- a/auth/token_response_json.go
+++ b/auth/token_response_json.go
@@ -1,0 +1,27 @@
+package auth
+
+type tokenResponseJson struct {
+	AccessToken  string  `json:"access_token"`
+	ExpiresIn    float32 `json:"expires_in"`
+	TokenType    string  `json:"token_type"`
+	Scope        string  `json:"scope"`
+	RefreshToken *string `json:"refresh_token,omitempty"`
+}
+
+func (r tokenResponseJson) Redacted() tokenResponseJson {
+	return tokenResponseJson{
+		AccessToken:  r.AccessToken,
+		ExpiresIn:    r.ExpiresIn,
+		TokenType:    r.TokenType,
+		Scope:        r.Scope,
+		RefreshToken: r.redact(r.RefreshToken),
+	}
+}
+
+func (r tokenResponseJson) redact(value *string) *string {
+	if value == nil {
+		return nil
+	}
+	result := redactedMessage
+	return &result
+}

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -2,10 +2,12 @@
 // across multiple CLI invocations.
 package cache
 
+import "time"
+
 // Cache interface for storing temporary data.
 // It is used to persist bearer tokens and other temporary auth tokens
 // in order to preserve them across multiple CLI invocations.
 type Cache interface {
-	Get(key string) (string, float32)
-	Set(key string, value string, expiresIn float32)
+	Get(key string) (string, time.Time)
+	Set(key string, value string, expiresAt time.Time)
 }

--- a/cache/file_cache_test.go
+++ b/cache/file_cache_test.go
@@ -16,7 +16,8 @@ func TestGetReturnsNoDataWhenNotCached(t *testing.T) {
 	if value != "" {
 		t.Errorf("Should not return any data from cache, but got: %v", value)
 	}
-	if expiry != 0 {
+	zero := time.Time{}
+	if expiry != zero {
 		t.Errorf("Should not return expiry value, but got: %v", expiry)
 	}
 }
@@ -25,16 +26,16 @@ func TestGetReturnsDataWhenSet(t *testing.T) {
 	cache := NewFileCache()
 
 	key := randomKey()
-	before := time.Now().Unix() + int64(60)
+	expiry := time.Now().UTC().Add(time.Second * 30)
 
-	cache.Set(key, "my-value", 60)
-	value, expiry := cache.Get(key)
+	cache.Set(key, "my-value", expiry)
+	value, expiresAt := cache.Get(key)
 
 	if value != "my-value" {
 		t.Errorf("Should return data from cache, but got: %v", value)
 	}
-	if expiry < float32(before) {
-		t.Errorf("Should return expiry value which is after %v, but got: %v", before, expiry)
+	if expiry.Unix() != expiresAt.Unix() {
+		t.Errorf("Should return expiry value %v, but got: %v", expiry.Unix(), expiresAt.Unix())
 	}
 }
 
@@ -42,28 +43,14 @@ func TestGetDoesNotReturnExpiredData(t *testing.T) {
 	cache := NewFileCache()
 
 	key := randomKey()
-	cache.Set(key, "my-value", -1)
+	cache.Set(key, "my-value", time.Now().UTC().Add(-time.Second))
 	value, expiry := cache.Get(key)
 
 	if value != "" {
 		t.Errorf("Should not return any data from cache, but got: %v", value)
 	}
-	if expiry != 0 {
-		t.Errorf("Should not return expiry value, but got: %v", expiry)
-	}
-}
-
-func TestGetDoesNotReturnDataWhichExpiresSoon(t *testing.T) {
-	cache := NewFileCache()
-
-	key := randomKey()
-	cache.Set(key, "my-value", 10)
-	value, expiry := cache.Get(key)
-
-	if value != "" {
-		t.Errorf("Should not return any data from cache, but got: %v", value)
-	}
-	if expiry != 0 {
+	zero := time.Time{}
+	if expiry != zero {
 		t.Errorf("Should not return expiry value, but got: %v", expiry)
 	}
 }

--- a/plugin/studio/publish/package_publish_command_test.go
+++ b/plugin/studio/publish/package_publish_command_test.go
@@ -152,7 +152,7 @@ func TestPublishUploadsLatestPackageFromDirectory(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = os.Chtimes(archive1Path, time.Time{}, time.Now().Add(-5*time.Minute))
+	err = os.Chtimes(archive1Path, time.Time{}, time.Now().Add(time.Duration(-5)*time.Minute))
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
The CLI makes the user go through the oauth login authorization flow every time the access token expired. The access tokens are short-lived and expiration is currently set to 1 hour which requires the user to re-login almost every time they are using the CLI.

Taking advantage of the refresh token support in the Identity Server to automatically renew access tokens for the user. If there is a valid refresh token, there is no action required by the user.

In case the refresh token expired or the renewal of the access token fails for any other reason, the user is required to login again.

Implementation:

- Automatically adding the offline_access scope during the oauth flow so that the Identity Server returns a refresh token.

- Caching the refresh token using the cache package similar to access tokens.

- Added new configuration parameter `offlineAccess` to disable refresh token support, e.g.

```
- name: default
  organization: <your-org>
  tenant: defaulttenant
  auth:
    offlineAccess: false
```

- Extended debug logging to log identity server requests and responses as well as detailed log messages for refresh token and access token handling. Redacting the client secret and refresh tokens to avoid them being accidentally leaked

Implements https://github.com/UiPath/uipathcli/issues/193