### PR TITLE
Improve command error messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -485,13 +485,13 @@ uipath orchestrator users get --profile automationsuite
 CLI commands consist of four main parts:
 
 ```bash
-uipath <service-name> <resource-name> <operation-name> --<argument1> --<argument2>
+uipath <service-name> <resource-name> <operation-name> --<argument1> <value1> [--<argument2> <value2>]
 ```
 
 - `<service-name>`: The UiPath product or service to call
 - `<resource-name>`: The resource to access
 - `<operation-name>`: The operation to perform on the resource
-- `<argument>`: A list of arguments passed to the operation
+- `--<argument> <value>`: A list of arguments and their values passed to the operation
 
 Example:
 

--- a/commandline/command_builder.go
+++ b/commandline/command_builder.go
@@ -669,8 +669,11 @@ func (b CommandBuilder) loadDefinitions(args []string, serviceVersion string) ([
 		return b.loadAllDefinitions(serviceVersion)
 	}
 	definition, err := b.DefinitionProvider.Load(args[1], serviceVersion)
-	if definition == nil {
+	if err != nil {
 		return nil, err
+	}
+	if definition == nil {
+		return b.DefinitionProvider.Index(serviceVersion)
 	}
 	return []parser.Definition{*definition}, err
 }

--- a/test/parser_test.go
+++ b/test/parser_test.go
@@ -6,6 +6,99 @@ import (
 	"testing"
 )
 
+func TestUnknownCommandShowsError(t *testing.T) {
+	definition := `
+paths:
+  /ping:
+    get:
+      summary: Simple ping
+`
+	context := NewContextBuilder().
+		WithDefinition("myservice", definition).
+		Build()
+
+	result := RunCli([]string{"unknown"}, context)
+
+	if result.Error == nil || result.Error.Error() != "Command 'unknown' not found" {
+		t.Errorf("Unexpected error, got: %v", result.Error)
+	}
+}
+
+func TestUnknownFlagOnMainCommandShowsError(t *testing.T) {
+	definition := `
+paths:
+  /ping:
+    get:
+      summary: Simple ping
+`
+	context := NewContextBuilder().
+		WithDefinition("myservice", definition).
+		Build()
+
+	result := RunCli([]string{"--unknown", "myvalue"}, context)
+
+	if result.Error == nil || result.Error.Error() != "Incorrect usage: flag provided but not defined: -unknown" {
+		t.Errorf("Unexpected error, got: %v", result.Error)
+	}
+}
+
+func TestRunMainCommandShowsError(t *testing.T) {
+	definition := `
+paths:
+  /ping:
+    get:
+      summary: Simple ping
+`
+	context := NewContextBuilder().
+		WithDefinition("myservice", definition).
+		Build()
+
+	result := RunCli([]string{"--query", "myvalue"}, context)
+
+	if result.Error == nil || result.Error.Error() != `No command provided.
+
+Please provide service and operation command in the following format:
+uipath <service> <operation> --<argument> <value>` {
+		t.Errorf("Unexpected error, got: %v", result.Error)
+	}
+}
+
+func TestUnknownSubCommandShowsError(t *testing.T) {
+	definition := `
+paths:
+  /ping:
+    get:
+      summary: Simple ping
+`
+	context := NewContextBuilder().
+		WithDefinition("myservice", definition).
+		Build()
+
+	result := RunCli([]string{"myservice", "unknown"}, context)
+
+	if result.Error == nil || result.Error.Error() != "Command 'unknown' not found" {
+		t.Errorf("Unexpected error, got: %v", result.Error)
+	}
+}
+
+func TestUnknownFlagOnSubCommandShowsError(t *testing.T) {
+	definition := `
+paths:
+  /ping:
+    get:
+      summary: Simple ping
+`
+	context := NewContextBuilder().
+		WithDefinition("myservice", definition).
+		Build()
+
+	result := RunCli([]string{"myservice", "--unknown", "myvalue"}, context)
+
+	if result.Error == nil || result.Error.Error() != "Incorrect usage: flag provided but not defined: -unknown" {
+		t.Errorf("Unexpected error, got: %v", result.Error)
+	}
+}
+
 func TestInvalidDefinitionReturnsError(t *testing.T) {
 	definition := `
 paths: INVALID DEFINITION


### PR DESCRIPTION
Properly handling unknown commands and flags to show meaningful error messags. Fixed a bug where the help output did not show all available commands.

- Using the CLI without command (e.g. `uipath --query 'my-query'`) will now show an error message that no command was provided.

- Providing an unknown command (e.g. `uipath du unknown`) displays now `Command 'unknown' not found`

- When using an invalid service name (e.g. `uipath unknown`) the help output now shows all available services

- Changed the error messages for unknown flags to be more consistent

Fixes https://github.com/UiPath/uipathcli/issues/162