### PR TITLE
Preserve slash in path parameter

### DIFF
--- a/test/execution_test.go
+++ b/test/execution_test.go
@@ -237,6 +237,35 @@ paths:
 	}
 }
 
+func TestGetRequestWithMultiSegmentPathParameter(t *testing.T) {
+	definition := `
+paths:
+  /api/{objectKey}:
+    parameters:
+    - name: objectKey
+      in: path
+      required: true
+      description: The object key
+      schema:
+        type: string
+    get:
+      operationId: download
+      summary: Download file
+`
+
+	context := NewContextBuilder().
+		WithDefinition("storage", definition).
+		WithResponse(http.StatusOK, "").
+		Build()
+
+	result := RunCli([]string{"storage", "download", "--object-key", "myfolder/myobject.txt"}, context)
+
+	expected := "/api/myfolder/myobject.txt"
+	if !strings.Contains(result.RequestUrl, expected) {
+		t.Errorf("Request url did not contain parameter value, expected: %v, got: %v", expected, result.RequestUrl)
+	}
+}
+
 func TestGetRequestWithCategory(t *testing.T) {
 	definition := `
 paths:

--- a/utils/converter/uri_builder.go
+++ b/utils/converter/uri_builder.go
@@ -38,8 +38,16 @@ func (b *UriBuilder) formatPathValue(value interface{}) string {
 		return b.toCommaSeparatedStringPathEscape(array)
 	default:
 		str := b.converter.ToString(value)
-		return url.PathEscape(str)
+		return b.escapePathPreserveSlashes(str)
 	}
+}
+
+func (b *UriBuilder) escapePathPreserveSlashes(value string) string {
+	segments := strings.Split(value, "/")
+	for i := range segments {
+		segments[i] = url.PathEscape(segments[i])
+	}
+	return strings.Join(segments, "/")
 }
 
 func (b *UriBuilder) toCommaSeparatedStringPathEscape(array []string) string {

--- a/utils/converter/uri_builder_test.go
+++ b/utils/converter/uri_builder_test.go
@@ -49,10 +49,10 @@ func TestFormatPathReplacesPlaceholderWithEscapedPathValue(t *testing.T) {
 	builder := NewUriBuilder(toUrl("https://cloud.uipath.com/{organization}/{tenant}/"), "/my-service")
 
 	builder.FormatPath("organization", "my org")
-	builder.FormatPath("tenant", "{my/tenant}")
+	builder.FormatPath("tenant", "{my%tenant}")
 
 	uri := builder.Build()
-	if uri != "https://cloud.uipath.com/my%20org/%7Bmy%2Ftenant%7D/my-service" {
+	if uri != "https://cloud.uipath.com/my%20org/%7Bmy%25tenant%7D/my-service" {
 		t.Errorf("Did not replace placeholder, got: %v", uri)
 	}
 }
@@ -124,11 +124,22 @@ func FormatPathDataTypes(t *testing.T, value interface{}, expected string) {
 func TestFormatPathEscapeStringValue(t *testing.T) {
 	builder := NewUriBuilder(toUrl("https://cloud.uipath.com"), "/{param}")
 
+	builder.FormatPath("param", "my#value")
+
+	uri := builder.Build()
+	if uri != "https://cloud.uipath.com/my%23value" {
+		t.Errorf("Did not escape path properly, got: %v", uri)
+	}
+}
+
+func TestFormatPathPreservesSlash(t *testing.T) {
+	builder := NewUriBuilder(toUrl("https://cloud.uipath.com"), "/{param}")
+
 	builder.FormatPath("param", "my/value")
 
 	uri := builder.Build()
-	if uri != "https://cloud.uipath.com/my%2Fvalue" {
-		t.Errorf("Did not escape path properly, got: %v", uri)
+	if uri != "https://cloud.uipath.com/my/value" {
+		t.Errorf("Did not preserve slash in path, got: %v", uri)
 	}
 }
 


### PR DESCRIPTION
The slash in the path parameter should not be escaped in order to support multi path segment parameters.

Example:

This change allows the support for storage object keys in the path. The following specification would allow `objectKey`s to contain a slash for folder support:

```
paths:
  /api/{objectKey}:
    parameters:
    - name: objectKey
      in: path
      required: true
      description: The object key
      schema:
        type: string
    get:
      operationId: download
      summary: Download file
```