### PR TITLE
Improve argument name conversion to snake case

### DIFF
--- a/parser/case_converter.go
+++ b/parser/case_converter.go
@@ -1,16 +1,36 @@
 package parser
 
 import (
-	"regexp"
 	"strings"
+	"unicode"
 )
-
-var snakeCaseRegex = regexp.MustCompile("([a-z0-9])([A-Z])")
 
 // toSnakeCase converts strings to snake case in order to have properly
 // named parameters, e.g.
 // MyOperation -> my-operation
-func toSnakeCase(str string) string {
-	snake := snakeCaseRegex.ReplaceAllString(str, "${1}-${2}")
-	return strings.ToLower(snake)
+func toSnakeCase(name string) string {
+	var builder strings.Builder
+	previousChar := ' '
+	withSeparator := false
+	for _, char := range name {
+		if char == '{' || char == '}' || char == '$' {
+			continue
+		}
+		if char == '/' || char == '_' || char == '-' {
+			withSeparator = true
+			continue
+		}
+		if unicode.IsLower(previousChar) && unicode.IsUpper(char) {
+			withSeparator = true
+		}
+
+		if withSeparator {
+			builder.WriteRune('-')
+		}
+		builder.WriteRune(unicode.ToLower(char))
+
+		withSeparator = false
+		previousChar = char
+	}
+	return builder.String()
 }

--- a/parser/case_converter_test.go
+++ b/parser/case_converter_test.go
@@ -6,10 +6,19 @@ func TestConvertsToSnakeCase(t *testing.T) {
 	t.Run("CamelCase", func(t *testing.T) { ConvertsToSnakeCase(t, "myValue", "my-value") })
 	t.Run("PascalCase", func(t *testing.T) { ConvertsToSnakeCase(t, "MyValue", "my-value") })
 	t.Run("ExistingDash", func(t *testing.T) { ConvertsToSnakeCase(t, "My-Value", "my-value") })
+	t.Run("IgnoresDuplicateDash", func(t *testing.T) { ConvertsToSnakeCase(t, "get--Ping", "get-ping") })
+	t.Run("IgnoresDuplicateUnderscore", func(t *testing.T) { ConvertsToSnakeCase(t, "get__Ping", "get-ping") })
+	t.Run("IgnoresDuplicateSlash", func(t *testing.T) { ConvertsToSnakeCase(t, "get//Ping", "get-ping") })
+	t.Run("IgnoresCurlyBrackets", func(t *testing.T) {
+		ConvertsToSnakeCase(t, "get/MyResource/{resourceId}", "get-my-resource-resource-id")
+	})
+	t.Run("IgnoresDollarSign", func(t *testing.T) {
+		ConvertsToSnakeCase(t, "get/$MyResource", "get-my-resource")
+	})
 }
 func ConvertsToSnakeCase(t *testing.T, input string, expected string) {
 	result := toSnakeCase(input)
 	if result != expected {
-		t.Errorf("Expected '%v' to be converted to snake case, but got: %v", expected, result)
+		t.Errorf("Expected %v, but got: %v", expected, result)
 	}
 }

--- a/parser/openapi_parser.go
+++ b/parser/openapi_parser.go
@@ -87,14 +87,6 @@ func (p OpenApiParser) getUri(document openapi3.T) (*url.URL, error) {
 	return url.Parse(server)
 }
 
-func (p OpenApiParser) formatName(name string) string {
-	name = strings.ReplaceAll(name, "$", "")
-	name = strings.ReplaceAll(name, "/", "-")
-	name = strings.ReplaceAll(name, "_", "-")
-	name = toSnakeCase(name)
-	return strings.ToLower(name)
-}
-
 func (p OpenApiParser) getOperationName(method string, route string, category *OperationCategory, operation openapi3.Operation) string {
 	name := method + route
 	customName := p.getCustomName(operation.Extensions)
@@ -104,7 +96,7 @@ func (p OpenApiParser) getOperationName(method string, route string, category *O
 	if operation.OperationID != "" {
 		name = operation.OperationID
 	}
-	name = p.formatName(name)
+	name = toSnakeCase(name)
 	if category != nil {
 		name = strings.TrimPrefix(name, category.Name+"-")
 	}
@@ -159,7 +151,7 @@ func (p OpenApiParser) parseSchema(fieldName string, schemaRef *openapi3.SchemaR
 	}
 	visitedSchemas[schemaRef] = true
 
-	name := p.formatName(fieldName)
+	name := toSnakeCase(fieldName)
 	_type := p.getType(schemaRef)
 	required := p.contains(requiredFieldnames, fieldName)
 	parameters := []Parameter{}
@@ -279,7 +271,7 @@ func (p OpenApiParser) parseRequestBodyParameters(requestBody *openapi3.RequestB
 
 func (p OpenApiParser) parseParameter(param openapi3.Parameter) Parameter {
 	fieldName := param.Name
-	name := p.formatName(fieldName)
+	name := toSnakeCase(fieldName)
 	customName := p.getCustomName(param.Extensions)
 	if customName != "" {
 		name = customName
@@ -320,7 +312,7 @@ func (p OpenApiParser) getCategory(definitionName string, document openapi3.T, o
 	if len(operation.Tags) > 0 {
 		name := operation.Tags[0]
 		tag := document.Tags.Get(name)
-		formattedName := p.formatName(name)
+		formattedName := toSnakeCase(name)
 		summary, description := p.getCategoryText(definitionName, formattedName, tag)
 		return NewOperationCategory(formattedName, summary, description)
 	}

--- a/test/parser_test.go
+++ b/test/parser_test.go
@@ -262,6 +262,42 @@ paths:
 	}
 }
 
+func TestCustomOperationNameFromRoute(t *testing.T) {
+	t.Run("SimpleGetRoute", func(t *testing.T) {
+		CustomOperationNameFromRoute(t, "get", "/ping", "get-ping")
+	})
+	t.Run("ComplexPathRoute", func(t *testing.T) {
+		CustomOperationNameFromRoute(t, "post", "/my-resource/update", "post-my-resource-update")
+	})
+	t.Run("CaseSensitiveRoute", func(t *testing.T) {
+		CustomOperationNameFromRoute(t, "get", "/MyResource/Ping", "get-my-resource-ping")
+	})
+	t.Run("CurlyBracketsAreIgnored", func(t *testing.T) {
+		CustomOperationNameFromRoute(t, "get", "/MyResource/{resourceId}/Ping", "get-my-resource-resource-id-ping")
+	})
+	t.Run("DollarSignIsIgnored", func(t *testing.T) {
+		CustomOperationNameFromRoute(t, "get", "/MyResource/$resourceId/Ping", "get-my-resource-resource-id-ping")
+	})
+}
+
+func CustomOperationNameFromRoute(t *testing.T, method string, route string, expectedName string) {
+	definition := `
+paths:
+  ` + route + `:
+    ` + method + `:
+      summary: Simple operation`
+
+	context := NewContextBuilder().
+		WithDefinition("myservice", definition).
+		Build()
+
+	result := RunCli([]string{"myservice"}, context)
+
+	if !strings.Contains(result.StdOut, expectedName) {
+		t.Errorf("stdout does not contain custom operation, expected: %v, got: %v", expectedName, result.StdOut)
+	}
+}
+
 func TestOperationsSummary(t *testing.T) {
 	definition := `
 paths:


### PR DESCRIPTION
Replaced the regex implementation with a more performant loop which also takes care of removing unwanted characters all within a single iteration.

The new implementation removes now curly brackets and dedupes multiple separators in a row.