### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -118,6 +118,8 @@ jobs:
     needs: [build, test_linux, test_windows, test_macos]
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     env:
       UIPATHCLI_VERSION: ${{ needs.build.outputs.UIPATHCLI_VERSION }}
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/UiPath/uipathcli/security/code-scanning/5](https://github.com/UiPath/uipathcli/security/code-scanning/5)

Add an explicit `permissions` block to the `release` job in `.github/workflows/ci.yaml` so token scopes are intentionally constrained.  
Best fix without changing intended functionality: set `contents: write` for `release` (since publishing commonly needs repository write access for creating/updating releases), and only that scope unless additional scopes are proven necessary.

Edit location:
- File: `.github/workflows/ci.yaml`
- Region: `release` job header (just under `runs-on` is a clear placement)

No imports/dependencies/methods are needed (YAML-only change).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
