### PR TITLE
Improve config set command

### DIFF
--- a/auth/authenticator_context.go
+++ b/auth/authenticator_context.go
@@ -8,7 +8,6 @@ import (
 
 // AuthenticatorContext provides information required for authenticating requests.
 type AuthenticatorContext struct {
-	Type        string
 	Config      map[string]interface{}
 	IdentityUri url.URL
 	OperationId string
@@ -19,7 +18,6 @@ type AuthenticatorContext struct {
 }
 
 func NewAuthenticatorContext(
-	authType string,
 	config map[string]interface{},
 	identityUri url.URL,
 	operationId string,
@@ -28,5 +26,13 @@ func NewAuthenticatorContext(
 	request AuthenticatorRequest,
 	logger log.Logger,
 ) *AuthenticatorContext {
-	return &AuthenticatorContext{authType, config, identityUri, operationId, insecure, debug, request, logger}
+	return &AuthenticatorContext{
+		config,
+		identityUri,
+		operationId,
+		insecure,
+		debug,
+		request,
+		logger,
+	}
 }

--- a/auth/oauth_authenticator_test.go
+++ b/auth/oauth_authenticator_test.go
@@ -424,7 +424,7 @@ func createNonConfidentialAuthContext(baseUrl url.URL) AuthenticatorContext {
 func createAuthContext(baseUrl url.URL, config map[string]interface{}, debug bool, writer io.Writer) AuthenticatorContext {
 	identityUrl := createIdentityUrl(baseUrl.Host)
 	request := NewAuthenticatorRequest(fmt.Sprintf("%s://%s", baseUrl.Scheme, baseUrl.Host), map[string]string{})
-	context := NewAuthenticatorContext("login", config, identityUrl, "d7b087788be2154da3ad9d6bc14588f4", false, debug, *request, log.NewDebugLogger(writer))
+	context := NewAuthenticatorContext(config, identityUrl, "d7b087788be2154da3ad9d6bc14588f4", false, debug, *request, log.NewDebugLogger(writer))
 	return *context
 }
 

--- a/commandline/command_builder.go
+++ b/commandline/command_builder.go
@@ -167,9 +167,8 @@ func (b CommandBuilder) createIdentityUri(context *CommandExecContext, config co
 		return identityUri, nil
 	}
 
-	value := config.Auth.Config["uri"]
-	uri, valid := value.(string)
-	if valid && uri != "" {
+	uri = config.AuthUri()
+	if uri != "" {
 		identityUri, err := url.Parse(uri)
 		if err != nil {
 			return nil, fmt.Errorf("Error parsing identity uri config: %w", err)
@@ -599,7 +598,7 @@ func (b CommandBuilder) createConfigSetCommand() *CommandDefinition {
 	const flagNameValue = "value"
 
 	flags := NewFlagBuilder().
-		AddFlag(NewFlag(flagNameKey, "The key", FlagTypeString).
+		AddFlag(NewFlag(flagNameKey, "The key\n\n"+b.configSetKeyAllowedValues(), FlagTypeString).
 			WithRequired(true)).
 		AddFlag(NewFlag(flagNameValue, "The value to set", FlagTypeString).
 			WithRequired(true)).
@@ -618,6 +617,18 @@ func (b CommandBuilder) createConfigSetCommand() *CommandDefinition {
 			handler := newConfigCommandHandler(b.StdIn, b.StdOut, b.ConfigProvider)
 			return handler.Set(key, value, profileName)
 		})
+}
+
+func (b CommandBuilder) configSetKeyAllowedValues() string {
+	builder := strings.Builder{}
+	builder.WriteString("Allowed values:")
+	for _, value := range ConfigKeys {
+		if strings.HasSuffix(value, ".") {
+			value = value + "<key>"
+		}
+		builder.WriteString("\n- " + value)
+	}
+	return builder.String()
 }
 
 func (b CommandBuilder) createCacheClearCommand() *CommandDefinition {

--- a/commandline/config_command_handler.go
+++ b/commandline/config_command_handler.go
@@ -27,6 +27,34 @@ const maskMessage = "*******"
 const successfullyConfiguredMessage = "Successfully configured uipath CLI"
 const successfullySetMessage = "Successfully set config value"
 
+const ConfigKeyServiceVersion = "serviceVersion"
+const ConfigKeyOrganization = "organization"
+const ConfigKeyTenant = "tenant"
+const ConfigKeyUri = "uri"
+const ConfigKeyInsecure = "insecure"
+const ConfigKeyDebug = "debug"
+const ConfigKeyAuthGrantType = "auth.grantType"
+const ConfigKeyAuthScopes = "auth.scopes"
+const ConfigKeyAuthUri = "auth.uri"
+const ConfigKeyAuthProperties = "auth.properties."
+const ConfigKeyHeader = "header."
+const ConfigKeyParameter = "parameter."
+
+var ConfigKeys = []string{
+	ConfigKeyServiceVersion,
+	ConfigKeyOrganization,
+	ConfigKeyTenant,
+	ConfigKeyUri,
+	ConfigKeyInsecure,
+	ConfigKeyDebug,
+	ConfigKeyAuthGrantType,
+	ConfigKeyAuthScopes,
+	ConfigKeyAuthUri,
+	ConfigKeyAuthProperties,
+	ConfigKeyHeader,
+	ConfigKeyParameter,
+}
+
 func (h configCommandHandler) Set(key string, value string, profileName string) error {
 	cfg := h.getOrCreateProfile(profileName)
 	err := h.setConfigValue(&cfg, key, value)
@@ -43,60 +71,62 @@ func (h configCommandHandler) Set(key string, value string, profileName string) 
 
 func (h configCommandHandler) setConfigValue(cfg *config.Config, key string, value string) error {
 	keyParts := strings.Split(key, ".")
-	if key == "serviceVersion" {
+	if key == ConfigKeyServiceVersion {
 		cfg.SetServiceVersion(value)
 		return nil
-	} else if key == "organization" {
+	} else if key == ConfigKeyOrganization {
 		cfg.SetOrganization(value)
 		return nil
-	} else if key == "tenant" {
+	} else if key == ConfigKeyTenant {
 		cfg.SetTenant(value)
 		return nil
-	} else if key == "uri" {
+	} else if key == ConfigKeyUri {
 		return cfg.SetUri(value)
-	} else if key == "insecure" {
+	} else if key == ConfigKeyInsecure {
 		insecure, err := h.convertToBool(value)
 		if err != nil {
-			return fmt.Errorf("Invalid value for 'insecure': %w", err)
+			return fmt.Errorf("Invalid value for '%s': %w", ConfigKeyInsecure, err)
 		}
 		cfg.SetInsecure(insecure)
 		return nil
-	} else if key == "debug" {
+	} else if key == ConfigKeyDebug {
 		debug, err := h.convertToBool(value)
 		if err != nil {
-			return fmt.Errorf("Invalid value for 'debug': %w", err)
+			return fmt.Errorf("Invalid value for '%s': %w", ConfigKeyDebug, err)
 		}
 		cfg.SetDebug(debug)
 		return nil
-	} else if key == "auth.grantType" {
+	} else if key == ConfigKeyAuthGrantType {
 		cfg.SetAuthGrantType(value)
 		return nil
-	} else if key == "auth.scopes" {
+	} else if key == ConfigKeyAuthScopes {
 		cfg.SetAuthScopes(value)
 		return nil
-	} else if h.isHeaderKey(keyParts) {
+	} else if key == ConfigKeyAuthUri {
+		return cfg.SetAuthUri(value)
+	} else if h.isHeaderKey(key, keyParts) {
 		cfg.SetHeader(keyParts[1], value)
 		return nil
-	} else if h.isParameterKey(keyParts) {
+	} else if h.isParameterKey(key, keyParts) {
 		cfg.SetParameter(keyParts[1], value)
 		return nil
-	} else if h.isAuthPropertyKey(keyParts) {
+	} else if h.isAuthPropertyKey(key, keyParts) {
 		cfg.SetAuthProperty(keyParts[2], value)
 		return nil
 	}
 	return fmt.Errorf("Unknown config key '%s'", key)
 }
 
-func (h configCommandHandler) isHeaderKey(keyParts []string) bool {
-	return len(keyParts) == 2 && keyParts[0] == "header"
+func (h configCommandHandler) isHeaderKey(key string, keyParts []string) bool {
+	return strings.HasPrefix(key, ConfigKeyHeader) && len(keyParts) == 2
 }
 
-func (h configCommandHandler) isParameterKey(keyParts []string) bool {
-	return len(keyParts) == 2 && keyParts[0] == "parameter"
+func (h configCommandHandler) isParameterKey(key string, keyParts []string) bool {
+	return strings.HasPrefix(key, ConfigKeyParameter) && len(keyParts) == 2
 }
 
-func (h configCommandHandler) isAuthPropertyKey(keyParts []string) bool {
-	return len(keyParts) == 3 && keyParts[0] == "auth" && keyParts[1] == "properties"
+func (h configCommandHandler) isAuthPropertyKey(key string, keyParts []string) bool {
+	return strings.HasPrefix(key, ConfigKeyAuthProperties) && len(keyParts) == 3
 }
 
 func (h configCommandHandler) convertToBool(value string) (bool, error) {

--- a/config/config_provider.go
+++ b/config/config_provider.go
@@ -44,7 +44,7 @@ func (p *ConfigProvider) Update(profileName string, config Config) error {
 	profile.Debug = config.Debug
 	profile.Organization = config.Organization
 	profile.Tenant = config.Tenant
-	profile.Auth = config.Auth.Config
+	profile.Auth = config.Auth
 	profile.Header = config.Header
 	profile.Parameter = config.Parameter
 	profile.ServiceVersion = config.ServiceVersion
@@ -73,15 +73,12 @@ func (p *ConfigProvider) convertToConfig(profile profileYaml) Config {
 		profile.Header = map[string]string{}
 	}
 	return Config{
-		Organization: profile.Organization,
-		Tenant:       profile.Tenant,
-		Uri:          profile.Uri.URL,
-		Parameter:    profile.Parameter,
-		Header:       profile.Header,
-		Auth: AuthConfig{
-			Type:   fmt.Sprint(profile.Auth["type"]),
-			Config: profile.Auth,
-		},
+		Organization:   profile.Organization,
+		Tenant:         profile.Tenant,
+		Uri:            profile.Uri.URL,
+		Parameter:      profile.Parameter,
+		Header:         profile.Header,
+		Auth:           profile.Auth,
 		Insecure:       profile.Insecure,
 		Debug:          profile.Debug,
 		Output:         profile.Output,

--- a/executor/execution_context.go
+++ b/executor/execution_context.go
@@ -3,7 +3,6 @@ package executor
 import (
 	"net/url"
 
-	"github.com/UiPath/uipathcli/config"
 	"github.com/UiPath/uipathcli/plugin"
 	"github.com/UiPath/uipathcli/utils/stream"
 )
@@ -19,7 +18,7 @@ type ExecutionContext struct {
 	ContentType  string
 	Input        stream.Stream
 	Parameters   ExecutionParameters
-	AuthConfig   config.AuthConfig
+	AuthConfig   map[string]interface{}
 	IdentityUri  url.URL
 	Plugin       plugin.CommandPlugin
 	Debug        bool
@@ -35,7 +34,7 @@ func NewExecutionContext(
 	contentType string,
 	input stream.Stream,
 	parameters []ExecutionParameter,
-	authConfig config.AuthConfig,
+	authConfig map[string]interface{},
 	identityUri url.URL,
 	plugin plugin.CommandPlugin,
 	debug bool,

--- a/executor/http_executor.go
+++ b/executor/http_executor.go
@@ -136,8 +136,7 @@ func (e HttpExecutor) formatUri(baseUri url.URL, route string, pathParameters []
 func (e HttpExecutor) authenticatorContext(ctx ExecutionContext, logger log.Logger, url string) auth.AuthenticatorContext {
 	authRequest := *auth.NewAuthenticatorRequest(url, map[string]string{})
 	return *auth.NewAuthenticatorContext(
-		ctx.AuthConfig.Type,
-		ctx.AuthConfig.Config,
+		ctx.AuthConfig,
 		ctx.IdentityUri,
 		ctx.Settings.OperationId,
 		ctx.Settings.Insecure,

--- a/executor/plugin_executor.go
+++ b/executor/plugin_executor.go
@@ -20,8 +20,7 @@ type PluginExecutor struct {
 func (e PluginExecutor) authenticatorContext(ctx ExecutionContext, logger log.Logger) auth.AuthenticatorContext {
 	authRequest := *auth.NewAuthenticatorRequest(ctx.BaseUri.String(), map[string]string{})
 	return *auth.NewAuthenticatorContext(
-		ctx.AuthConfig.Type,
-		ctx.AuthConfig.Config,
+		ctx.AuthConfig,
 		ctx.IdentityUri,
 		ctx.Settings.OperationId,
 		ctx.Settings.Insecure,

--- a/test/config_set_test.go
+++ b/test/config_set_test.go
@@ -340,3 +340,36 @@ func TestConfigSetServiceVersion(t *testing.T) {
 		t.Errorf("Expected generated config %v, but got %v", expectedConfig, string(config))
 	}
 }
+
+func TestConfigSetAuthUri(t *testing.T) {
+	configFile := TempFile(t)
+	context := NewContextBuilder().
+		WithConfigFile(configFile).
+		Build()
+
+	RunCli([]string{"config", "set", "--key", "auth.uri", "--value", "https://alpha.uipath.com/identity_"}, context)
+
+	config, err := os.ReadFile(configFile)
+	if err != nil {
+		t.Errorf("Config file does not exist: %v", err)
+	}
+	expectedConfig := `profiles:
+- name: default
+  auth:
+    uri: https://alpha.uipath.com/identity_
+`
+	if string(config) != expectedConfig {
+		t.Errorf("Expected generated config %v, but got %v", expectedConfig, string(config))
+	}
+}
+
+func TestConfigInvalidAuthUri(t *testing.T) {
+	context := NewContextBuilder().
+		Build()
+
+	result := RunCli([]string{"config", "set", "--key", "auth.uri", "--value", "invalid uri\t"}, context)
+
+	if !strings.HasPrefix(result.StdErr, "Invalid value for 'auth.uri'") {
+		t.Errorf("Expected invalid auth.uri error, but got %v", result.StdErr)
+	}
+}


### PR DESCRIPTION
- Document allowed values for the `uipath config set` command so that the user actually knows which config values can be updated

- Add support to set identity server URI using the `auth.uri` key

Example (Set Identity Server URI):

```
uipath config set --key auth.uri --value https://<your-server>/identity_
```

Improves: https://github.com/UiPath/uipathcli/issues/192