### PR TITLE
Add support for HTTP proxies

### DIFF
--- a/utils/network/http_client.go
+++ b/utils/network/http_client.go
@@ -87,6 +87,7 @@ func (c HttpClient) resetReader(reader io.Reader) bool {
 
 func (c HttpClient) send(request *HttpRequest, ctx context.Context) (*HttpResponse, error) {
 	transport := &http.Transport{
+		Proxy:                 http.ProxyFromEnvironment,
 		TLSClientConfig:       &tls.Config{InsecureSkipVerify: c.settings.Insecure}, //nolint:gosec // This is user configurable and disabled by default
 		ResponseHeaderTimeout: c.settings.Timeout,
 	}


### PR DESCRIPTION
Passing the ProxyFromEnvironment when initializing the http.Transport so that HTTP_PROXY, HTTPS_PROXY and NO_PROXY environment variables are taken into account when sending HTTP requests.

Customers can set the env variables to enable their HTTP proxies, e.g.

```
$env:HTTPS_PROXY="localhost:8888"; uipath du discovery projects
```

Fixes https://github.com/UiPath/uipathcli/issues/201